### PR TITLE
feat(bug-hunt): Agent Team協調型バグ調査スキルの実装

### DIFF
--- a/bug-hunt/SKILL.md
+++ b/bug-hunt/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: bug-hunt
+description: |
+  Collaborative multi-agent bug investigation using Agent Team.
+  Generates hypotheses, investigates in parallel, dynamically redirects based on findings.
+  Use when: (1) complex bugs with unclear root cause, (2) intermittent/hard-to-reproduce issues,
+  (3) multi-component bugs crossing module boundaries,
+  (4) keywords: bug hunt, root cause, investigate, debug, intermittent failure, flaky test
+allowed-tools:
+  - Task
+  - Bash
+  - Skill
+---
+
+# Bug Hunt
+
+Collaborative multi-agent bug investigation with dynamic hypothesis management.
+
+## Usage
+
+```
+/bug-hunt <issue-or-description> [--max-hypotheses N] [--max-turns N] [--repo-path <path>]
+```
+
+## Args
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `<issue-or-description>` | required | GitHub issue number or symptom text |
+| `--max-hypotheses` | `8` | Maximum hypotheses tracked simultaneously |
+| `--max-turns` | `30` | Team turn budget (cost control) |
+| `--repo-path` | `.` | Target repository path |
+
+## Workflow
+
+```
+Phase 1: Triage (hunt-lead)
+  ├── Analyze and categorize symptoms
+  ├── Generate 3-5 initial hypotheses
+  ├── Create TaskList verification tasks
+  └── Assign to investigators
+
+Phase 2: Investigate (parallel, dynamic)
+  ├── Each investigator verifies assigned hypothesis
+  ├── Findings → SendMessage to hunt-lead
+  ├── hunt-lead adds/rejects/redirects hypotheses
+  └── Real-time investigator redirection
+
+Phase 3: Converge (hunt-lead)
+  ├── Declare root cause identification
+  ├── Build evidence chain
+  └── Instruct fix-proposer
+
+Phase 4: Propose Fix (fix-proposer)
+  ├── Create fix code proposal
+  ├── Create regression test cases
+  └── hunt-lead reviews → present to user
+```
+
+## Team Composition
+
+| Role | Name | Agent Type | Responsibility |
+|------|------|-----------|----------------|
+| Leader | `hunt-lead` | general-purpose | Hypothesis generation, priority management, convergence |
+| Investigator 1 | `investigator-1` | Explore | Code investigation, hypothesis verification |
+| Investigator 2 | `investigator-2` | Explore | Parallel investigation line |
+| Fix Proposer | `fix-proposer` | general-purpose | Fix proposal after root cause identified |
+
+Cost control: For simple bugs, start with investigator-1 only. Spawn investigator-2 when multiple hypotheses need parallel work. Spawn fix-proposer only after root cause is confirmed.
+
+## Phase 1: Triage
+
+hunt-lead executes:
+
+1. Parse issue number (fetch via `gh issue view`) or symptom text
+2. Get code area overview via Explore agent
+3. Generate initial hypotheses from categories (see [hypothesis-categories.md](references/hypothesis-categories.md))
+4. Create TaskList tasks with verification steps per hypothesis
+5. Assign to investigator-1 (and investigator-2 if >= 3 hypotheses)
+
+### Initialize State
+
+```bash
+$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh init \
+  --target "<issue or description>" \
+  --max-hypotheses N --max-turns N \
+  --repo-path <path>
+```
+
+## Phase 2: Investigate
+
+Each investigator:
+- Follow assigned hypothesis verification steps
+- Use Grep/Read/Bash to collect evidence
+- SendMessage findings to hunt-lead
+
+hunt-lead dynamic adjustments:
+- Hypothesis rejected -> assign next hypothesis to investigator
+- New hypothesis emerges -> add to TaskList, assign to available investigator
+- Strong lead found -> redirect other investigator to related area
+- Both investigators on same area -> redirect one to different hypothesis
+
+```bash
+# Add hypothesis
+$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh add-hypothesis \
+  --id "h3" --description "Race condition in session handler" \
+  --category "state" --assigned-to "investigator-1"
+
+# Update hypothesis
+$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh update-hypothesis \
+  --id "h1" --status "rejected" \
+  --reason "Session store uses Redis, no memory leak"
+```
+
+### Convergence Conditions
+
+- Root cause identified with sufficient evidence
+- Reproduction steps established
+- All hypotheses rejected (request additional info from user)
+
+### Budget Check
+
+```bash
+$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh check-budget
+```
+
+## Phase 3: Converge
+
+hunt-lead produces:
+1. One-sentence root cause summary
+2. Evidence chain with file:line references
+3. Impact assessment
+
+## Phase 4: Propose Fix
+
+fix-proposer creates:
+1. Fix code proposal for root cause
+2. Regression test cases
+3. Similar-area impact check
+
+## State Management
+
+State persisted in `$CWD/.claude/bug-hunt-state.json`. See [team-lifecycle.md](references/team-lifecycle.md) for Team patterns.
+
+```bash
+# Read current state
+$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh read --repo-path <path>
+```
+
+## Output Format
+
+```markdown
+## Bug Hunt Report
+
+### Root Cause
+[One-sentence summary]
+
+### Evidence Chain
+1. [file:line] - [finding]
+2. [file:line] - [finding]
+
+### Hypotheses Investigated
+| # | Hypothesis | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | ... | Confirmed/Rejected | ... |
+
+### Proposed Fix
+[Fix code proposal]
+
+### Regression Test
+[Test case proposal]
+
+### Impact Assessment
+[Affected scope]
+```
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| All hypotheses rejected | Request additional info from user, attempt new hypotheses |
+| max-turns reached | Report current findings and exit |
+| Investigator stuck | hunt-lead redefines hypothesis, suggests different approach |
+| Team communication error | Recover via file-based state, reconstruct Team |
+
+## Journal Logging
+
+```bash
+# On success
+$SKILLS_DIR/skill-retrospective/scripts/journal.sh log bug-hunt success \
+  --issue $ISSUE --duration-turns $TURNS
+
+# On failure
+$SKILLS_DIR/skill-retrospective/scripts/journal.sh log bug-hunt failure \
+  --issue $ISSUE --error-category <category> --error-msg "<message>"
+```
+
+## References
+
+- [Team Lifecycle](references/team-lifecycle.md) - Agent Team lifecycle patterns
+- [Hypothesis Categories](references/hypothesis-categories.md) - Bug hypothesis categories and verification approaches

