### PR TITLE
feat(worktree): .worktreeinclude 移行に伴い sync-env deprecate + git-prepare 簡素化

### DIFF
--- a/git-prepare/SKILL.md
+++ b/git-prepare/SKILL.md
@@ -3,7 +3,7 @@ name: git-prepare
 description: |
   Git worktree preparation for feature development. Creates isolated worktree for parallel development.
   Use when: starting new feature work, preparing isolated git environment for issue implementation.
-  Accepts args: <issue-number> [--suffix <suffix>] [--base <branch>] [--env-mode hardlink|symlink|copy|none]
+  Accepts args: <issue-number> [--suffix <suffix>] [--base <branch>]
 allowed-tools:
   - Bash
 ---
@@ -17,7 +17,7 @@ Prepare git worktree for isolated feature development.
 ❌ **NEVER**: `git worktree add` を直接実行
 ✅ **ALWAYS**: 下記スクリプトを使用
 
-理由: スクリプトが .env* ハードリンク処理と正しいディレクトリ命名を行う
+理由: スクリプトが正しいディレクトリ命名とブランチリンクを行う
 
 ## Execution
 
@@ -25,7 +25,7 @@ Prepare git worktree for isolated feature development.
 $SKILLS_DIR/git-prepare/scripts/git-prepare.sh <issue-number> [options]
 ```
 
-**Output**: JSON with `worktree_path`, `branch`, `base`, `env_mode`, `env_files`
+**Output**: JSON with `worktree_path`, `branch`, `base`
 
 ## Options
 
@@ -33,16 +33,11 @@ $SKILLS_DIR/git-prepare/scripts/git-prepare.sh <issue-number> [options]
 |--------|---------|-------------|
 | `--suffix` | `m` | Branch suffix → `feature/issue-{N}-{suffix}` |
 | `--base` | `dev` | Base branch |
-| `--env-mode` | `hardlink` | Env file handling |
 
-## Env Modes
+## .env ファイルの自動コピー
 
-| Mode | Docker | Sync | Cross-FS |
-|------|--------|------|----------|
-| `hardlink` | ✅ | ✅ bidirectional | ❌ (fallback to copy) |
-| `symlink` | ❌ | ✅ bidirectional | ✅ |
-| `copy` | ✅ | ❌ | ✅ |
-| `none` | - | - | - |
+`.worktreeinclude` と Claude Code hooks により、worktree 作成時に `.env` ファイルが自動コピーされる。
+`git-prepare` は `.env` の管理を行わない（Claude Code に委譲）。
 
 ## Journal Logging
 

--- a/git-prepare/scripts/git-prepare.sh
+++ b/git-prepare/scripts/git-prepare.sh
@@ -5,7 +5,6 @@
 # Options:
 #   --suffix <suffix>     Branch suffix (default: m)
 #   --base <branch>       Base branch (default: dev)
-#   --env-mode <mode>     hardlink|symlink|copy|none (default: hardlink)
 #   --local               Skip gh issue develop and keep branch local-only (no remote push)
 #
 # Output: JSON with worktree info
@@ -15,7 +14,6 @@ set -euo pipefail
 # Defaults
 SUFFIX="m"
 BASE_BRANCH="dev"
-ENV_MODE="hardlink"
 LOCAL_ONLY=false
 ISSUE_NUMBER=""
 
@@ -24,10 +22,9 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --suffix) SUFFIX="$2"; shift 2 ;;
         --base) BASE_BRANCH="$2"; shift 2 ;;
-        --env-mode) ENV_MODE="$2"; shift 2 ;;
         --local) LOCAL_ONLY=true; shift ;;
         -h|--help)
-            echo "Usage: git-prepare.sh <issue-number> [--suffix <s>] [--base <branch>] [--env-mode <mode>]"
+            echo "Usage: git-prepare.sh <issue-number> [--suffix <s>] [--base <branch>]"
             exit 0
             ;;
         -*)
@@ -49,11 +46,6 @@ if [[ -z "$ISSUE_NUMBER" ]]; then
     exit 1
 fi
 
-if [[ ! "$ENV_MODE" =~ ^(hardlink|symlink|copy|none)$ ]]; then
-    echo "Error: Invalid env-mode. Use: hardlink, symlink, copy, or none" >&2
-    exit 1
-fi
-
 # Get repository info
 REPO_ROOT=$(git rev-parse --show-toplevel)
 REPO_NAME=$(basename "$REPO_ROOT")
@@ -63,42 +55,18 @@ BRANCH_NAME="feature/issue-${ISSUE_NUMBER}-${SUFFIX}"
 WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 WORKTREE_PATH="${WORKTREE_BASE}/feature-issue-${ISSUE_NUMBER}-${SUFFIX}"
 
-# Sync env helper path
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SYNC_ENV="$SCRIPT_DIR/../../sync-env/scripts/sync-env.sh"
-
 # Create worktrees directory
 mkdir -p "$WORKTREE_BASE"
 
 # Fetch latest
 git fetch origin "$BASE_BRANCH" 2>/dev/null || true
 
-# Helper: run sync-env if available, otherwise skip with warning
-run_sync_env() {
-    local worktree="$1" source="$2" mode="$3" force_flag="${4:-}"
-    if [[ "$mode" == "none" ]]; then
-        echo '{"status":"skipped","mode":"none","files_synced":[],"total_synced":0}'
-        return
-    fi
-    if [[ -x "$SYNC_ENV" ]]; then
-        "$SYNC_ENV" --worktree "$worktree" --source "$source" --mode "$mode" $force_flag
-    else
-        echo "Warning: sync-env.sh not found, skipping env sync" >&2
-        echo '{"status":"skipped","mode":"'"$mode"'","files_synced":[],"total_synced":0}'
-    fi
-}
-
 # Check if worktree already exists
 if [[ -d "$WORKTREE_PATH" ]]; then
-    # Sync .env files even for existing worktrees (without --force to skip existing)
-    ENV_RESULT=$(run_sync_env "$WORKTREE_PATH" "$REPO_ROOT" "$ENV_MODE")
-    ENV_SYNC_JSON=$(echo "$ENV_RESULT" | jq -c '{status: .status, files_synced: .files_synced, total_synced: .total_synced}' 2>/dev/null || echo '{"status":"unknown"}')
     jq -n \
         --arg worktree_path "$WORKTREE_PATH" \
         --arg branch "$BRANCH_NAME" \
-        --arg env_mode "$ENV_MODE" \
-        --argjson env_sync "$ENV_SYNC_JSON" \
-        '{status: "exists", worktree_path: $worktree_path, branch: $branch, env_mode: $env_mode, env_sync: $env_sync}'
+        '{status: "exists", worktree_path: $worktree_path, branch: $branch}'
     exit 0
 fi
 
@@ -125,17 +93,9 @@ else
     fi
 fi
 
-# Sync environment files via sync-env skill (--force for new worktrees)
-ENV_RESULT=$(run_sync_env "$WORKTREE_PATH" "$REPO_ROOT" "$ENV_MODE" "--force")
-
-# Extract env_files array from sync-env result using jq
-ENV_FILES_JSON=$(echo "$ENV_RESULT" | jq -c '.files_synced' 2>/dev/null || echo '[]')
-
 # Output JSON result
 jq -n \
     --arg worktree_path "$WORKTREE_PATH" \
     --arg branch "$BRANCH_NAME" \
     --arg base "origin/$BASE_BRANCH" \
-    --arg env_mode "$ENV_MODE" \
-    --argjson env_files "$ENV_FILES_JSON" \
-    '{status: "created", worktree_path: $worktree_path, branch: $branch, base: $base, env_mode: $env_mode, env_files: $env_files}'
+    '{status: "created", worktree_path: $worktree_path, branch: $branch, base: $base}'

--- a/sync-env/SKILL.md
+++ b/sync-env/SKILL.md
@@ -1,86 +1,30 @@
 ---
 name: sync-env
 description: |
-  Sync .env files from source repository to target worktree directory.
-  Use when: (1) worktree missing .env files, (2) retry after failed integration,
-  (3) keywords: env sync, dotenv, .env copy, worktree env
-  Accepts args: --worktree <path> [--mode hardlink|symlink|copy] [--source <path>] [--force]
+  [DEPRECATED] .worktreeinclude + Claude Code hooks に移行済み。
+  dotfiles/claude-code/hooks/generate-worktreeinclude.sh が自動生成する .worktreeinclude により、
+  worktree 作成時に .env ファイルが自動コピーされる。
+  このスキルは後方互換のため残存。新規利用は非推奨。
 allowed-tools:
   - Bash
 ---
 
-# Sync Env
+# Sync Env [DEPRECATED]
 
-Sync `.env` files from a source repository to a target worktree directory.
+> **⚠️ このスキルは非推奨です。**
+> `.worktreeinclude` + Claude Code hooks による自動コピーに移行しました。
+> 詳細: dotfiles/claude-code/hooks/generate-worktreeinclude.sh
 
-## Usage
+## 移行先
+
+1. `dotfiles/claude-code/hooks/generate-worktreeinclude.sh` が `.worktreeinclude` を自動生成
+2. Claude Code v2.1.x が worktree 作成時に `.worktreeinclude` のパターンに従い自動コピー
+3. `**/.env*` glob でサブディレクトリもカバー
+
+## レガシー使用法
+
+スクリプト自体は残っているため、`.worktreeinclude` 非対応環境では引き続き使用可能:
 
 ```bash
 scripts/sync-env.sh --worktree <path> [--mode hardlink|symlink|copy] [--source <path>] [--force]
