### PR TITLE
refactor: dev-flow Single ModeのSkill呼び出しをTask subagent化

### DIFF
--- a/dev-flow/SKILL.md
+++ b/dev-flow/SKILL.md
@@ -28,7 +28,9 @@ dev-flow operates in two modes based on issue complexity:
 ```
 dev-flow (mode branch)
 ├── Single mode (default / small issues)
-│   └── dev-kickoff 1 instance → git-pr → pr-iterate
+│   ├── Task: dev-kickoff 1 instance → git-pr (subagent, independent context)
+│   ├── gh pr view (main context)
+│   └── Task: pr-iterate (subagent, independent context)
 │
 └── Parallel mode (--parallel / large issues)
     ├── dev-issue-analyze
@@ -43,19 +45,76 @@ dev-flow (mode branch)
 
 For small issues or when `--parallel` is not specified.
 
+dev-kickoff and pr-iterate run as Task subagents with independent contexts to keep the main dev-flow context lightweight.
+
 | Step | Action | Complete When |
 |------|--------|---------------|
-| 1 | `Skill: dev-kickoff` | PR URL available |
+| 1 | `Task: dev-kickoff` (subagent) | PR URL available |
 | 2 | `gh pr view --json url` | URL captured |
-| 3 | `Skill: pr-iterate` | LGTM achieved or max iterations |
+| 3 | `Task: pr-iterate` (subagent) | LGTM achieved or max iterations |
 
 ### Single Mode Checklist
 
 ```
-[ ] Step 1: Skill: dev-kickoff $ISSUE --strategy $STRATEGY --depth $DEPTH --base $BASE
-[ ] Step 2: PR_URL=$(gh pr view --json url --jq .url)
-[ ] Step 3: Skill: pr-iterate $PR_URL --max-iterations $MAX
+[ ] Step 1: Task subagent → dev-kickoff (see prompt below)
+[ ] Step 2: PR_URL=$(gh pr view --json url --jq .url)  (run in worktree)
+[ ] Step 3: Task subagent → pr-iterate (see prompt below)
 ```
+
+### Step 1: dev-kickoff Subagent
+
+Launch dev-kickoff as a Task subagent. The subagent runs in its own context and returns only the result.
+
+**Task prompt:**
+
+```
+Execute the dev-kickoff skill for issue #$ISSUE.
+Run: Skill: dev-kickoff $ISSUE --strategy $STRATEGY --depth $DEPTH --base $BASE
+
+After completion, return ONLY a JSON result:
+- On success: {"status": "completed", "worktree": "<path>", "pr_url": "<url>", "pr_number": <number>}
+- On failure: {"status": "failed", "error": "<message>", "phase": "<failed_phase>"}
+```
+
+**Result handling:**
+
+| Result | Action |
+|--------|--------|
+| `status: "completed"` | Extract `worktree`, `pr_url` → proceed to Step 2 |
+| `status: "failed"` | Log failure via journal.sh → abort dev-flow |
+| Task tool error | Log error → abort dev-flow |
+
+### Step 2: Get PR URL
+
+```bash
+# Run from worktree returned by Step 1
+cd $WORKTREE && gh pr view --json url --jq .url
+```
+
+### Step 3: pr-iterate Subagent
+
+Launch pr-iterate as a Task subagent.
+
+**Task prompt:**
+
+```
+Execute the pr-iterate skill for PR $PR_URL.
+Run: Skill: pr-iterate $PR_URL --max-iterations $MAX
+
+After completion, return ONLY a JSON result:
+- On LGTM: {"status": "lgtm", "iterations": <count>}
+- On max reached: {"status": "max_reached", "iterations": <count>}
+- On failure: {"status": "failed", "error": "<message>"}
+```
+
+**Result handling:**
+
+| Result | Action |
+|--------|--------|
+| `status: "lgtm"` | Workflow complete (merge manually) |
+| `status: "max_reached"` | Report status, user decides |
+| `status: "failed"` | Log failure via journal.sh → report error |
+| Task tool error | Log error → report error |
 
 ## Parallel Mode
 

--- a/dev-flow/references/workflow-detail.md
+++ b/dev-flow/references/workflow-detail.md
@@ -18,14 +18,14 @@ dev-flow (main context - lightweight)
     │       ├─→ Phase 3: dev-implement (coding)
     │       ├─→ Phase 4: dev-validate (testing)
     │       ├─→ Phase 5: git-commit (commit)
-    │       └─→ Phase 6: git-pr (PR creation)
+    │       ├─→ Phase 6: git-pr (PR creation)
     │       └── Returns: {status, worktree, pr_url, pr_number}
     │
     ├─→ Step 2: Get PR URL (main context)
     │       └─→ gh pr view --json url --jq .url
     │
     └─→ Step 3: Task subagent → pr-iterate (independent context)
-            └─→ Review → Fix → Push → Repeat
+            ├─→ Review → Fix → Push → Repeat
             └── Returns: {status, iterations}
 ```
 