--- a/bug-hunt/SKILL.md
+++ b/bug-hunt/SKILL.md
@@ -5,7 +5,9 @@ description: |
   Generates hypotheses, investigates in parallel, dynamically redirects based on findings.
   Use when: (1) complex bugs with unclear root cause, (2) intermittent/hard-to-reproduce issues,
   (3) multi-component bugs crossing module boundaries,
-  (4) keywords: bug hunt, root cause, investigate, debug, intermittent failure, flaky test
+  (4) keywords: bug hunt, root cause, investigate, debug, intermittent failure, flaky test,
+  原因調査, なぜ落ちる, 再現しない, 時々失敗
+  Accepts args: <issue-or-description> [--max-hypotheses N] [--max-turns N] [--repo-path <path>]
 allowed-tools:
   - Task
   - Bash
@@ -121,7 +123,7 @@ $SKILLS_DIR/bug-hunt/scripts/hunt-state.sh update-hypothesis \
 ### Budget Check
 
 ```bash
-$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh check-budget
+$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh check-budget --repo-path <path>
 ```
 
 ## Phase 3: Converge

--- a/bug-hunt/SKILL.md
+++ b/bug-hunt/SKILL.md
@@ -24,6 +24,10 @@ Collaborative multi-agent bug investigation with dynamic hypothesis management.
 /bug-hunt <issue-or-description> [--max-hypotheses N] [--max-turns N] [--repo-path <path>]
 ```
 
+## Prerequisites
+
+- `jq` - Required for state file management (`brew install jq`)
+
 ## Args
 
 | Arg | Default | Description |
@@ -112,6 +116,14 @@ $SKILLS_DIR/bug-hunt/scripts/hunt-state.sh add-hypothesis \
 $SKILLS_DIR/bug-hunt/scripts/hunt-state.sh update-hypothesis \
   --id "h1" --status "rejected" \
   --reason "Session store uses Redis, no memory leak"
+```
+
+### Turn Tracking
+
+Increment turns_used after each investigator message:
+
+```bash
+$SKILLS_DIR/bug-hunt/scripts/hunt-state.sh increment-turn --repo-path <path>
 ```
 
 ### Convergence Conditions

