### PR TITLE
feat(_lib): PreToolUse Hook による SKILL.md frontmatter バリデーション

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash _lib/scripts/validate-skill-frontmatter.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code / Serena / Codex
 .claude/*
+!.claude/settings.json
 # Legacy: skill-config.json は現在リポジトリルートに配置
 .serena/
 .system/

--- a/_lib/scripts/validate-skill-frontmatter.sh
+++ b/_lib/scripts/validate-skill-frontmatter.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# validate-skill-frontmatter.sh - PreToolUse Hook for SKILL.md frontmatter validation
+#
+# Reads PreToolUse JSON from stdin. Blocks Write if SKILL.md frontmatter is invalid.
+# Output: {"decision":"block","reason":"..."} on failure, empty on success (implicit approve).
+#
+# Validation rules:
+#   - name: required
+#   - description: required, max 500 chars
+#   - model: if present, must be haiku|sonnet|opus
+#   - effort: if present, must be low|medium|high
+#   - context: if present, must be fork
+
+set -euo pipefail
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Extract tool_input fields
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null) || exit 0
+
+# Only validate SKILL.md files
+case "$FILE_PATH" in
+  */SKILL.md) ;;
+  *) exit 0 ;;
+esac
+
+# Skip if content is empty
+[[ -z "$CONTENT" ]] && exit 0
+
+# Extract frontmatter (between first pair of ---)
+FRONTMATTER=$(echo "$CONTENT" | sed -n '/^---$/,/^---$/p' | sed '1d;$d')
+
+# Skip if no frontmatter found
+[[ -z "$FRONTMATTER" ]] && exit 0
+
+ERRORS=()
+
+# --- Required field checks ---
+
+# Check 'name' exists and is non-empty
+NAME=$(echo "$FRONTMATTER" | grep -E '^name:\s*' | head -1 | sed 's/^name:\s*//' | xargs 2>/dev/null || true)
+if [[ -z "$NAME" ]]; then
+  ERRORS+=("Missing required field: name")
+fi
+
+# Check 'description' exists
+# description can be multi-line (block scalar with |), so check the key exists
+if ! echo "$FRONTMATTER" | grep -qE '^description:'; then
+  ERRORS+=("Missing required field: description")
+else
+  # Extract description value for length check
+  # Handle both inline and block scalar (|) formats
+  DESC_LINE=$(echo "$FRONTMATTER" | grep -E '^description:' | head -1)
+  DESC_INLINE=$(echo "$DESC_LINE" | sed 's/^description:\s*//')
+
+  if [[ "$DESC_INLINE" == "|" || "$DESC_INLINE" == ">" || -z "$DESC_INLINE" ]]; then
+    # Block scalar: extract indented lines after 'description:'
+    DESC_VALUE=$(echo "$FRONTMATTER" | sed -n '/^description:/,/^[a-z]/{/^description:/d;/^[a-z]/d;p;}' | sed 's/^  //')
+  else
+    DESC_VALUE="$DESC_INLINE"
+  fi
+
+  # Check description length (character count)
+  DESC_LEN=${#DESC_VALUE}
+  if [[ $DESC_LEN -gt 500 ]]; then
+    ERRORS+=("description exceeds 500 character limit (current: ${DESC_LEN} chars)")
+  fi
+
+  # Check description is not empty
+  TRIMMED_DESC=$(echo "$DESC_VALUE" | xargs 2>/dev/null || true)
+  if [[ -z "$TRIMMED_DESC" ]]; then
+    ERRORS+=("description is empty")
+  fi
+fi
+
+# --- Optional field value validation ---
+
+# Validate 'model' if present
+MODEL=$(echo "$FRONTMATTER" | grep -E '^model:\s*' | head -1 | sed 's/^model:\s*//' | xargs 2>/dev/null || true)
+if [[ -n "$MODEL" ]]; then
+  case "$MODEL" in
+    haiku|sonnet|opus) ;;
+    *) ERRORS+=("Invalid model: '${MODEL}'. Must be one of: haiku, sonnet, opus") ;;
+  esac
+fi
+
+# Validate 'effort' if present
+EFFORT=$(echo "$FRONTMATTER" | grep -E '^effort:\s*' | head -1 | sed 's/^effort:\s*//' | xargs 2>/dev/null || true)
+if [[ -n "$EFFORT" ]]; then
+  case "$EFFORT" in
+    low|medium|high) ;;
+    *) ERRORS+=("Invalid effort: '${EFFORT}'. Must be one of: low, medium, high") ;;
+  esac
+fi
+
+# Validate 'context' if present
+CONTEXT=$(echo "$FRONTMATTER" | grep -E '^context:\s*' | head -1 | sed 's/^context:\s*//' | xargs 2>/dev/null || true)
+if [[ -n "$CONTEXT" ]]; then
+  case "$CONTEXT" in
+    fork) ;;
+    *) ERRORS+=("Invalid context: '${CONTEXT}'. Must be: fork") ;;
+  esac
+fi
+
+# --- Output result ---
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  # Join errors with "; "
+  REASON=""
+  for err in "${ERRORS[@]}"; do
+    [[ -n "$REASON" ]] && REASON+="; "
+    REASON+="$err"
+  done
+
+  # Output block decision
+  jq -n --arg reason "SKILL.md frontmatter validation failed: $REASON" \
+    '{"decision":"block","reason":$reason}'
+fi


### PR DESCRIPTION
## 概要

SKILL.md への Write 時に PreToolUse Hook で frontmatter の自動バリデーションを実行する機能を追加。

Closes #29

## 変更内容

- `_lib/scripts/validate-skill-frontmatter.sh` を新規作成
  - 必須フィールド (name, description) の存在チェック
  - description の 500 文字上限チェック
  - model (haiku/sonnet/opus)、effort (low/medium/high)、context (fork) の値バリデーション
  - SKILL.md 以外のファイルは即座にスキップ
  - エラー時は `{"decision":"block","reason":"..."}` を出力してツールコールをブロック
- `.claude/settings.json` に PreToolUse Write Hook 設定を追加
- `.gitignore` に `!.claude/settings.json` 例外を追加

## テスト計画

- [x] 正常な SKILL.md での approve 確認
- [x] name 欠落での block 確認
- [x] description 欠落での block 確認
- [x] description 500 文字超での block 確認
- [x] 不正な model/effort/context 値での block 確認
- [x] SKILL.md 以外のファイルでの approve 確認
- [x] 複数エラー同時検出の確認
- [x] 既存 SKILL.md (dev-kickoff) での approve 確認