### PR TITLE
refactor: /sc:* プレフィックスをスキルベースコマンドに置換

### DIFF
--- a/dev-cleanup/SKILL.md
+++ b/dev-cleanup/SKILL.md
@@ -14,7 +14,7 @@ Systematic code cleanup and dead code removal.
 ## Usage
 
 ```
-/sc:cleanup [target] [--type code|imports|files|all] [--safe] [--aggressive]
+/dev-cleanup [target] [--type code|imports|files|all] [--safe] [--aggressive]
 ```
 
 | Arg | Description |
@@ -69,7 +69,7 @@ Systematic code cleanup and dead code removal.
 ## Examples
 
 ```bash
-/sc:cleanup src/ --type imports
-/sc:cleanup --type all --safe
-/sc:cleanup lib/ --aggressive
+/dev-cleanup src/ --type imports
+/dev-cleanup --type all --safe
+/dev-cleanup lib/ --aggressive
 ```

--- a/doc-generate/SKILL.md
+++ b/doc-generate/SKILL.md
@@ -14,7 +14,7 @@ Focused documentation generation.
 ## Usage
 
 ```
-/sc:document [target] [--type inline|external|api|guide] [--style brief|detailed]
+/doc-generate [target] [--type inline|external|api|guide] [--style brief|detailed]
 ```
 
 | Arg | Description |
@@ -75,7 +75,7 @@ For --type inline:
 ## Examples
 
 ```bash
-/sc:document src/api/ --type api --style detailed
-/sc:document lib/utils.ts --type inline
-/sc:document --type guide --style brief
+/doc-generate src/api/ --type api --style detailed
+/doc-generate lib/utils.ts --type inline
+/doc-generate --type guide --style brief
 ```

--- a/doc-index/SKILL.md
+++ b/doc-index/SKILL.md
@@ -14,7 +14,7 @@ Project documentation and knowledge base generation.
 ## Usage
 
 ```
-/sc:index [target] [--type docs|api|structure|readme] [--format md|json]
+/doc-index [target] [--type docs|api|structure|readme] [--format md|json]
 ```
 
 | Arg | Description |
@@ -67,7 +67,7 @@ Generated docs go to `claudedocs/` by default.
 ## Examples
 
 ```bash
-/sc:index . --type structure
-/sc:index src/api/ --type api --format md
-/sc:index --type readme
+/doc-index . --type structure
+/doc-index src/api/ --type api --format md
+/doc-index --type readme
 ```

--- a/mcp-guide/SKILL.md
+++ b/mcp-guide/SKILL.md
@@ -201,7 +201,7 @@ Reference guide for MCP server selection and usage patterns.
 - Symbol operations: rename, extract, move functions/classes
 - Project-wide code navigation and exploration
 - Multi-language projects requiring LSP integration
-- Session lifecycle: `/sc:load`, `/sc:save`, project activation
+- Session lifecycle: `/session-load`, `/session-save`, project activation
 - Memory-driven development workflows
 - Large codebase analysis (>50 files, complex architecture)
 
@@ -220,8 +220,8 @@ Reference guide for MCP server selection and usage patterns.
 ```
 "rename getUserData function everywhere" -> Serena (symbol operation with dependency tracking)
 "find all references to this class" -> Serena (semantic search and navigation)
-"load my project context" -> Serena (/sc:load with project activation)
-"save my current work session" -> Serena (/sc:save with memory persistence)
+"load my project context" -> Serena (/session-load with project activation)
+"save my current work session" -> Serena (/session-save with memory persistence)
 "update all console.log to logger" -> Morphllm (pattern-based replacement)
 "create a login form" -> Magic (UI component generation)
 ```

--- a/plan-brainstorm/SKILL.md
+++ b/plan-brainstorm/SKILL.md
@@ -14,7 +14,7 @@ Collaborative discovery for transforming vague ideas into concrete specification
 ## Usage
 
 ```
-/sc:brainstorm [topic] [--depth shallow|normal|deep] [--parallel]
+/plan-brainstorm [topic] [--depth shallow|normal|deep] [--parallel]
 ```
 
 | Arg | Description |
@@ -78,13 +78,13 @@ Collaborative discovery for transforming vague ideas into concrete specification
 ## Examples
 
 ```
-/sc:brainstorm "AI-powered todo app"
+/plan-brainstorm "AI-powered todo app"
 → Asks about target users, AI features, existing solutions
 
-/sc:brainstorm "improve authentication" --depth deep
+/plan-brainstorm "improve authentication" --depth deep
 → Deep dive into security requirements, UX, compliance
 
-/sc:brainstorm "new feature ideas" --parallel
+/plan-brainstorm "new feature ideas" --parallel
 → Multi-perspective exploration with different user personas
 ```
 

--- a/plan-workflow/SKILL.md
+++ b/plan-workflow/SKILL.md
@@ -14,7 +14,7 @@ Implementation workflow generation.
 ## Usage
 
 ```
-/sc:workflow [source] [--strategy systematic|agile] [--depth shallow|normal|deep]
+/plan-workflow [source] [--strategy systematic|agile] [--depth shallow|normal|deep]
 ```
 
 | Arg | Description |