--- a/bug-hunt/references/hypothesis-categories.md
+++ b/bug-hunt/references/hypothesis-categories.md
@@ -1,0 +1,124 @@
+# Bug Hypothesis Categories
+
+Systematic categorization of bug hypotheses with typical verification approaches.
+
+## Categories
+
+### 1. Logic Bugs
+
+Errors in program logic, control flow, or data transformation.
+
+| Sub-category | Symptoms | Verification Approach |
+|-------------|----------|----------------------|
+| Conditional branch | Wrong branch taken, missing case | Trace condition values, check edge cases |
+| Boundary value | Off-by-one, overflow, underflow | Check loop bounds, array indices, comparisons |
+| Type conversion | Unexpected coercion, precision loss | Search for implicit casts, parseInt vs Number |
+| Null/undefined | NPE, undefined property access | Trace nullable paths, check optional chaining |
+| Regex | Wrong match, catastrophic backtracking | Test regex with edge inputs |
+
+**Grep patterns:**
+```
+# Off-by-one
+< len|<= len|> 0|>= 0|length - 1
+
+# Null checks
+\?\.|!= null|!== null|== null|=== null|undefined
+```
+
+### 2. State Management
+
+Issues with shared, mutable, or asynchronous state.
+
+| Sub-category | Symptoms | Verification Approach |
+|-------------|----------|----------------------|
+| Race condition | Intermittent failures, order-dependent | Search for shared mutable state, async operations |
+| Stale state | Shows old data, cache inconsistency | Check cache invalidation, TTL, event listeners |
+| Memory leak | Growing memory, performance degradation | Search for event listeners not removed, growing arrays |
+| Initialization order | Fails on cold start, works after retry | Trace module load order, constructor dependencies |
+| Closure capture | Variable has unexpected value | Check loop variables captured by closures |
+
+**Grep patterns:**
+```
+# Shared state
+global|static|singleton|shared|mutex|lock
+
+# Async state
+await|Promise|setTimeout|setInterval|EventEmitter
+```
+
+### 3. External Dependencies
+
+Issues with APIs, databases, file systems, or network.
+
+| Sub-category | Symptoms | Verification Approach |
+|-------------|----------|----------------------|
+| API change | Broke after update, field missing | Check API version, diff response schemas |
+| DB connection | Timeout, connection pool exhaustion | Check pool config, connection lifecycle |
+| File system | Permission denied, path not found | Check permissions, relative vs absolute paths |
+| Network | Timeout, DNS, SSL errors | Check timeout config, retry logic, certificates |
+| Configuration | Works locally, fails in CI/prod | Diff env configs, check env variable loading |
+
+**Grep patterns:**
+```
+# API calls
+fetch|axios|http\.|request\(|\.get\(|\.post\(
+
+# DB
+connect|pool|query|transaction
+
+# Config
+process\.env|config\.|\.env|dotenv
+```
+
+### 4. Environment Differences
+
+Issues that manifest differently across environments.
+
+| Sub-category | Symptoms | Verification Approach |
+|-------------|----------|----------------------|
+| OS differences | Works on Mac, fails on Linux | Check path separators, case sensitivity, line endings |
+| Timezone | Wrong dates, off-by-N-hours | Search for Date, timezone, UTC handling |
+| Locale | Number format, string comparison | Check locale-sensitive operations |
+| Version mismatch | Works with Node 18, fails with 20 | Check package.json engines, lockfile diff |
+| Docker/container | Works locally, fails in container | Check Dockerfile, volume mounts, user permissions |
+
+**Grep patterns:**
+```
+# Timezone
+timezone|tz|UTC|toLocal|getTimezone|Intl\.DateTimeFormat
+
+# OS-specific
+path\.sep|os\.platform|process\.platform|\\\\|\/
+```
+
+## Hypothesis Generation Process
+
+### Step 1: Symptom Classification
+
+Map reported symptoms to likely categories:
+
+| Symptom Pattern | Primary Categories | Secondary |
+|----------------|-------------------|-----------|
+| "Sometimes fails" | State (race), Environment | External |
+| "Worked before" | External (API), Logic | Environment |
+| "Wrong result" | Logic, State | External |
+| "Crash/error" | Logic (null), External | State |
+| "Slow/hang" | External (network), State (leak) | Logic |
+| "Works locally" | Environment, External (config) | State |
+
+### Step 2: Prioritization
+
+Rank hypotheses by:
+
+1. **Likelihood**: How well symptoms match the category
+2. **Verifiability**: How quickly the hypothesis can be confirmed or rejected
+3. **Impact**: How much of the codebase is affected
+
+### Step 3: Verification Plan
+
+For each hypothesis, define:
+
+1. **Search targets**: Files, patterns, symbols to examine
+2. **Expected evidence**: What to find if hypothesis is correct
+3. **Rejection criteria**: What definitively rules out the hypothesis
+4. **Time estimate**: Quick check (1-2 steps) vs deep dive (5+ steps)

