### PR TITLE
feat(worktree): .worktreeinclude で .env 自動コピーを実装

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.env.local
+.env.development

--- a/git-prepare/SKILL.md
+++ b/git-prepare/SKILL.md
@@ -35,6 +35,12 @@ $SKILLS_DIR/git-prepare/scripts/git-prepare.sh <issue-number> [options]
 | `--base` | `dev` | Base branch |
 | `--env-mode` | `hardlink` | Env file handling |
 
+## `.worktreeinclude` 自動コピー
+
+プロジェクトルートに `.worktreeinclude` が存在する場合、Claude Code v2.1.x 以降が worktree 作成時にルートレベルの `.env` ファイルを自動コピーする。この場合、`git-prepare.sh` は新規 worktree 作成時にルートレベル `.env` の `--force` コピーをスキップし、サブディレクトリの `.env` のみ sync-env で処理する。
+
+`.worktreeinclude` が存在しない環境では従来通り sync-env が全 `.env` をコピーする（後方互換性あり）。
+
 ## Env Modes
 
 | Mode | Docker | Sync | Cross-FS |

--- a/git-prepare/scripts/git-prepare.sh
+++ b/git-prepare/scripts/git-prepare.sh
@@ -125,8 +125,14 @@ else
     fi
 fi
 
-# Sync environment files via sync-env skill (--force for new worktrees)
-ENV_RESULT=$(run_sync_env "$WORKTREE_PATH" "$REPO_ROOT" "$ENV_MODE" "--force")
+# Sync environment files via sync-env skill
+# If .worktreeinclude exists, Claude Code already copied root-level .env files
+# so we skip --force to avoid overwriting them; sync-env will handle subdirectory .env files
+if [[ -f "$REPO_ROOT/.worktreeinclude" ]]; then
+    ENV_RESULT=$(run_sync_env "$WORKTREE_PATH" "$REPO_ROOT" "$ENV_MODE")
+else
+    ENV_RESULT=$(run_sync_env "$WORKTREE_PATH" "$REPO_ROOT" "$ENV_MODE" "--force")
+fi
 
 # Extract env_files array from sync-env result using jq
 ENV_FILES_JSON=$(echo "$ENV_RESULT" | jq -c '.files_synced' 2>/dev/null || echo '[]')

--- a/sync-env/SKILL.md
+++ b/sync-env/SKILL.md
@@ -13,6 +13,18 @@ allowed-tools:
 
 Sync `.env` files from a source repository to a target worktree directory.
 
+## `.worktreeinclude` との役割分担
+
+Claude Code v2.1.x 以降では、プロジェクトルートの `.worktreeinclude` により worktree 作成時にルートレベルの `.env` ファイルが自動コピーされる。
+
+**`.worktreeinclude` がカバーする範囲**: ルート直下の `.env`, `.env.local`, `.env.development`
+
+**sync-env が引き続き必要なケース**:
+- サブディレクトリの `.env` ファイル（例: `qiita-publish/.env`）
+- `--force` による再同期（既存ファイルの上書き）
+- `--mode symlink` によるシンボリックリンクモード
+- `.worktreeinclude` 非対応環境（Claude Code 旧バージョン）での後方互換
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary

- `.worktreeinclude` をプロジェクトルートに追加し、Claude Code v2.1.x の worktree 作成時に `.env`, `.env.local`, `.env.development` を自動コピーさせる
- `git-prepare.sh` を修正し、`.worktreeinclude` 存在時は `--force` をスキップして二重コピーを防止
- `sync-env/SKILL.md` と `git-prepare/SKILL.md` に `.worktreeinclude` との役割分担を明記

## 変更内容

| ファイル | 変更 | 説明 |
|---------|------|------|
| `.worktreeinclude` | 新規 | `.env`, `.env.local`, `.env.development` の3パターンを記載 |
| `sync-env/SKILL.md` | 修正 | `.worktreeinclude` との役割分担セクションを追加 |
| `git-prepare/SKILL.md` | 修正 | `.worktreeinclude` 自動コピーの説明を追加 |
| `git-prepare/scripts/git-prepare.sh` | 修正 | `.worktreeinclude` 存在時のフォールバック動作を追加 |

## 後方互換性

- `.worktreeinclude` が存在しない環境（Claude Code 旧バージョン）では従来通り sync-env が全 `.env` をコピー
- sync-env は `--force` なしで既存ファイルをスキップするため、二重コピーの心配なし

## Test plan

- [ ] `.worktreeinclude` がプロジェクトルートに存在することを確認
- [ ] 新規 worktree 作成時に `.env` ファイルが自動コピーされることを確認
- [ ] `git-prepare.sh` が `.worktreeinclude` 存在時に `--force` なしで sync-env を呼ぶことを確認
- [ ] `.worktreeinclude` を削除した状態で従来の `--force` 動作が維持されることを確認

Closes #30