### PR TITLE
refactor: dev-flowのパラレルモード選択をauto-detect方式に置換

### DIFF
--- a/dev-decompose/SKILL.md
+++ b/dev-decompose/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Creates contract branch, worktrees, and flow.json for parallel dev-kickoff execution.
   Use when: (1) large issues need parallel implementation, (2) file-boundary decomposition,
   (3) keywords: decompose, split, parallel, subtasks
-  Accepts args: <issue-number> [--base <branch>] [--env-mode hardlink|symlink|copy|none] [--flow-state <path>]
+  Accepts args: <issue-number> [--base <branch>] [--env-mode hardlink|symlink|copy|none] [--flow-state <path>] [--dry-run]
 allowed-tools:
   - Bash
   - Task
@@ -27,6 +27,8 @@ Decompose large issues into parallel subtasks with file-boundary isolation. Crea
 
 ## Workflow
 
+### Full Execution (default)
+
 ```
 1. Read issue analysis (from dev-issue-analyze output or issue body)
 2. Identify affected files and dependencies
@@ -38,6 +40,35 @@ Decompose large issues into parallel subtasks with file-boundary isolation. Crea
 8. Create worktrees for each subtask (git-prepare --base contract-branch --suffix taskN)
 9. Generate flow.json
 10. Validate decomposition (validate-decomposition.sh)
+```
+
+### Dry-Run Mode (`--dry-run`)
+
+Lightweight mode that executes only Steps 1-4 (analysis and file grouping) without creating branches, worktrees, or flow.json. Used by dev-flow for auto-detect mode selection.
+
+```
+1. Read issue analysis (from dev-issue-analyze output or issue body)
+2. Identify affected files and dependencies
+3. Group files into subtasks (no file overlap)
+4. Apply fallback criteria (see Decomposition Guide)
+→ Return assessment JSON (no side effects)
+```
+
+Dry-run output:
+```json
+// single_fallback
+{"status": "single_fallback", "reason": "Fewer than 4 affected files", "file_count": 2}
+
+// ready for parallel
+{"status": "ready", "subtask_count": 3, "file_groups": [
+  {"id": "task1", "files": ["src/models/user.ts", "src/models/user.test.ts"]},
+  {"id": "task2", "files": ["src/routes/auth.ts", "src/middleware/jwt.ts"]}
+]}
+```
+
+To continue from dry-run to full execution, pass the dry-run result path:
+```bash
+Skill: dev-decompose $ISSUE --resume /path/to/dry-run-result.json --base $BASE
 ```
 
 ### Step 1-4: Analysis & File Grouping