--- a/bug-hunt/references/team-lifecycle.md
+++ b/bug-hunt/references/team-lifecycle.md
@@ -1,0 +1,126 @@
+# Agent Team Lifecycle Patterns
+
+Common patterns for Agent Team coordination in bug-hunt.
+
+## Team Setup
+
+```
+TeamCreate → TaskCreate (hypotheses) → Spawn teammates → Assign → Coordinate → Shutdown → TeamDelete
+```
+
+### 1. Create Team
+
+```
+TeamCreate: team_name="bug-hunt-{issue}", description="Bug investigation for {target}"
+```
+
+### 2. Create Tasks
+
+Create one TaskCreate per hypothesis. Include:
+- Subject: hypothesis description (imperative form)
+- Description: verification steps, expected evidence, files to check
+- ActiveForm: "Investigating {hypothesis summary}"
+
+### 3. Spawn Teammates
+
+```
+Task(Explore): investigator-1, team_name="bug-hunt-{issue}"
+Task(Explore): investigator-2, team_name="bug-hunt-{issue}"  # only if needed
+Task: fix-proposer, team_name="bug-hunt-{issue}"             # only after root cause
+```
+
+### 4. Assign Tasks
+
+Use TaskUpdate with `owner` to assign hypothesis tasks to investigators.
+
+### 5. Coordinate
+
+- Receive investigator messages automatically (no polling needed)
+- Use SendMessage for redirection instructions
+- Update TaskList as hypotheses are added/rejected
+- Monitor budget via hunt-state.sh check-budget
+
+### 6. Shutdown
+
+```
+SendMessage: type="shutdown_request", recipient="investigator-1"
+SendMessage: type="shutdown_request", recipient="investigator-2"
+SendMessage: type="shutdown_request", recipient="fix-proposer"
+```
+
+Wait for shutdown_response from each. Then call TeamDelete.
+
+## Cost Control
+
+### Turn Budget
+
+- Track turns per investigator via state file
+- Each investigator message = 1 turn
+- hunt-lead management messages not counted
+- Check budget before assigning new work
+
+### Scaling Rules
+
+| Hypotheses | Investigators | Rationale |
+|-----------|---------------|-----------|
+| 1-2 | 1 | Simple bug, sequential sufficient |
+| 3-5 | 2 | Parallel investigation beneficial |
+| 5+ | 2 | Cap at 2, prioritize hypotheses |
+
+### Early Termination
+
+- Root cause confirmed with high confidence -> skip remaining hypotheses
+- Budget at 80% -> converge with best available evidence
+- All active hypotheses rejected, no new leads -> request user input
+
+## Idle State Handling
+
+Teammates go idle after every turn. This is normal.
+
+- Idle does NOT mean done or unavailable
+- Sending a message wakes idle teammates
+- Do not react to idle notifications unless assigning new work
+
+## Error Recovery
+
+### Communication Failure
+
+If SendMessage fails:
+1. Check state file for last known status
+2. Retry message once
+3. If still failing, read team config to verify member exists
+4. Reconstruct team if necessary
+
+### State File Recovery
+
+If state file corrupted:
+1. Create new state from TaskList current status
+2. Mark in-progress hypotheses as needs-review
+3. Continue investigation
+
+## Investigator Instructions Template
+
+When spawning investigators, include this context:
+
+```
+You are investigating a bug. Your role:
+1. Read your assigned task from TaskList
+2. Follow the verification steps in the task description
+3. Use Grep, Read, Bash to collect evidence
+4. SendMessage your findings to hunt-lead with:
+   - What you found (with file:line references)
+   - Whether the hypothesis is confirmed/rejected/needs more info
+   - Any new hypotheses that emerged
+5. Wait for hunt-lead to assign your next task
+```
+
+## Fix Proposer Instructions Template
+
+```
+You are proposing a fix for a confirmed root cause. Your role:
+1. Read the root cause and evidence chain from hunt-lead's message
+2. Create a minimal fix that addresses the root cause
+3. Create regression test cases
+4. Check for similar patterns in the codebase
+5. SendMessage your proposal to hunt-lead for review
+```

--- a/bug-hunt/scripts/hunt-state.sh
+++ b/bug-hunt/scripts/hunt-state.sh
@@ -6,6 +6,7 @@
 #   init              Initialize bug-hunt-state.json
 #   add-hypothesis    Add a new hypothesis
 #   update-hypothesis Update hypothesis status