-```
-
-## Arguments
-
-| Arg | Default | Description |
-|-----|---------|-------------|
-| `--worktree` | required | Target worktree path |
-| `--mode` | `hardlink` | Link strategy: hardlink, symlink, or copy |
-| `--source` | auto | Source repository root (auto-detected from worktree git info) |
-| `--force` | false | Overwrite existing .env files |
-
-## Examples
-
-```bash
-# Basic: sync .env files to worktree (auto-detect source)
-scripts/sync-env.sh --worktree /path/to/worktree
-
-# Use symlinks instead of hardlinks
-scripts/sync-env.sh --worktree /path/to/worktree --mode symlink
-
-# Force overwrite existing .env files
-scripts/sync-env.sh --worktree /path/to/worktree --force
-
-# Explicit source repository
-scripts/sync-env.sh --worktree /path/to/worktree --source /path/to/repo
-```
-
-## Output
-
-```json
-{
-  "status": "synced",
-  "source": "/path/to/repo",
-  "worktree": "/path/to/worktree",
-  "mode": "hardlink",
-  "files_synced": ["hardlink:.env", "hardlink:apps/api/.env.local"],
-  "files_skipped": [],
-  "total_synced": 2,
-  "total_skipped": 0
-}
-```
-
-## Requirements
-
-- `jq` - JSON output の構築に使用
-
-## Notes
-
-- Follows symlinks (`find -L`) for monorepo workspace support
-- Idempotent: without `--force`, existing files are skipped
-- With `--force`, existing files are removed and re-created
-- Excludes `node_modules/`, `.git/`, and `*-worktrees/` directories
-- Falls back to copy if hardlink fails (cross-device)
-
-## Journal Logging
-
-On completion, log execution to skill-retrospective journal:
-
-```bash
-# On success
-$SKILLS_DIR/skill-retrospective/scripts/journal.sh log sync-env success \
-  --duration-turns $TURNS
-
-# On failure
-$SKILLS_DIR/skill-retrospective/scripts/journal.sh log sync-env failure \
-  --error-category <category> --error-msg "<message>"
 ```


### PR DESCRIPTION
## Summary

- `sync-env` スキルを deprecate し、SKILL.md を非推奨通知に置き換え（スクリプトは後方互換のため残存）
- `git-prepare.sh` から sync-env 関連コード（`run_sync_env` 関数、`--env-mode` オプション、env 出力フィールド）を全削除
- `git-prepare/SKILL.md` を更新し、`.worktreeinclude` + Claude Code hooks への委譲を明記

## 背景

`.worktreeinclude` と Claude Code hooks により、worktree 作成時の `.env` ファイルコピーが自動化された。
`sync-env` スキルおよび `git-prepare` 内の env 同期ロジックは不要となったため、整理する。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `sync-env/SKILL.md` | 非推奨通知に置き換え |
| `git-prepare/scripts/git-prepare.sh` | sync-env 関連コード・`--env-mode` オプション削除 |
| `git-prepare/SKILL.md` | env 関連セクション削除、`.worktreeinclude` 説明追加 |

## Test plan

- [ ] `git-prepare.sh --help` が `--env-mode` を含まないことを確認
- [ ] `git-prepare.sh` の出力 JSON に `env_mode`/`env_files`/`env_sync` が含まれないことを確認
- [ ] `sync-env/scripts/sync-env.sh` が変更されていないことを確認（後方互換）

Closes #35