### PR TITLE
refactor: scripts/を_lib/infra/に移動しsession-loadに自動リンクを統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ __pycache__/
 
 # --- external skills (auto-managed) ---
 find-skills
+vercel-react-best-practices
 # --- end external skills ---

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Claude Code内で `/スキル名` を実行:
 ```
 skills/
 ├── _lib/                    # 共有ライブラリ
+│   ├── infra/               # リポジトリ基盤管理スクリプト
+│   ├── scripts/             # スキル共通ユーティリティ
+│   ├── schemas/             # JSON Schema定義
+│   └── templates/           # テンプレート
 ├── <skill-name>/
 │   ├── SKILL.md             # スキル定義（必須）
 │   ├── scripts/             # 実行スクリプト

--- a/_lib/infra/link-agent-skills.sh
+++ b/_lib/infra/link-agent-skills.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 AGENTS_SKILLS_DIR="$REPO_ROOT/.agents/skills"
 GITIGNORE="$REPO_ROOT/.gitignore"
 

--- a/_lib/infra/unlink-agent-skills.sh
+++ b/_lib/infra/unlink-agent-skills.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 GITIGNORE="$REPO_ROOT/.gitignore"
 
 MARKER_BEGIN="# --- external skills (auto-managed) ---"

--- a/session-load/SKILL.md
+++ b/session-load/SKILL.md
@@ -33,10 +33,11 @@ Load project context and session state.
 ## Workflow
 
 1. **Initialize** → Establish session
-2. **Discover** → Find project context files
-3. **Load** → Read CLAUDE.md, memories
-4. **Activate** → Set up working context
-5. **Report** → Show loaded state
+2. **Sync External Skills** → Run `~/.claude/skills/_lib/infra/link-agent-skills.sh` to sync `.agents/skills/` symlinks
+3. **Discover** → Find project context files
+4. **Load** → Read CLAUDE.md, memories
+5. **Activate** → Set up working context
+6. **Report** → Show loaded state
 
 ## What Gets Loaded
 


### PR DESCRIPTION
## 概要

- トップレベルの `scripts/` ディレクトリをスキルと同列に置く不整合を解消
- `.agents/skills/` 変更時の手動 link/unlink を不要に

## 変更内容

- `scripts/{link,unlink}-agent-skills.sh` → `_lib/infra/` に移動
- `REPO_ROOT` パス解決を新配置（2階層上）に修正
- `session-load/SKILL.md` のワークフローに `link-agent-skills.sh` 自動実行ステップを追加
- `README.md` の構造セクションに `_lib/` サブディレクトリを明記

## 動機

- `scripts/` はスキルではないのにスキルディレクトリと同列に配置されていた
- `_lib/` は既に「スキルではない共有資産」の置き場として機能しており、`infra/` として分類するのが適切
- `.agents/skills/` 配下の変更時に手動で link/unlink を実行する手間を排除

## テスト計画

- [x] `_lib/infra/link-agent-skills.sh` の動作確認（2スキルのリンク作成）
- [x] `_lib/infra/unlink-agent-skills.sh` の動作確認（リンク削除＋.gitignoreクリーンアップ）
- [x] 再リンク時の冪等性確認