+#   increment-turn    Increment turns_used counter
 #   check-budget      Check remaining turn budget
 #   read              Read current state
 
@@ -34,13 +35,16 @@ HYP_ASSIGNED=""
 HYP_REASON=""
 HYP_EVIDENCE=""
 
+# Valid enum values
+VALID_CATEGORIES="logic state external environment"
+
 # ============================================================================
 # Parse arguments
 # ============================================================================
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            init|add-hypothesis|update-hypothesis|check-budget|read)
+            init|add-hypothesis|update-hypothesis|increment-turn|check-budget|read)
                 COMMAND="$1"; shift ;;
             --target) TARGET="$2"; shift 2 ;;
             --max-hypotheses) MAX_HYPOTHESES="$2"; shift 2 ;;
@@ -58,7 +62,7 @@ parse_args() {
         esac
     done
 
-    [[ -n "$COMMAND" ]] || die_json "Command required: init|add-hypothesis|update-hypothesis|check-budget|read" 1
+    [[ -n "$COMMAND" ]] || die_json "Command required: init|add-hypothesis|update-hypothesis|increment-turn|check-budget|read" 1
 }
 
 usage() {
@@ -69,6 +73,7 @@ Commands:
   init                Initialize state file
   add-hypothesis      Add a hypothesis
   update-hypothesis   Update hypothesis status
+  increment-turn      Increment turns_used counter
   check-budget        Check turn budget
   read                Read current state
 
@@ -110,6 +115,14 @@ ensure_state_exists() {
 cmd_init() {
     [[ -n "$TARGET" ]] || die_json "--target required for init" 1
 
+    # Validate numeric arguments
+    if ! [[ "$MAX_HYPOTHESES" =~ ^[0-9]+$ ]]; then
+        die_json "Max hypotheses must be a positive integer" 1
+    fi
+    if ! [[ "$MAX_TURNS" =~ ^[0-9]+$ ]]; then
+        die_json "Max turns must be a positive integer" 1
+    fi
+
     local state_file
     state_file=$(resolve_state_file)
     local state_dir
@@ -138,7 +151,6 @@ cmd_init() {
             },
             turns_used: $turns_used,
             hypotheses: [],
-            findings: [],
             root_cause: null,
             fix_proposal: null,
             created_at: $created_at,
@@ -175,10 +187,17 @@ cmd_add_hypothesis() {
         die_json "Hypothesis with id '$HYP_ID' already exists" 1
     fi
 
+    # Validate category if provided
+    if [[ -n "$HYP_CATEGORY" ]]; then
+        if ! echo "$VALID_CATEGORIES" | grep -qw "$HYP_CATEGORY"; then
+            die_json "Invalid category: $HYP_CATEGORY. Must be one of: $VALID_CATEGORIES" 1
+        fi
+    fi
+
     local tmp
     tmp=$(mktemp)
 
-    jq --arg id "$HYP_ID" \
+    if jq --arg id "$HYP_ID" \
        --arg desc "$HYP_DESC" \
        --arg cat "${HYP_CATEGORY:-unknown}" \
        --arg status "${HYP_STATUS:-pending}" \
@@ -193,9 +212,13 @@ cmd_add_hypothesis() {
             evidence: [],
             rejected_reason: null,
             created_at: $now
-        }] | .updated_at = $now' "$state_file" > "$tmp" && mv "$tmp" "$state_file"
-
-    echo "{\"status\":\"added\",\"hypothesis_id\":\"$HYP_ID\"}"
+        }] | .updated_at = $now' "$state_file" > "$tmp"; then
+        mv "$tmp" "$state_file"
+        echo "{\"status\":\"added\",\"hypothesis_id\":\"$HYP_ID\"}"
+    else
+        rm -f "$tmp"
+        die_json "Failed to add hypothesis" 1
+    fi
 }
 
 cmd_update_hypothesis() {
@@ -260,6 +283,28 @@ cmd_update_hypothesis() {
     fi
 }
 
+cmd_increment_turn() {
+    local state_file
+    state_file=$(ensure_state_exists)
+
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    local tmp
+    tmp=$(mktemp)
+
+    if jq --arg now "$now" \
+       '.turns_used += 1 | .updated_at = $now' "$state_file" > "$tmp"; then
+        mv "$tmp" "$state_file"
+        local turns_used
+        turns_used=$(jq '.turns_used' "$state_file")
+        echo "{\"status\":\"incremented\",\"turns_used\":$turns_used}"
+    else
+        rm -f "$tmp"
+        die_json "Failed to increment turn" 1
+    fi
+}
+
 cmd_check_budget() {
     local state_file
     state_file=$(ensure_state_exists)
@@ -312,6 +357,7 @@ case "$COMMAND" in
     init) cmd_init ;;
     add-hypothesis) cmd_add_hypothesis ;;
     update-hypothesis) cmd_update_hypothesis ;;