@@ -72,7 +72,7 @@ Implementation workflow generation.
 ## Examples
 
 ```bash
-/sc:workflow docs/prd.md --strategy systematic
-/sc:workflow "user authentication feature" --depth deep
-/sc:workflow requirements.md --strategy agile
+/plan-workflow docs/prd.md --strategy systematic
+/plan-workflow "user authentication feature" --depth deep
+/plan-workflow requirements.md --strategy agile
 ```

--- a/session-load/SKILL.md
+++ b/session-load/SKILL.md
@@ -14,7 +14,7 @@ Load project context and session state.
 ## Usage
 
 ```
-/sc:load [--type project|checkpoint] [--refresh] [--analyze]
+/session-load [--type project|checkpoint] [--refresh] [--analyze]
 ```
 
 | Arg | Description |
@@ -66,11 +66,11 @@ Load project context and session state.
 ## Examples
 
 ```bash
-/sc:load
-/sc:load --type checkpoint
-/sc:load --refresh --analyze
+/session-load
+/session-load --type checkpoint
+/session-load --refresh --analyze
 ```
 
 ## Integration
 
-Pairs with `/sc:save` for session lifecycle.
+Pairs with `/session-save` for session lifecycle.

--- a/session-save/SKILL.md
+++ b/session-save/SKILL.md
@@ -14,7 +14,7 @@ Save session context and learnings.
 ## Usage
 
 ```
-/sc:save [--type session|learnings|checkpoint] [--summarize]
+/session-save [--type session|learnings|checkpoint] [--summarize]
 ```
 
 | Arg | Description |
@@ -59,17 +59,17 @@ Save session context and learnings.
 [Brief session summary]
 
 ### Recovery
-To resume: `/sc:load --type checkpoint`
+To resume: `/session-load --type checkpoint`
 ```
 
 ## Examples
 
 ```bash
-/sc:save
-/sc:save --type checkpoint
-/sc:save --type learnings --summarize
+/session-save
+/session-save --type checkpoint
+/session-save --type learnings --summarize
 ```
 
 ## Integration
 
-Pairs with `/sc:load` for session lifecycle.
+Pairs with `/session-load` for session lifecycle.

--- a/think-analyze/SKILL.md
+++ b/think-analyze/SKILL.md
@@ -14,7 +14,7 @@ Multi-domain code analysis for quality, security, performance, and architecture.
 ## Usage
 
 ```
-/sc:analyze [target] [--focus DOMAIN] [--scope file|module|project] [--report]
+/think-analyze [target] [--focus DOMAIN] [--scope file|module|project] [--report]
 ```
 
 | Arg | Description |
@@ -81,16 +81,16 @@ See `~/.claude/skills/_lib/analysis-domains.md` for detailed criteria per domain
 ## Examples
 
 ```
-/sc:analyze src/auth/ --focus security
+/think-analyze src/auth/ --focus security
 → Security-focused analysis of authentication code
 
-/sc:analyze . --scope project --report
+/think-analyze . --scope project --report
 → Full project analysis with report saved to claudedocs/
 
-/sc:analyze lib/utils.ts --focus quality
+/think-analyze lib/utils.ts --focus quality
 → Quality analysis of single file
 
-/sc:analyze --focus performance --scope module
+/think-analyze --focus performance --scope module
 → Performance analysis of current module
 ```
 

--- a/think-deep/SKILL.md
+++ b/think-deep/SKILL.md
@@ -14,7 +14,7 @@ Multi-level structured analysis for complex problem solving.
 ## Usage
 
 ```
-/sc:think [topic] [--level think|think-hard|ultrathink] [--focus DOMAIN]
+/think-deep [topic] [--level think|think-hard|ultrathink] [--focus DOMAIN]
 ```
 
 | Arg | Description |
@@ -102,13 +102,13 @@ Use these markers in analysis output:
 ## Examples
 
 ```
-/sc:think "why is this API slow?"
+/think-deep "why is this API slow?"
 → Standard analysis of performance bottlenecks
 
-/sc:think "authentication redesign" --level think-hard
+/think-deep "authentication redesign" --level think-hard
 → Deep analysis with documentation reference
 
-/sc:think "legacy system migration" --level ultrathink --focus architecture
+/think-deep "legacy system migration" --level ultrathink --focus architecture
 → Maximum depth architectural analysis
 ```
 


### PR DESCRIPTION
## 概要
- `/sc:*` プレフィックスをスキルベースのコマンド形式に置換
- 10個のSKILL.mdファイルを更新

## 変更内容
- `dev-cleanup/SKILL.md`
- `doc-generate/SKILL.md`
- `doc-index/SKILL.md`
- `mcp-guide/SKILL.md`
- `plan-brainstorm/SKILL.md`
- `plan-workflow/SKILL.md`
- `session-load/SKILL.md`
- `session-save/SKILL.md`
- `think-analyze/SKILL.md`
- `think-deep/SKILL.md`

## テスト計画
- [ ] 各スキルのコマンド実行確認