### PR TITLE
feat(pr-review): レビュー送信スクリプトの追加

### DIFF
--- a/pr-review/SKILL.md
+++ b/pr-review/SKILL.md
@@ -38,25 +38,24 @@ Using [review-sections.md](references/review-sections.md) checklist, determine:
 - **Decision**: `approve` (LGTM) or `request-changes` (issues found)
 - **Review body**: Markdown formatted review
 
-### Step 3: Submit Directly
+### Step 3: Submit Review
 
-**Important**: Use a single Bash call with fallback to prevent duplicate submissions.
+1. Write review body to a temporary file
+2. Call submit script with decision
 
 ```bash
-# Single command with fallback (DO NOT run separate commands)
-gh pr review <pr-number> --approve --body "$(cat <<'EOF'
+# Write review to temp file
+cat > /tmp/pr-review-body.md <<'EOF'
 <review-content>
 EOF
-)" 2>&1 || gh pr review <pr-number> --comment --body "$(cat <<'EOF'
-<review-content>
-EOF
-)"
+
+# Submit review (handles own-PR fallback automatically)
+~/.claude/skills/pr-review/scripts/submit-review.sh <pr-number> <decision> /tmp/pr-review-body.md
 ```
 
-⚠️ **Do NOT execute additional review commands after the fallback succeeds.**
-
-Options:
-- `--approve` for LGTM (auto-falls back to `--comment` for own PRs)
-- `--request-changes` for issues found
+**Decision options**:
+- `approve` - LGTM (auto-falls back to comment for own PRs)
+- `request-changes` - Issues found
+- `comment` - Neutral feedback
 
 Report PR URL when complete.

--- a/pr-review/scripts/submit-review.sh
+++ b/pr-review/scripts/submit-review.sh
@@ -32,7 +32,7 @@ if [[ ! -f "$BODY_FILE" ]]; then
     die_json "Body file not found: $BODY_FILE"
 fi
 
-require_cmd "gh" "GitHub CLI (gh) not installed. Install: brew install gh"
+require_gh_auth
 
 BODY=$(cat "$BODY_FILE")
 

--- a/pr-review/scripts/submit-review.sh
+++ b/pr-review/scripts/submit-review.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# submit-review.sh - Submit PR review with automatic fallback
+# Usage: submit-review.sh <pr-number> <decision> <body-file>
+#
+# Arguments:
+#   pr-number  - PR number or URL
+#   decision   - approve | request-changes | comment
+#   body-file  - Path to file containing review body (markdown)
+#
+# Behavior:
+#   - approve: Tries --approve first, falls back to --comment for own PRs
+#   - request-changes: Uses --request-changes
+#   - comment: Uses --comment directly
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_ROOT="$SCRIPT_DIR/../.."
+
+source "$SKILL_ROOT/_lib/common.sh"
+
+# Parse arguments
+PR_REF="${1:-}"
+DECISION="${2:-}"
+BODY_FILE="${3:-}"
+
+if [[ -z "$PR_REF" ]] || [[ -z "$DECISION" ]] || [[ -z "$BODY_FILE" ]]; then
+    die_json "Usage: submit-review.sh <pr-number> <decision> <body-file>"
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+    die_json "Body file not found: $BODY_FILE"
+fi
+
+require_cmd "gh" "GitHub CLI (gh) not installed. Install: brew install gh"
+
+BODY=$(cat "$BODY_FILE")
+
+case "$DECISION" in
+    approve)
+        echo "Attempting to approve PR #$PR_REF..." >&2
+        if gh pr review "$PR_REF" --approve --body "$BODY" 2>&1; then
+            echo "Review submitted: approved" >&2
+        else
+            echo "Cannot approve (likely own PR), falling back to comment..." >&2
+            gh pr review "$PR_REF" --comment --body "$BODY"
+            echo "Review submitted: comment (fallback)" >&2
+        fi
+        ;;
+    request-changes)
+        echo "Submitting changes requested for PR #$PR_REF..." >&2
+        gh pr review "$PR_REF" --request-changes --body "$BODY"
+        echo "Review submitted: request-changes" >&2
+        ;;
+    comment)
+        echo "Submitting comment for PR #$PR_REF..." >&2
+        gh pr review "$PR_REF" --comment --body "$BODY"
+        echo "Review submitted: comment" >&2
+        ;;
+    *)
+        die_json "Invalid decision: $DECISION. Must be: approve | request-changes | comment"
+        ;;
+esac
+
+# Output PR URL
+gh pr view "$PR_REF" --json url -q '.url'


### PR DESCRIPTION
## 概要

PRレビュー送信時の信頼性を向上させるため、専用スクリプトを追加しました。

## 変更内容

- `submit-review.sh` スクリプトを新規追加
  - 自分のPRに対するレビュー時、自動的にコメントにフォールバック
  - approve / request-changes / comment の3種類のデシジョンをサポート
- SKILL.md のレビュー送信手順をスクリプト使用に簡素化

## 動作

```bash
# 使用例
~/.claude/skills/pr-review/scripts/submit-review.sh 123 approve /tmp/pr-review-body.md
```

- `approve`: 承認を試み、失敗時（自分のPR等）はコメントにフォールバック
- `request-changes`: 変更要求として送信
- `comment`: コメントとして送信

## テスト計画

- [ ] 他人のPRに対してapproveが正常に動作すること
- [ ] 自分のPRに対してapproveがコメントにフォールバックすること
- [ ] request-changesが正常に動作すること