+    increment-turn) cmd_increment_turn ;;
     check-budget) cmd_check_budget ;;
     read) cmd_read ;;
     *) die_json "Unknown command: $COMMAND" 1 ;;

--- a/bug-hunt/scripts/hunt-state.sh
+++ b/bug-hunt/scripts/hunt-state.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# hunt-state.sh - State management helper for bug-hunt skill
+# Usage: hunt-state.sh <command> [options]
+#
+# Commands:
+#   init              Initialize bug-hunt-state.json
+#   add-hypothesis    Add a new hypothesis
+#   update-hypothesis Update hypothesis status
+#   check-budget      Check remaining turn budget
+#   read              Read current state
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+# ============================================================================
+# Defaults
+# ============================================================================
+COMMAND=""
+REPO_PATH="."
+TARGET=""
+MAX_HYPOTHESES=8
+MAX_TURNS=30
+
+# Hypothesis fields
+HYP_ID=""
+HYP_DESC=""
+HYP_CATEGORY=""
+HYP_STATUS=""
+HYP_ASSIGNED=""
+HYP_REASON=""
+HYP_EVIDENCE=""
+
+# ============================================================================
+# Parse arguments
+# ============================================================================
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            init|add-hypothesis|update-hypothesis|check-budget|read)
+                COMMAND="$1"; shift ;;
+            --target) TARGET="$2"; shift 2 ;;
+            --max-hypotheses) MAX_HYPOTHESES="$2"; shift 2 ;;
+            --max-turns) MAX_TURNS="$2"; shift 2 ;;
+            --repo-path) REPO_PATH="$2"; shift 2 ;;
+            --id) HYP_ID="$2"; shift 2 ;;
+            --description) HYP_DESC="$2"; shift 2 ;;
+            --category) HYP_CATEGORY="$2"; shift 2 ;;
+            --status) HYP_STATUS="$2"; shift 2 ;;
+            --assigned-to) HYP_ASSIGNED="$2"; shift 2 ;;
+            --reason) HYP_REASON="$2"; shift 2 ;;
+            --evidence) HYP_EVIDENCE="$2"; shift 2 ;;
+            -h|--help) usage; exit 0 ;;
+            *) die_json "Unknown argument: $1" 1 ;;
+        esac
+    done
+
+    [[ -n "$COMMAND" ]] || die_json "Command required: init|add-hypothesis|update-hypothesis|check-budget|read" 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: hunt-state.sh <command> [options]
+
+Commands:
+  init                Initialize state file
+  add-hypothesis      Add a hypothesis
+  update-hypothesis   Update hypothesis status
+  check-budget        Check turn budget
+  read                Read current state
+
+Options:
+  --target <text>         Issue or description (init)
+  --max-hypotheses <N>    Max hypotheses (init, default: 8)
+  --max-turns <N>         Max turns (init, default: 30)
+  --repo-path <path>      Repository path (default: .)
+  --id <id>               Hypothesis ID
+  --description <text>    Hypothesis description
+  --category <cat>        Category: logic|state|external|environment
+  --status <status>       Status: pending|investigating|confirmed|rejected
+  --assigned-to <name>    Investigator name
+  --reason <text>         Rejection/confirmation reason
+  --evidence <text>       Evidence (comma-separated)
+EOF
+}
+
+# ============================================================================
+# State file path resolution
+# ============================================================================
+resolve_state_file() {
+    local repo
+    repo=$(cd "$REPO_PATH" && pwd) || die_json "Cannot resolve repo path: $REPO_PATH" 1
+    echo "$repo/.claude/bug-hunt-state.json"
+}
+
+ensure_state_exists() {
+    local state_file
+    state_file=$(resolve_state_file)
+    [[ -f "$state_file" ]] || die_json "State file not found: $state_file. Run 'init' first." 1
+    echo "$state_file"
+}
+
+# ============================================================================
+# Commands
+# ============================================================================
+
+cmd_init() {
+    [[ -n "$TARGET" ]] || die_json "--target required for init" 1
+
+    local state_file
+    state_file=$(resolve_state_file)
+    local state_dir
+    state_dir=$(dirname "$state_file")
+    mkdir -p "$state_dir"
+
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    jq -n \
+        --arg version "1.0.0" \
+        --arg target "$TARGET" \
+        --arg status "triaging" \
+        --argjson max_hypotheses "$MAX_HYPOTHESES" \
+        --argjson max_turns "$MAX_TURNS" \
+        --argjson turns_used 0 \
+        --arg created_at "$now" \
+        --arg updated_at "$now" \
+        '{
+            version: $version,
+            target: $target,
+            status: $status,
+            config: {
+                max_hypotheses: $max_hypotheses,
+                max_turns: $max_turns
+            },
+            turns_used: $turns_used,
+            hypotheses: [],
+            findings: [],
+            root_cause: null,
+            fix_proposal: null,
+            created_at: $created_at,
+            updated_at: $updated_at
+        }' > "$state_file"
+
+    echo "{\"status\":\"initialized\",\"state_file\":\"$state_file\"}"
+}
+
+cmd_add_hypothesis() {
+    [[ -n "$HYP_ID" ]] || die_json "--id required" 1
+    [[ -n "$HYP_DESC" ]] || die_json "--description required" 1
+
+    local state_file
+    state_file=$(ensure_state_exists)
+
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Check max hypotheses limit
+    local current_count
+    current_count=$(jq '.hypotheses | length' "$state_file")
+    local max
+    max=$(jq '.config.max_hypotheses' "$state_file")
+
+    if [[ "$current_count" -ge "$max" ]]; then
+        die_json "Max hypotheses limit reached ($max). Reject or remove a hypothesis first." 1
+    fi
+
+    # Check for duplicate ID
+    local exists
+    exists=$(jq --arg id "$HYP_ID" '.hypotheses | map(select(.id == $id)) | length' "$state_file")
+    if [[ "$exists" -gt 0 ]]; then
+        die_json "Hypothesis with id '$HYP_ID' already exists" 1
+    fi
+
+    local tmp
+    tmp=$(mktemp)
+
+    jq --arg id "$HYP_ID" \
+       --arg desc "$HYP_DESC" \
+       --arg cat "${HYP_CATEGORY:-unknown}" \
+       --arg status "${HYP_STATUS:-pending}" \
+       --arg assigned "${HYP_ASSIGNED:-}" \
+       --arg now "$now" \
+       '.hypotheses += [{
+            id: $id,
+            description: $desc,
+            category: $cat,
+            status: $status,
+            assigned_to: (if $assigned == "" then null else $assigned end),
+            evidence: [],
+            rejected_reason: null,
+            created_at: $now
+        }] | .updated_at = $now' "$state_file" > "$tmp" && mv "$tmp" "$state_file"
+
+    echo "{\"status\":\"added\",\"hypothesis_id\":\"$HYP_ID\"}"
+}
+
+cmd_update_hypothesis() {
+    [[ -n "$HYP_ID" ]] || die_json "--id required" 1
+
+    local state_file
+    state_file=$(ensure_state_exists)
+
+    # Verify hypothesis exists
+    local exists
+    exists=$(jq --arg id "$HYP_ID" '.hypotheses | map(select(.id == $id)) | length' "$state_file")
+    if [[ "$exists" -eq 0 ]]; then
+        die_json "Hypothesis '$HYP_ID' not found" 1
+    fi
+
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Build update filter
+    local jq_filter='.updated_at = $now'
+    local -a jq_args=(--arg id "$HYP_ID" --arg now "$now")
+
+    if [[ -n "$HYP_STATUS" ]]; then
+        # Validate status
+        case "$HYP_STATUS" in
+            pending|investigating|confirmed|rejected) ;;
+            *) die_json "Invalid hypothesis status: $HYP_STATUS. Use: pending|investigating|confirmed|rejected" 1 ;;
+        esac
+        jq_args+=(--arg new_status "$HYP_STATUS")
+        jq_filter="$jq_filter | .hypotheses = [.hypotheses[] | if .id == \$id then .status = \$new_status else . end]"
+    fi
+
+    if [[ -n "$HYP_ASSIGNED" ]]; then
+        jq_args+=(--arg assigned "$HYP_ASSIGNED")
+        jq_filter="$jq_filter | .hypotheses = [.hypotheses[] | if .id == \$id then .assigned_to = \$assigned else . end]"
+    fi
+
+    if [[ -n "$HYP_REASON" ]]; then
+        jq_args+=(--arg reason "$HYP_REASON")
+        jq_filter="$jq_filter | .hypotheses = [.hypotheses[] | if .id == \$id then .rejected_reason = \$reason else . end]"
+    fi
+
+    if [[ -n "$HYP_EVIDENCE" ]]; then
+        jq_args+=(--arg evidence "$HYP_EVIDENCE")
+        jq_filter="$jq_filter | .hypotheses = [.hypotheses[] | if .id == \$id then .evidence += [\$evidence] else . end]"
+    fi
+
+    # Update overall status if a hypothesis is confirmed
+    if [[ "$HYP_STATUS" == "confirmed" ]]; then
+        jq_filter="$jq_filter | .status = \"converging\""
+    fi
+
+    local tmp
+    tmp=$(mktemp)
+
+    if jq "${jq_args[@]}" "$jq_filter" "$state_file" > "$tmp"; then
+        mv "$tmp" "$state_file"
+        echo "{\"status\":\"updated\",\"hypothesis_id\":\"$HYP_ID\"}"
+    else
+        rm -f "$tmp"
+        die_json "Failed to update hypothesis" 1
+    fi
+}
+
+cmd_check_budget() {
+    local state_file
+    state_file=$(ensure_state_exists)
+
+    local turns_used max_turns remaining pct
+    turns_used=$(jq '.turns_used' "$state_file")
+    max_turns=$(jq '.config.max_turns' "$state_file")
+    remaining=$((max_turns - turns_used))
+    if [[ "$max_turns" -gt 0 ]]; then
+        pct=$(( (turns_used * 100) / max_turns ))
+    else
+        pct=0
+    fi
+
+    local warning=""
+    if [[ "$pct" -ge 80 ]]; then
+        warning="CRITICAL: Budget nearly exhausted. Consider converging."
+    elif [[ "$pct" -ge 60 ]]; then
+        warning="WARNING: Over 60% budget used. Prioritize strongest hypotheses."
+    fi
+
+    jq -n \
+        --argjson used "$turns_used" \
+        --argjson max "$max_turns" \
+        --argjson remaining "$remaining" \
+        --argjson pct "$pct" \
+        --arg warning "$warning" \
+        '{
+            turns_used: $used,
+            max_turns: $max,
+            remaining: $remaining,
+            percent_used: $pct,
+            warning: (if $warning == "" then null else $warning end),
+            within_budget: ($remaining > 0)
+        }'
+}
+
+cmd_read() {
+    local state_file
+    state_file=$(ensure_state_exists)
+    jq '.' "$state_file"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+parse_args "$@"
+
+case "$COMMAND" in
+    init) cmd_init ;;
+    add-hypothesis) cmd_add_hypothesis ;;
+    update-hypothesis) cmd_update_hypothesis ;;
+    check-budget) cmd_check_budget ;;
+    read) cmd_read ;;
+    *) die_json "Unknown command: $COMMAND" 1 ;;
+esac