@@ -108,10 +139,14 @@ If decomposition yields 1 subtask, return fallback (see [Decomposition Guide](re
 | `--base` | `main` | Base branch for contract |
 | `--env-mode` | `hardlink` | Env file handling for worktrees |
 | `--flow-state` | auto | Path to flow.json output location |
+| `--dry-run` | false | Run Steps 1-4 only (analysis + grouping), no side effects |
+| `--resume` | - | Path to dry-run result JSON, skip Steps 1-4 and continue from Step 5 |
 
 When `--flow-state` is `auto`, the path defaults to `$WORKTREE_BASE/.claude/flow.json` where `$WORKTREE_BASE` is the parent worktrees directory for the issue.
 
 ## Output
+
+### Full Execution
 
 flow.json is created at `$WORKTREE_BASE/.claude/flow.json`.
 
@@ -122,6 +157,17 @@ See [flow.schema.json](../_lib/schemas/flow.schema.json) for full schema.
 Return value:
 ```json
 {"status": "decomposed|single_fallback", "subtask_count": N, "flow_state": "/path/to/flow.json"}
+```
+
+### Dry-Run
+
+No files created on disk. Return value only:
+```json
+// Ready for parallel
+{"status": "ready", "subtask_count": N, "file_groups": [{"id": "taskN", "files": [...]}]}
+
+// Fallback to single
+{"status": "single_fallback", "reason": "<criteria from Decomposition Guide>", "file_count": N}
 ```
 
 ## Error Handling

--- a/dev-flow-doctor/SKILL.md
+++ b/dev-flow-doctor/SKILL.md
@@ -48,16 +48,17 @@ Diagnose dev-flow pipeline health and generate actionable improvement recommenda
 ### Check 1: Parallel Mode Usage
 
 ```bash
-# Check if --parallel has ever been used
+# Check if parallel mode has ever been used (auto-detect or force-parallel)
 $SKILLS_DIR/skill-retrospective/scripts/journal.sh query --skill dev-flow --limit 100 | \
-  jq '[.[] | select(.args != null and (.args | contains("parallel")))] | length'
+  jq '[.[] | select(.args != null and (.args | test("parallel|force-parallel")))] | length'
 ```
 
 | Finding | Recommendation |
 |---------|----------------|
-| Never used | Consider using `--parallel` for issues touching 3+ files |
-| Used but failed | Investigate decomposition failures |
-| Used successfully | No action needed |
+| Never triggered | Auto-detect may be too conservative, review dry-run criteria |
+| Triggered but failed | Investigate decomposition failures |
+| Triggered successfully | No action needed |
+| Override frequently used | Review auto-detect accuracy, consider criteria adjustment |
 
 ### Check 2: Phase Failure Distribution
 
@@ -136,7 +137,7 @@ score = 100
 score -= (failure_rate * 30)        # Max -30 for high failure rate
 score -= (avg_recovery_turns * 5)    # Max -25 for slow recovery
 score -= (stale_worktrees * 2)       # Max -10 for cleanup debt
-score -= (parallel_unused * 10)      # -10 if parallel never used
+score -= (auto_detect_override * 5)   # -5 per frequent override (auto-detect inaccuracy)
 score -= (env_errors_pct * 15)       # Max -15 for env issues
 score = max(0, score)
 ```
@@ -159,8 +160,8 @@ score = max(0, score)
 
 ### Findings
 
-1. **[WARN]** Parallel mode never used
-   → 3+ file issues could benefit from `--parallel`
+1. **[WARN]** Auto-detect override frequently used
+   → Investigate dry-run accuracy, consider criteria adjustment
 
 2. **[WARN]** Phase 4 (validate) fails 35% of the time
    → Most failures are lint errors (auto-fixable)
@@ -169,7 +170,7 @@ score = max(0, score)
    → Run cleanup commands below
 
 ### Recommended Actions
-- [ ] Try `--parallel` on next large issue
+- [ ] Review auto-detect dry-run criteria if overrides are frequent
 - [ ] Add `--fix` to dev-validate default behavior
 - [ ] Clean stale worktrees: `git worktree remove ...`
 

--- a/dev-flow/SKILL.md
+++ b/dev-flow/SKILL.md
@@ -3,10 +3,10 @@ name: dev-flow
 description: |
   End-to-end development flow automation - from issue to LGTM.
   Note: Merge is performed manually by the user after review approval.
-  Supports parallel subtask decomposition for large issues.
+  Auto-detects parallel vs single mode based on issue complexity.
   Use when: (1) complete development cycle needed, (2) issue to PR automation,
   (3) keywords: full flow, development cycle, issue to PR
-  Accepts args: <issue-number> [--strategy tdd|bdd|ddd] [--depth minimal|standard|comprehensive] [--base <branch>] [--max-iterations N] [--parallel]
+  Accepts args: <issue-number> [--strategy tdd|bdd|ddd] [--depth minimal|standard|comprehensive] [--base <branch>] [--max-iterations N] [--force-single] [--force-parallel]
 allowed-tools:
   - Skill
   - Bash
@@ -27,47 +27,81 @@ End-to-end development automation from issue to LGTM (merge manually).
 
 **DO NOT EXIT until pr-iterate completes.**
 
-## Mode Selection
+## Mode Selection (Auto-Detect)
 
-dev-flow operates in two modes based on issue complexity:
+dev-flow automatically selects single or parallel mode using `dev-decompose --dry-run`.
+Override with `--force-single` or `--force-parallel` when needed.
 
 ```
-dev-flow (mode branch)
-├── Single mode (default / small issues)
-│   ├── Task: dev-kickoff 1 instance → git-pr (subagent, independent context)
-│   ├── gh pr view (main context)
-│   └── Task: pr-iterate (subagent, independent context)
+dev-flow <issue>
 │
-└── Parallel mode (--parallel / large issues)
-    ├── dev-issue-analyze
-    ├── dev-decompose → flow.json + N worktrees
-    ├── dev-kickoff × N (parallel via Task tool)
-    ├── dev-integrate (merge + type check + test)
-    ├── git-pr
-    └── pr-iterate
+├─→ Step 0: dev-issue-analyze --depth standard
+│
+├─→ Step 1: Mode Decision
+│   ├── --force-single  → Single Mode (skip dry-run)
+│   ├── --force-parallel → Parallel Mode (skip dry-run)
+│   └── auto (default)  → dev-decompose --dry-run
+│       ├── single_fallback → Single Mode
+│       └── ready          → Parallel Mode
+│
+├─→ [Single]   Steps 2a-4a (see below)
+└─→ [Parallel] Steps 2b-9b (see below)
 ```
 
-## Single Mode (Default)
+## Step 0: Issue Analysis (Always)
 
-For small issues or when `--parallel` is not specified.
+```bash
+Skill: dev-issue-analyze $ISSUE --depth standard
+```
+
+Provides context for both modes and for dry-run decomposition assessment.
+
+## Step 1: Mode Decision
+
+### Auto-Detect (default)
+
+```bash
+Skill: dev-decompose $ISSUE --dry-run
+```
+
+Assess issue complexity using actual codebase file dependencies (not issue text parsing).
+Criteria defined in [Decomposition Guide](../dev-decompose/references/decomposition-guide.md#when-to-fall-back-to-single-mode):
+
+- `single_fallback`: < 4 affected files, single component, all files tightly coupled, or 1 subtask after grouping
+- `ready`: Multiple independent subtask groups identified
+
+### Force Overrides
+
+| Flag | Behavior |
+|------|----------|
+| `--force-single` | Skip dry-run, go directly to Single Mode |
+| `--force-parallel` | Skip dry-run, go directly to Parallel Mode (full dev-decompose) |
+| `--parallel` | **Deprecated alias** for `--force-parallel`. Shows deprecation notice |
+| Both specified | **Error**: "Cannot specify both --force-single and --force-parallel" |
+
+## Single Mode
+
+For small issues or when auto-detect returns `single_fallback`.
 
 dev-kickoff and pr-iterate run as Task subagents with independent contexts to keep the main dev-flow context lightweight.
 
 | Step | Action | Complete When |
 |------|--------|---------------|
-| 1 | `Task: dev-kickoff` (subagent) | PR URL available |
-| 2 | `gh pr view --json url` | URL captured |
-| 3 | `Task: pr-iterate` (subagent) | LGTM achieved or max iterations |
+| 2a | `Task: dev-kickoff` (subagent) | PR URL available |
+| 3a | `gh pr view --json url` | URL captured |
+| 4a | `Task: pr-iterate` (subagent) | LGTM achieved or max iterations |
 
 ### Single Mode Checklist
 
 ```
-[ ] Step 1: Task subagent → dev-kickoff (see prompt below)
-[ ] Step 2: PR_URL=$(gh pr view --json url --jq .url)  (run in worktree)
-[ ] Step 3: Task subagent → pr-iterate (see prompt below)
+[ ] Step 0: Skill: dev-issue-analyze (see above)
+[ ] Step 1: Mode decision → single
+[ ] Step 2a: Task subagent → dev-kickoff (see prompt below)
+[ ] Step 3a: PR_URL=$(gh pr view --json url --jq .url)  (run in worktree)
+[ ] Step 4a: Task subagent → pr-iterate (see prompt below)
 ```
 
-### Step 1: dev-kickoff Subagent
+### Step 2a: dev-kickoff Subagent
 
 Launch dev-kickoff as a Task subagent. The subagent runs in its own context and returns only the result.
 
@@ -96,19 +130,19 @@ After completion, return ONLY a JSON result:
 
 | Result | Action |
 |--------|--------|
-| `status: "completed"` | Verify `worktree` path exists and is not the main repo → proceed to Step 2 |
+| `status: "completed"` | Verify `worktree` path exists and is not the main repo → proceed to Step 3a |
 | `status: "completed"` but no `worktree` or worktree is main repo | **ABORT** — worktree was not created |
 | `status: "failed"` | Log failure via journal.sh → abort dev-flow |
 | Task tool error | Log error → abort dev-flow |
 
-### Step 2: Get PR URL
+### Step 3a: Get PR URL
 
 ```bash
-# Run from worktree returned by Step 1
+# Run from worktree returned by Step 2a
 cd $WORKTREE && gh pr view --json url --jq .url
 ```
 
-### Step 3: pr-iterate Subagent
+### Step 4a: pr-iterate Subagent
 
 Launch pr-iterate as a Task subagent.
 
@@ -165,20 +199,31 @@ After completion, return ONLY a JSON result:
 
 ## Parallel Mode
 
-For large issues requiring decomposition. Activated with `--parallel` flag.
+For large issues. Activated automatically when dry-run returns `ready`, or with `--force-parallel`.
 
 | Step | Action | Complete When |
 |------|--------|---------------|
-| 1 | `Skill: dev-issue-analyze` | Requirements understood |
-| 2 | `Skill: dev-decompose` | flow.json + worktrees created |
-| 3 | Check decomposition result | Single fallback or proceed |
-| 4 | `dev-kickoff x N` (parallel) | All subtasks completed |
-| 5 | Aggregate results | flow.json updated |
-| 6 | `Skill: dev-integrate` | Merge + tests pass |
-| 7 | `Skill: git-pr` | PR URL available |
-| 8 | `Skill: pr-iterate` | LGTM or max iterations |
+| 2b | `Skill: dev-decompose` (full, with `--resume` if dry-run ran) | flow.json + worktrees created |
+| 3b | Check decomposition result | Verify subtask count > 1 |
+| 4b | `dev-kickoff x N` (parallel) | All subtasks completed |
+| 5b | Aggregate results | flow.json updated |
+| 6b | `Skill: dev-integrate` | Merge + tests pass |
+| 7b | `Skill: git-pr` | PR URL available |
+| 8b | `Skill: pr-iterate` | LGTM or max iterations |
 
-### Batch Scheduling (Step 4)
+### Step 2b: Full Decomposition
+
+If dry-run already ran (auto-detect path), pass its result to avoid re-analysis:
+```bash
+Skill: dev-decompose $ISSUE --resume $DRY_RUN_RESULT --base $BASE --env-mode $ENV_MODE
+```
+
+If `--force-parallel` (no dry-run), run full decomposition:
+```bash
+Skill: dev-decompose $ISSUE --base $BASE --env-mode $ENV_MODE
+```
+
+### Batch Scheduling (Step 4b)
 
 Launch subtasks in dependency-ordered batches (independent first, then dependents). Each invocation:
 
@@ -186,7 +231,7 @@ Launch subtasks in dependency-ordered batches (independent first, then dependent
 Skill: dev-kickoff $ISSUE --worktree $SUBTASK_WORKTREE --task-id $TASK_ID --flow-state $FLOW_STATE --strategy $STRATEGY
 ```
 
-### Result Aggregation (Step 5)
+### Result Aggregation (Step 5b)
 
 For each completed subtask, read kickoff.json and update flow.json:
 
@@ -199,7 +244,7 @@ $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
 ## Usage
 
 ```
-/dev-flow <issue> [--strategy tdd] [--depth comprehensive] [--base dev] [--max-iterations 10] [--parallel]
+/dev-flow <issue> [--strategy tdd] [--depth comprehensive] [--base dev] [--max-iterations 10] [--force-single] [--force-parallel]
 ```
 
 ## Args
@@ -211,7 +256,9 @@ $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
 | `--depth` | `standard` | Analysis depth |
 | `--base` | `dev` | PR base branch |
 | `--max-iterations` | `10` | Max pr-iterate iterations |
-| `--parallel` | - | Enable parallel subtask decomposition |
+| `--force-single` | - | Skip auto-detect, force single mode |
+| `--force-parallel` | - | Skip auto-detect, force parallel mode |
+| `--parallel` | - | **Deprecated**: alias for `--force-parallel` |
 
 ## Completion Conditions
 
@@ -221,7 +268,7 @@ $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
 | LGTM achieved | Workflow complete (merge manually) |
 | Max iterations reached | Report status, user decides |
 | Any step fails | Report error, do not proceed |
-| Decomposition yields 1 subtask | Fallback to single mode |
+| Dry-run returns single_fallback | Use single mode |
 
 ## No Auto-Merge
 
@@ -258,7 +305,7 @@ git worktree remove $SUBTASK_WORKTREE --force
 ## Journal Logging
 
 On workflow completion, log execution to skill-retrospective journal.
-**CRITICAL: Always pass `--args` with the original invocation arguments** (e.g. `--parallel`, `--strategy tdd`) so that usage patterns are tracked.
+**CRITICAL: Always pass `--args` with the original invocation arguments** so that usage patterns are tracked.
 
 ```bash
 # On success (LGTM achieved)
@@ -270,7 +317,7 @@ $SKILLS_DIR/skill-retrospective/scripts/journal.sh log dev-flow failure \
   --issue $ISSUE --error-category <category> --error-msg "<message>" --args "$ORIGINAL_ARGS"
 ```
 
-Where `$ORIGINAL_ARGS` is the full argument string passed to dev-flow (e.g. `"42 --parallel --strategy tdd"`).
+Where `$ORIGINAL_ARGS` is the full argument string passed to dev-flow (e.g. `"42 --force-parallel --strategy tdd"`).
 
 Note: dev-kickoff and pr-iterate also log independently. dev-flow logging captures the overall flow outcome.
 

--- a/dev-flow/references/workflow-detail.md
+++ b/dev-flow/references/workflow-detail.md
@@ -4,69 +4,69 @@ Detailed documentation for the dev-flow skill workflow.
 
 ## Architecture
 
-### Single Mode (Default)
-
-dev-kickoff and pr-iterate run as Task subagents with independent contexts.
-The main dev-flow context stays lightweight (instruction + result only).
+### Auto-Detect Flow
 
 ```
 dev-flow (main context - lightweight)
     │
-    ├─→ Step 1: Task subagent → dev-kickoff (independent context)
-    │       ├─→ Phase 1: git-prepare.sh (worktree)
-    │       ├─→ Phase 2: dev-issue-analyze (exploration)
-    │       ├─→ Phase 3: dev-implement (coding)
-    │       ├─→ Phase 4: dev-validate (testing)
-    │       ├─→ Phase 5: git-commit (commit)
-    │       ├─→ Phase 6: git-pr (PR creation)
-    │       └── Returns: {status, worktree, pr_url, pr_number}
+    ├─→ Step 0: dev-issue-analyze --depth standard (always)
     │
-    ├─→ Step 2: Get PR URL (main context)
-    │       └─→ gh pr view --json url --jq .url
+    ├─→ Step 1: Mode Decision
+    │       ├── --force-single  → Single Mode (skip dry-run)
+    │       ├── --force-parallel → Parallel Mode (skip dry-run)
+    │       └── auto → dev-decompose --dry-run
+    │           ├── single_fallback → Single Mode
+    │           └── ready → Parallel Mode
     │
-    └─→ Step 3: Task subagent → pr-iterate (independent context)
-            ├─→ Review → Fix → Push → Repeat
-            └── Returns: {status, iterations}
-```
-
-### Parallel Mode (--parallel)
-
-```
-dev-flow (orchestrator)
+    ├─→ [Single Mode]
+    │   ├─→ Step 2a: Task subagent → dev-kickoff (independent context)
+    │   │       ├─→ Phase 1: git-prepare.sh (worktree)
+    │   │       ├─→ Phase 2: dev-issue-analyze (exploration)
+    │   │       ├─→ Phase 3: dev-implement (coding)
+    │   │       ├─→ Phase 4: dev-validate (testing)
+    │   │       ├─→ Phase 5: git-commit (commit)
+    │   │       ├─→ Phase 6: git-pr (PR creation)
+    │   │       └── Returns: {status, worktree, pr_url, pr_number}
+    │   │
+    │   ├─→ Step 3a: Get PR URL (main context)
+    │   │       └─→ gh pr view --json url --jq .url
+    │   │
+    │   └─→ Step 4a: Task subagent → pr-iterate (independent context)
+    │           ├─→ Review → Fix → Push → Repeat
+    │           └── Returns: {status, iterations}
     │
-    ├─→ Step 1: dev-issue-analyze (comprehensive)
-    │
-    ├─→ Step 2: dev-decompose
-    │       ├─→ Identify affected files
-    │       ├─→ Build dependency graph
-    │       ├─→ Split into subtasks (file boundary)
-    │       ├─→ Generate shared contract (interfaces/types)
-    │       ├─→ Create contract branch + commit
-    │       ├─→ Create N worktrees (git-prepare x N)
-    │       └─→ Generate flow.json
-    │
-    ├─→ Step 3: Check decomposition
-    │       └─→ subtask_count == 1 → fallback to single mode
-    │
-    ├─→ Step 4: Batch scheduling (depends_on graph)
-    │       ├─→ Batch 1: [task1, task3] (independent) ── parallel
-    │       │       ├─→ dev-kickoff --task-id task1 (Phase 3-5 only)
-    │       │       └─→ dev-kickoff --task-id task3 (Phase 3-5 only)
-    │       └─→ Batch 2: [task2] (depends on task1) ── after batch 1
-    │               └─→ dev-kickoff --task-id task2 (Phase 3-5 only)
-    │
-    ├─→ Step 5: Aggregate results
-    │       └─→ Read kickoff.json → update flow.json (actual_files_changed)
-    │
-    ├─→ Step 6: dev-integrate
-    │       ├─→ Check drift (planned vs actual files)
-    │       ├─→ Merge subtask branches (topological order)
-    │       ├─→ Type check (tsc/mypy/go vet)
-    │       └─→ dev-validate (integration tests)
-    │
-    ├─→ Step 7: git-pr (from merge worktree)
-    │
-    └─→ Step 8: pr-iterate (review loop)
+    └─→ [Parallel Mode]
+        ├─→ Step 2b: dev-decompose (full, --resume if dry-run ran)
+        │       ├─→ Identify affected files
+        │       ├─→ Build dependency graph
+        │       ├─→ Split into subtasks (file boundary)
+        │       ├─→ Generate shared contract (interfaces/types)
+        │       ├─→ Create contract branch + commit
+        │       ├─→ Create N worktrees (git-prepare x N)
+        │       └─→ Generate flow.json
+        │
+        ├─→ Step 3b: Check decomposition
+        │       └─→ subtask_count verified > 1
+        │
+        ├─→ Step 4b: Batch scheduling (depends_on graph)
+        │       ├─→ Batch 1: [task1, task3] (independent) ── parallel
+        │       │       ├─→ dev-kickoff --task-id task1 (Phase 3-5 only)
+        │       │       └─→ dev-kickoff --task-id task3 (Phase 3-5 only)
+        │       └─→ Batch 2: [task2] (depends on task1) ── after batch 1
+        │               └─→ dev-kickoff --task-id task2 (Phase 3-5 only)
+        │
+        ├─→ Step 5b: Aggregate results
+        │       └─→ Read kickoff.json → update flow.json (actual_files_changed)
+        │
+        ├─→ Step 6b: dev-integrate
+        │       ├─→ Check drift (planned vs actual files)
+        │       ├─→ Merge subtask branches (topological order)
+        │       ├─→ Type check (tsc/mypy/go vet)
+        │       └─→ dev-validate (integration tests)
+        │
+        ├─→ Step 7b: git-pr (from merge worktree)
+        │
+        └─→ Step 8b: pr-iterate (review loop)
 ```
 
 ## State Flow
@@ -94,7 +94,7 @@ analyzing → decomposing → implementing → integrating → pr → iterating 
 
 ## Single Mode Details
 
-### Step 1: dev-kickoff (Task Subagent)
+### Step 2a: dev-kickoff (Task Subagent)
 
 dev-kickoff runs as a Task subagent with its own independent context. The main dev-flow context only holds the Task invocation prompt and the returned result JSON. This prevents dev-kickoff's internal turns (up to 50) from accumulating in the main context.
 
@@ -118,14 +118,14 @@ The subagent returns: `{"status": "completed", "worktree": "<path>", "pr_url": "
 
 On failure, the subagent returns: `{"status": "failed", "error": "<message>", "phase": "<failed_phase>"}`
 
-### Step 2: Get PR URL
+### Step 3a: Get PR URL
 
 ```bash
-# Run from worktree returned by Step 1 subagent
+# Run from worktree returned by Step 2a subagent
 cd $WORKTREE && gh pr view --json url --jq .url
 ```
 
-### Step 3: pr-iterate (Task Subagent)
+### Step 4a: pr-iterate (Task Subagent)
 
 pr-iterate runs as a Task subagent with its own independent context. This prevents the review-fix loop iterations from accumulating in the main dev-flow context.
 
@@ -143,16 +143,25 @@ The Task tool is used to spawn a subagent that executes `Skill: pr-iterate`. The
 
 ## Parallel Mode Details
 
-### Step 1: Issue Analysis
+### Step 0: Issue Analysis (Always)
 
 ```
-Skill: dev-issue-analyze $ISSUE --depth comprehensive
+Skill: dev-issue-analyze $ISSUE --depth standard
 ```
 
-Produces comprehensive analysis including affected files list, used as input for decomposition.
+Provides context for dry-run decomposition assessment and for both modes.
 
-### Step 2: Decomposition
+### Step 1: Mode Decision
 
+Auto-detect uses `dev-decompose --dry-run` to assess complexity based on actual codebase file dependencies. See [Decomposition Guide](../../dev-decompose/references/decomposition-guide.md#when-to-fall-back-to-single-mode) for criteria.
+
+### Step 2b: Decomposition
+
+```
+Skill: dev-decompose $ISSUE --resume $DRY_RUN_RESULT --base $BASE --env-mode $ENV_MODE
+```
+
+If `--force-parallel` (no dry-run), run full:
 ```
 Skill: dev-decompose $ISSUE --base $BASE --env-mode $ENV_MODE
 ```
@@ -162,14 +171,7 @@ Creates:
 - Subtask worktrees: `feature-issue-{N}-task1`, `feature-issue-{N}-task2`, ...
 - flow.json with subtask definitions
 
-### Step 3: Fallback Check
-
-If `subtask_count == 1`:
-- Switch to single mode
-- Use the single subtask worktree
-- Run dev-kickoff normally
-
-### Step 4: Parallel Execution
+### Step 4b: Parallel Execution
 
 Launch subtasks via Task tool in dependency-ordered batches:
 
@@ -192,14 +194,14 @@ In `--task-id` mode, dev-kickoff only executes:
 - Phase 4: validate
 - Phase 5: commit (+ records actual_files_changed)
 
-### Step 5: Result Aggregation
+### Step 5b: Result Aggregation
 
 For each completed subtask:
 1. Read `actual_files_changed` from subtask's kickoff.json
 2. Update flow.json via `flow-update.sh`
 3. Check for failures (any subtask status == "failed" → abort)
 
-### Step 6: Integration
+### Step 6b: Integration
 
 ```
 Skill: dev-integrate --flow-state $FLOW_STATE
@@ -207,7 +209,7 @@ Skill: dev-integrate --flow-state $FLOW_STATE
 
 See [dev-integrate/SKILL.md](../../dev-integrate/SKILL.md).
 
-### Step 7: PR Creation
+### Step 7b: PR Creation
 
 ```
 Skill: git-pr $ISSUE --base $BASE --worktree $MERGE_WORKTREE
@@ -215,7 +217,7 @@ Skill: git-pr $ISSUE --base $BASE --worktree $MERGE_WORKTREE
 
 PR is created from the merge worktree containing all integrated changes.
 
-### Step 8: PR Iteration
+### Step 8b: PR Iteration
 
 ```
 Skill: pr-iterate $PR_URL --max-iterations $MAX
@@ -247,6 +249,7 @@ Same as single mode.
 
 | Scenario | Action |
 |----------|--------|
+| Dry-run fails | Fall back to single mode (safe default) |
 | Phase fails in kickoff | kickoff.json records error, stops |
 | Subtask fails in parallel | flow.json records, abort remaining |
 | PR creation fails | Manual `gh pr create`, then update state |
@@ -289,7 +292,8 @@ cat $SUBTASK_WT/.claude/kickoff.json | jq '.current_phase'
 - In single mode, the Task subagent returns `{status, worktree, pr_url, pr_number}` to dev-flow
 
 ### With dev-decompose
-- dev-flow calls dev-decompose after issue analysis
+- Auto-detect: dev-flow calls `dev-decompose --dry-run` for mode assessment
+- Parallel mode: dev-flow calls `dev-decompose --resume` (or full) for actual decomposition
 - flow.json is the handoff point (contains subtask definitions)
 
 ### With dev-integrate

--- a/git-prepare/scripts/git-prepare.sh
+++ b/git-prepare/scripts/git-prepare.sh
@@ -99,13 +99,22 @@ if [[ -d "$WORKTREE_PATH" ]]; then
     exit 0
 fi
 
-# Check if branch exists
+# Check if branch exists locally
 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
     # Branch exists, use it
     git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
 else
-    # Create new branch from base
-    git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "origin/$BASE_BRANCH"
+    # Try creating linked branch via gh issue develop (links to issue's Development sidebar)
+    if gh issue develop "$ISSUE_NUMBER" --name "$BRANCH_NAME" --base "$BASE_BRANCH" 2>/dev/null; then
+        git fetch origin "$BRANCH_NAME" 2>/dev/null || true
+    fi
+
+    # Create worktree (auto-tracks remote branch if exists, otherwise creates from base)
+    if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME" 2>/dev/null; then
+        git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+    else
+        git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" "origin/$BASE_BRANCH"
+    fi
 fi
 
 # Sync environment files via sync-env skill (--force for new worktrees)


### PR DESCRIPTION
## 概要

dev-flowのモード選択を手動フラグ（`--parallel`）から自動検出方式に変更し、ユーザー体験を改善。

### 主な変更点

- **dev-flow**: `--parallel`フラグを廃止し、`dev-decompose --dry-run`によるauto-detect方式を導入
  - `--force-single` / `--force-parallel` で手動オーバーライドも可能
  - `--parallel` は `--force-parallel` のdeprecatedエイリアスとして残存
- **dev-decompose**: `--dry-run`モードを追加（Step 1-4のみ実行、副作用なし）
  - `--resume` オプションでdry-run結果から本実行を再開可能
- **dev-flow-doctor**: パラレルモードの診断をauto-detect方式に対応
- **git-prepare**: `gh issue develop`を使用してブランチ作成し、issueのDevelopmentサイドバーにPRを自動リンク

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `dev-flow/SKILL.md` | auto-detectフロー、新フラグ、ステップ番号改訂 |
| `dev-flow/references/workflow-detail.md` | アーキテクチャ図・詳細ドキュメントの更新 |
| `dev-decompose/SKILL.md` | `--dry-run`・`--resume`オプション追加 |
| `dev-flow-doctor/SKILL.md` | auto-detect対応の診断ロジック更新 |
| `git-prepare/scripts/git-prepare.sh` | `gh issue develop`によるブランチ作成 |

## テスト計画

- [ ] `dev-flow <issue>` でauto-detectが正しくsingle/parallelを判定すること
- [ ] `--force-single` でdry-runをスキップしsingleモードになること
- [ ] `--force-parallel` でdry-runをスキップしparallelモードになること
- [ ] `--parallel`（deprecated）が`--force-parallel`として動作すること
- [ ] `dev-decompose --dry-run` が副作用なしで結果JSONを返すこと
- [ ] `git-prepare.sh` が`gh issue develop`でブランチ作成しissueにリンクすること