--- a/dev-flow/references/workflow-detail.md
+++ b/dev-flow/references/workflow-detail.md
@@ -6,22 +6,27 @@ Detailed documentation for the dev-flow skill workflow.
 
 ### Single Mode (Default)
 
+dev-kickoff and pr-iterate run as Task subagents with independent contexts.
+The main dev-flow context stays lightweight (instruction + result only).
+
 ```
-dev-flow (wrapper)
+dev-flow (main context - lightweight)
     │
-    ├─→ Step 1: dev-kickoff (orchestrator)
+    ├─→ Step 1: Task subagent → dev-kickoff (independent context)
     │       ├─→ Phase 1: git-prepare.sh (worktree)
     │       ├─→ Phase 2: dev-issue-analyze (exploration)
     │       ├─→ Phase 3: dev-implement (coding)
     │       ├─→ Phase 4: dev-validate (testing)
     │       ├─→ Phase 5: git-commit (commit)
     │       └─→ Phase 6: git-pr (PR creation)
+    │       └── Returns: {status, worktree, pr_url, pr_number}
     │
-    ├─→ Step 2: Get PR URL
+    ├─→ Step 2: Get PR URL (main context)
     │       └─→ gh pr view --json url --jq .url
     │
-    └─→ Step 3: pr-iterate (review loop)
+    └─→ Step 3: Task subagent → pr-iterate (independent context)
             └─→ Review → Fix → Push → Repeat
+            └── Returns: {status, iterations}
 ```
 
 ### Parallel Mode (--parallel)
@@ -89,9 +94,15 @@ analyzing → decomposing → implementing → integrating → pr → iterating 
 
 ## Single Mode Details
 
-### Step 1: dev-kickoff
+### Step 1: dev-kickoff (Task Subagent)
+
+dev-kickoff runs as a Task subagent with its own independent context. The main dev-flow context only holds the Task invocation prompt and the returned result JSON. This prevents dev-kickoff's internal turns (up to 50) from accumulating in the main context.
 
 The orchestrator handles 6 phases internally. See [dev-kickoff/SKILL.md](../../dev-kickoff/SKILL.md).
+
+#### Task Invocation
+
+The Task tool is used to spawn a subagent that executes `Skill: dev-kickoff`. The subagent returns a structured JSON result containing the worktree path and PR information.
 
 #### Completion Signal
 
@@ -101,15 +112,34 @@ When Phase 6 (PR creation) completes, kickoff.json is updated with:
 - `next_action`: "pr-iterate"
 - `current_phase`: "completed"
 
+The subagent returns: `{"status": "completed", "worktree": "<path>", "pr_url": "<url>", "pr_number": <number>}`
+
+#### Error Signal
+
+On failure, the subagent returns: `{"status": "failed", "error": "<message>", "phase": "<failed_phase>"}`
+
 ### Step 2: Get PR URL
 
 ```bash
-gh pr view --json url --jq .url
+# Run from worktree returned by Step 1 subagent
+cd $WORKTREE && gh pr view --json url --jq .url
 ```
 
-### Step 3: pr-iterate
+### Step 3: pr-iterate (Task Subagent)
+
+pr-iterate runs as a Task subagent with its own independent context. This prevents the review-fix loop iterations from accumulating in the main dev-flow context.
 
 Handles the review-fix-push loop. See [pr-iterate/SKILL.md](../../pr-iterate/SKILL.md).