### PR DESCRIPTION
## Summary

- Agent Team協調型バグ調査スキル `/bug-hunt` を新規実装
- 複数エージェントが仮説ベースで並列調査し、動的に方向転換しながらバグの根本原因を特定
- `hunt-state.sh` による状態管理（init/add-hypothesis/update-hypothesis/check-budget/read）

## Changes

### New Files
- `bug-hunt/SKILL.md` - スキル定義（201行、500行制限内）
- `bug-hunt/references/team-lifecycle.md` - Agent Teamライフサイクルパターン
- `bug-hunt/references/hypothesis-categories.md` - バグ仮説カテゴリと検証アプローチ
- `bug-hunt/scripts/hunt-state.sh` - 状態管理ヘルパースクリプト

### Features
- 4フェーズワークフロー: Triage → Investigate → Converge → Propose Fix
- TeamCreate/SendMessage/TaskListによるAgent Team協調
- 動的仮説管理（追加/棄却/方向転換）
- `--max-turns` によるコスト制御
- `bug-hunt-state.json` による状態永続化と復旧
- コスト最適化（単純バグではinvestigator-1のみ起動）

## Test plan

- [x] hunt-state.sh init コマンドの動作確認
- [x] hunt-state.sh add-hypothesis コマンドの動作確認
- [x] hunt-state.sh update-hypothesis コマンドの動作確認（reject/confirm）
- [x] hunt-state.sh check-budget コマンドの動作確認
- [x] hunt-state.sh read コマンドの動作確認
- [x] 重複ID拒否のエラーハンドリング確認
- [x] 存在しない仮説更新のエラーハンドリング確認
- [x] SKILL.md 500行制限の確認（201行）

Closes #21