+
+#### Task Invocation
+
+The Task tool is used to spawn a subagent that executes `Skill: pr-iterate`. The subagent returns a structured JSON result containing the final status and iteration count.
+
+#### Result Signal
+
+- LGTM: `{"status": "lgtm", "iterations": <count>}`
+- Max reached: `{"status": "max_reached", "iterations": <count>}`
+- Failure: `{"status": "failed", "error": "<message>"}`
 
 ## Parallel Mode Details
 
@@ -253,9 +283,10 @@ cat $SUBTASK_WT/.claude/kickoff.json | jq '.current_phase'
 ## Integration Points
 
 ### With dev-kickoff
-- Single mode: dev-flow calls dev-kickoff as first step
+- Single mode: dev-flow launches dev-kickoff as Task subagent (independent context)
 - Parallel mode: dev-flow launches multiple dev-kickoff instances via Task tool
 - kickoff.json is the per-task handoff point
+- In single mode, the Task subagent returns `{status, worktree, pr_url, pr_number}` to dev-flow
 
 ### With dev-decompose
 - dev-flow calls dev-decompose after issue analysis
@@ -267,9 +298,10 @@ cat $SUBTASK_WT/.claude/kickoff.json | jq '.current_phase'
 - Merge worktree is the output
 
 ### With pr-iterate
-- dev-flow extracts PR URL from kickoff (single) or flow.json (parallel)
-- Passes URL to pr-iterate
+- Single mode: dev-flow launches pr-iterate as Task subagent (independent context)
+- Parallel mode: dev-flow extracts PR URL from flow.json, passes to pr-iterate (Skill call)
 - pr-iterate creates its own iterate.json
+- In single mode, the Task subagent returns `{status, iterations}` to dev-flow
 
 ### With GitHub CLI
 - `gh pr view` for PR status

--- a/dev-flow/scripts/flow-status.sh
+++ b/dev-flow/scripts/flow-status.sh
@@ -188,14 +188,14 @@ FLOW_STEP=$(determine_flow_step)
 # Determine next action command
 case "$FLOW_STEP" in
     step_1_kickoff)
-        NEXT_CMD="Skill: dev-kickoff $ISSUE --strategy $STRATEGY --depth $DEPTH --base $BASE_BRANCH"
+        NEXT_CMD="Task subagent: Skill: dev-kickoff $ISSUE --strategy $STRATEGY --depth $DEPTH --base $BASE_BRANCH"
         STATUS="kickoff_in_progress"
         ;;
     step_3_iterate)
         if [[ -n "$PR_URL" ]]; then
-            NEXT_CMD="Skill: pr-iterate $PR_URL"
+            NEXT_CMD="Task subagent: Skill: pr-iterate $PR_URL"
         else
-            NEXT_CMD="Skill: pr-iterate $PR_NUMBER"
+            NEXT_CMD="Task subagent: Skill: pr-iterate $PR_NUMBER"
         fi
         STATUS="ready_for_iterate"
         ;;


### PR DESCRIPTION
## Summary

Closes #18

- dev-flow Single Mode の Step 1 (dev-kickoff) と Step 3 (pr-iterate) を `Skill:` 直接呼び出しから `Task` subagent 実行に変更
- subagent は独立コンテキストで実行され、結果のみ JSON で返却する設計
- メインの dev-flow コンテキストが軽量に保たれ、auto-compact による状態ロストリスクを軽減

## Changes

- `dev-flow/SKILL.md` — Single Mode セクションを Task subagent 化、プロンプトテンプレートと JSON 戻り値契約を追加
- `dev-flow/references/workflow-detail.md` — アーキテクチャ図と詳細説明を更新
- `dev-flow/scripts/flow-status.sh` — 状態復帰時の next_action を Task subagent 形式に更新

## Test plan

- [ ] Single Mode で dev-flow 実行時、dev-kickoff が Task subagent として起動されること
- [ ] pr-iterate が Task subagent として起動されること
- [ ] subagent から返却された PR URL が正しく後続ステップに渡されること
- [ ] Parallel Mode のセクションに変更がないこと（diff で確認済み）
- [ ] flow-status.sh が正しいコマンド形式を出力すること