### PR TITLE
feat(dev-kickoff): kickoff.json schema 拡張 — feature_list (immutable) + progress_log

### DIFF
--- a/dev-implement/SKILL.md
+++ b/dev-implement/SKILL.md
@@ -88,6 +88,29 @@ Select tools based on `--type`. Follow project conventions, maintain existing pa
 
 Details: [Tool Selection](references/tool-selection.md)
 
+**Feature trace logging (kickoff.json 連携)**:
+
+`$WORKTREE/.claude/kickoff.json` に `feature_list` が存在する場合（`dev-plan-impl` で初期化済）、各 feature 完了時に以下を必ず呼び出す:
+
+```bash
+# 着手時
+$SKILLS_DIR/dev-kickoff/scripts/update-feature.sh \
+  --worktree "$WORKTREE" --id "F1" --status in_progress
+
+# 完了時
+$SKILLS_DIR/dev-kickoff/scripts/update-feature.sh \
+  --worktree "$WORKTREE" --id "F1" --status done
+
+$SKILLS_DIR/dev-kickoff/scripts/append-progress.sh \
+  --worktree "$WORKTREE" --phase "4" --note "F1 (feature desc) 完了、test green"
+```
+
+**Mandatory rules**:
+- `feature_list[i].id` と `desc` は **書き換え禁止**。`update-feature.sh` は `status` のみ変更する。
+- `Edit` ツールで kickoff.json の `feature_list` を直接書き換えない。必ずスクリプトを使う。
+- `progress_log` は append-only。既存エントリに触れない。
+- 後方互換: `feature_list` が未定義 or 空の場合（standalone 実行時など）はスキップして通常実装を続行する。
+
 ### Step 5: Validate
 
 - [ ] Todos completed

--- a/dev-kickoff/SKILL.md
+++ b/dev-kickoff/SKILL.md
@@ -65,7 +65,15 @@ After Phase 8: Call `Skill: pr-iterate $PR_URL` to complete the workflow.
 
 State persisted in `$WORKTREE/.claude/kickoff.json`. Use `init-kickoff.sh` after Phase 1, `update-phase.sh` for status updates.
 
-Details: [State Management](references/state-management.md)
+Details: [State Management](references/state-management.md), [kickoff.json Schema](references/kickoff-schema.md)
+
+### Mandatory Rules — feature_list immutability
+
+**`kickoff.json.feature_list` の `id` と `desc` は書き換え禁止。** Phase 3 (`dev-plan-impl`) で一度だけ初期化し、以降は `status` のみ更新可能。
+
+- `id` / `desc` の書き換え → `dev-validate` が warning を出す
+- `status` 更新は `dev-kickoff/scripts/update-feature.sh` を必ず使用する（`Edit` ツールで JSON を直接書き換えない）
+- `progress_log` は append-only。追加は `dev-kickoff/scripts/append-progress.sh` を使用する
 
 ## Phase Execution
 
@@ -145,6 +153,7 @@ $SKILLS_DIR/skill-retrospective/scripts/journal.sh log dev-kickoff partial \
 
 ## References
 
+- [kickoff.json Schema](references/kickoff-schema.md) - feature_list / progress_log / decisions 仕様
 - [State Management](references/state-management.md) - Init scripts, update commands, state schema, recovery
 - [Evaluate-Retry Loop](references/evaluate-retry.md) - Detailed evaluate-retry flow with reset commands
 - [Error Handling](references/error-handling.md) - Per-phase error handling, auto-retry protocol

--- a/dev-kickoff/references/kickoff-schema.md
+++ b/dev-kickoff/references/kickoff-schema.md
@@ -1,0 +1,109 @@
+# kickoff.json Schema
+
+`$WORKTREE/.claude/kickoff.json` のスキーマ定義。`dev-kickoff` ワークフロー全体の state を保持する。
+
+## 全体構造
+
+```jsonc
+{
+  "version": "3.0.0",
+  "issue": 42,
+  "branch": "feature/issue-42-m",
+  "worktree": "/path/to/worktree",
+  "base_branch": "dev",
+  "started_at": "2026-04-11T10:00:00Z",
+  "updated_at": "2026-04-11T11:30:00Z",
+  "current_phase": "4_implement",
+
+  "phases": { /* phase ごとの status・結果 */ },
+  "next_actions": ["..."],
+  "config": { /* testing / design / depth / lang / env_mode */ },
+
+  // --- Narrative & immutability フィールド (v3.1.0〜) ---
+  "feature_list": [
+    { "id": "F1", "desc": "...", "status": "todo" }
+  ],
+  "progress_log": [
+    { "ts": "2026-04-11T10:00:00Z", "phase": "3", "note": "plan 完了" }
+  ],
+  "decisions": [
+    { "ts": "2026-04-11T10:30:00Z", "topic": "cache strategy", "decision": "Redis 採用" }
+  ]
+}
+```
+
+## 新規フィールド (v3.1.0〜)
+
+### `feature_list` — immutable feature list
+
+**目的**: Anthropic 公式「Effective harnesses for long-running agents」の feature list immutability パターンを実現する。`dev-plan-impl` が一度だけ書き込み、以降は `status` のみ更新する。
+
+| Field | Type | Required | Mutable | Description |
+|-------|------|----------|---------|-------------|
+| `id` | string | yes | **NO** | `F1`, `F2`, ... のような一意識別子 |
+| `desc` | string | yes | **NO** | 機能の簡潔な説明（impl-plan.md と対応） |
+| `status` | string | yes | **YES** | `todo` / `in_progress` / `done` / `skipped` |
+
+**書き込みルール**:
+
+1. **初期化**: `dev-plan-impl` の Step 5 完了後に `impl-plan.md` から抽出して一度だけ書き込む。
+2. **immutability**: `id` と `desc` は以降 **書き換え禁止**。`dev-validate` が警告を出す。
+3. **status 更新**: `dev-implement` が各 feature 完了時に `update-feature.sh` 経由で変更する。
+4. **LLM による直接編集禁止**: `Edit` ツールで feature_list を直接書き換えない。必ず `update-feature.sh` を使用する。
+
+### `progress_log` — append-only narrative
+
+**目的**: phase 遷移や重要決定を時系列で記録し、SessionStart hook から Claude が context に取り込む。
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ts` | string (ISO8601 UTC) | yes | タイムスタンプ |
+| `phase` | string | yes | 記録時点の phase (`1`, `2`, `3`, `3b`, `4`, `5`, `6`, `7`, `8`) |
+| `note` | string | yes | 短い narrative (1-2 行) |
+
+**書き込みルール**:
+
+1. **append-only**: 既存エントリの書き換え・削除禁止。
+2. **追加手段**: `dev-kickoff/scripts/append-progress.sh` のみを使用する。
+3. **頻度**: phase 遷移時 + feature 完了時 + 重要な設計判断時。ログ過多を避ける。
+
+### `decisions` — 設計判断の記録
+
+**目的**: 設計判断を後から参照できるようにする。`progress_log` より詳細な「なぜ」を記録する。
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ts` | string (ISO8601 UTC) | yes | タイムスタンプ |
+| `topic` | string | yes | 判断対象トピック (例: "cache strategy") |
+| `decision` | string | yes | 判断内容と理由 |
+
+**書き込みルール**: append-only。`decisions` フィールドは `init-kickoff.sh` で `[]` 初期化される。
+
+## 後方互換
+
+- 既存の kickoff.json に `feature_list` / `progress_log` が無い場合は **空配列扱い**。
+- 読み取り側は必ず `// []` フォールバックを使う:
+  ```bash
+  jq '.feature_list // []' kickoff.json
+  jq '.progress_log // []' kickoff.json
+  ```
+- `append-progress.sh` / `update-feature.sh` は、フィールド未定義の kickoff.json に対して自動的にフィールドを作成する。
+
+## SessionStart hook 連携
+
+`dotfiles` 側の SessionStart hook が `$WORKTREE/.claude/kickoff.json` を検知した場合、以下を context に注入する想定（別 issue で実装）:
+
+- `feature_list` の `status == "todo"` のエントリのみ
+- `progress_log` の末尾 5 件
+- `decisions` 全件
+
+## 関連スクリプト
+
+- `dev-kickoff/scripts/init-kickoff.sh` — 初期化
+- `dev-kickoff/scripts/append-progress.sh` — `progress_log.append`
+- `dev-kickoff/scripts/update-feature.sh` — `feature_list[i].status` 更新
+- `dev-validate/scripts/validate-kickoff.sh` — immutability warning
+
+## 参考
+
+- Anthropic: [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)

--- a/dev-kickoff/scripts/append-progress.sh
+++ b/dev-kickoff/scripts/append-progress.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# append-progress.sh - Append entry to kickoff.json progress_log (append-only).
+# Usage: append-progress.sh --worktree PATH --phase PHASE --note TEXT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+WORKTREE=""
+PHASE=""
+NOTE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree) WORKTREE="$2"; shift 2 ;;
+        --phase) PHASE="$2"; shift 2 ;;
+        --note) NOTE="$2"; shift 2 ;;
+        -*) die_json "Unknown option: $1" 1 ;;
+        *) die_json "Unexpected positional arg: $1" 1 ;;
+    esac
+done
+
+[[ -n "$WORKTREE" ]] || die_json "--worktree required" 1
+[[ -n "$PHASE" ]]    || die_json "--phase required" 1
+[[ -n "$NOTE" ]]     || die_json "--note required" 1
+
+[[ -d "$WORKTREE" ]] || die_json "Worktree path does not exist: $WORKTREE" 1
+WORKTREE=$(cd "$WORKTREE" && pwd) || die_json "Cannot resolve worktree path" 1
+
+STATE_FILE="$WORKTREE/.claude/kickoff.json"
+[[ -f "$STATE_FILE" ]] || die_json "kickoff.json not found: $STATE_FILE" 1
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+TMP_FILE=$(mktemp)
+if jq \
+    --arg ts "$NOW" \
+    --arg phase "$PHASE" \
+    --arg note "$NOTE" \
+    '.progress_log = ((.progress_log // []) + [{ts: $ts, phase: $phase, note: $note}])
+     | .updated_at = $ts' \
+    "$STATE_FILE" > "$TMP_FILE"; then
+    mv "$TMP_FILE" "$STATE_FILE"
+    echo "{\"status\":\"appended\",\"phase\":\"$PHASE\"}"
+else
+    rm -f "$TMP_FILE"
+    die_json "Failed to append progress" 1
+fi

--- a/dev-kickoff/scripts/init-kickoff.sh
+++ b/dev-kickoff/scripts/init-kickoff.sh
@@ -125,6 +125,8 @@ jq -n \
             "8_pr": { status: "pending" }
         },
         next_actions: ["Run dev-issue-analyze"],
+        feature_list: [],
+        progress_log: [],
         decisions: [],
         config: {
             testing: $testing,

--- a/dev-kickoff/scripts/update-feature.sh
+++ b/dev-kickoff/scripts/update-feature.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# update-feature.sh - Update feature_list[i].status in kickoff.json.
+# id and desc are immutable — this script only modifies status.
+# Usage: update-feature.sh --worktree PATH --id F1 --status done
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+WORKTREE=""
+FEATURE_ID=""
+NEW_STATUS=""
+
+VALID_STATUSES="todo in_progress done skipped"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree) WORKTREE="$2"; shift 2 ;;
+        --id) FEATURE_ID="$2"; shift 2 ;;
+        --status) NEW_STATUS="$2"; shift 2 ;;
+        -*) die_json "Unknown option: $1" 1 ;;
+        *) die_json "Unexpected positional arg: $1" 1 ;;
+    esac
+done
+
+[[ -n "$WORKTREE" ]]   || die_json "--worktree required" 1
+[[ -n "$FEATURE_ID" ]] || die_json "--id required" 1
+[[ -n "$NEW_STATUS" ]] || die_json "--status required" 1
+
+if ! echo "$VALID_STATUSES" | grep -qw "$NEW_STATUS"; then
+    die_json "Invalid status: $NEW_STATUS. Must be one of: $VALID_STATUSES" 1
+fi
+
+[[ -d "$WORKTREE" ]] || die_json "Worktree path does not exist: $WORKTREE" 1
+WORKTREE=$(cd "$WORKTREE" && pwd) || die_json "Cannot resolve worktree path" 1
+
+STATE_FILE="$WORKTREE/.claude/kickoff.json"
+[[ -f "$STATE_FILE" ]] || die_json "kickoff.json not found: $STATE_FILE" 1
+
+# Verify feature id exists
+if ! jq -e --arg id "$FEATURE_ID" '(.feature_list // []) | map(select(.id == $id)) | length > 0' "$STATE_FILE" > /dev/null; then
+    die_json "Feature id not found: $FEATURE_ID" 1
+fi
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+TMP_FILE=$(mktemp)
+if jq \
+    --arg id "$FEATURE_ID" \
+    --arg status "$NEW_STATUS" \
+    --arg now "$NOW" \
+    '.feature_list = ((.feature_list // []) | map(
+        if .id == $id then .status = $status else . end
+     ))
+     | .updated_at = $now' \
+    "$STATE_FILE" > "$TMP_FILE"; then
+    mv "$TMP_FILE" "$STATE_FILE"
+    echo "{\"status\":\"updated\",\"id\":\"$FEATURE_ID\",\"new_status\":\"$NEW_STATUS\"}"
+else
+    rm -f "$TMP_FILE"
+    die_json "Failed to update feature" 1
+fi

--- a/dev-plan-impl/SKILL.md
+++ b/dev-plan-impl/SKILL.md
@@ -82,6 +82,36 @@ Write the plan to `$WORKTREE/.claude/impl-plan.md`.
 
 If a previous plan exists (retry), overwrite it entirely with the revised plan.
 
+## Step 6: Initialize feature_list (first run only)
+
+Extract features from the plan and write them to `kickoff.json.feature_list` **once**.
+This list is immutable — `dev-implement` may only update `status`, never `id` or `desc`.
+
+**手順**:
+
+1. `impl-plan.md` の "Feature List" / "File Changes" / 主要タスクから `F1`, `F2`, ... の単位で feature を抽出
+2. `kickoff.json.feature_list` が空配列 (`[]`) の場合のみ書き込み (既に値があれば skip = immutability 尊重)
+3. jq で一度だけ書き込む:
+
+```bash
+jq --argjson features "$FEATURES_JSON" \
+   '.feature_list = (if (.feature_list // [] | length) == 0 then $features else .feature_list end)
+    | .updated_at = (now | todate)' \
+   "$WORKTREE/.claude/kickoff.json" > "$WORKTREE/.claude/kickoff.json.tmp" \
+  && mv "$WORKTREE/.claude/kickoff.json.tmp" "$WORKTREE/.claude/kickoff.json"
+```
+
+ここで `$FEATURES_JSON` は `[{"id":"F1","desc":"...","status":"todo"}, ...]` の形式。
+
+4. 初期化後、`append-progress.sh` で trace 記録:
+
+```bash
+$SKILLS_DIR/dev-kickoff/scripts/append-progress.sh \
+  --worktree "$WORKTREE" --phase "3" --note "impl-plan.md 作成、feature_list (N 件) 初期化"
+```
+
+**Retry 時**: `feature_list` が既に存在する場合は touch しない。plan の revision でも feature の追加・削除・rename はしない（新しい plan が必要な場合は issue 側で対応）。
+
 ## Important
 
 - **Be concrete, not abstract**: The Generator (Sonnet) needs specific instructions it can follow

--- a/dev-validate/SKILL.md
+++ b/dev-validate/SKILL.md
@@ -46,6 +46,22 @@ $SKILLS_DIR/dev-validate/scripts/validate.sh [--fix] [--strict] [--worktree <pat
 | 2 | Lint/type errors |
 | 3 | No changes |
 
+## kickoff.json Immutability Check
+
+`dev-kickoff` ワークフロー下で動作する場合、`kickoff.json.feature_list` の `id` / `desc` が初コミット時点から変わっていないかを warning レベルでチェックする:
+
+```bash
+$SKILLS_DIR/dev-validate/scripts/validate-kickoff.sh --worktree <path>
+```
+
+挙動:
+- `feature_list` が空 / 未定義 → silent pass（後方互換）
+- `kickoff.json` に git 履歴が無い → silent pass
+- `id` / `desc` が変更されている → stderr に warning を出力、JSON の `status: warning` を返す（exit 0、非致命）
+- `id` が削除されている → 同じく warning
+
+このチェックは warning-only で、overall の pass/fail には影響しない。詳細: [kickoff.json Schema](../dev-kickoff/references/kickoff-schema.md)
+
 ## Auto-Detection
 
 | Project Type | Test Command | Lint Command |

--- a/dev-validate/scripts/validate-kickoff.sh
+++ b/dev-validate/scripts/validate-kickoff.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# validate-kickoff.sh - Check kickoff.json feature_list immutability.
+# Warns (non-fatal) if feature_list[i].id or desc changed from initial commit.
+# Usage: validate-kickoff.sh [--worktree PATH]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+WORKTREE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree) WORKTREE="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: validate-kickoff.sh [--worktree <path>]"
+            exit 0
+            ;;
+        *) shift ;;
+    esac
+done
+
+[[ -n "$WORKTREE" ]] || WORKTREE=$(pwd)
+[[ -d "$WORKTREE" ]] || { echo '{"status":"skipped","reason":"worktree not found"}'; exit 0; }
+WORKTREE=$(cd "$WORKTREE" && pwd)
+
+STATE_FILE="$WORKTREE/.claude/kickoff.json"
+
+# Silent pass if kickoff.json is absent (standalone invocation)
+if [[ ! -f "$STATE_FILE" ]]; then
+    echo '{"status":"skipped","reason":"kickoff.json not found"}'
+    exit 0
+fi
+
+# Silent pass if feature_list is empty or missing (backward compat)
+FEATURE_COUNT=$(jq '(.feature_list // []) | length' "$STATE_FILE" 2>/dev/null || echo 0)
+if [[ "$FEATURE_COUNT" -eq 0 ]]; then
+    echo '{"status":"skipped","reason":"feature_list is empty"}'
+    exit 0
+fi
+
+cd "$WORKTREE" || exit 0
+
+# Find the commit where kickoff.json was first introduced in this branch
+FIRST_COMMIT=$(git log --diff-filter=A --format=%H -- .claude/kickoff.json 2>/dev/null | tail -1)
+
+if [[ -z "$FIRST_COMMIT" ]]; then
+    # kickoff.json is untracked or never committed — we cannot compare baseline
+    echo '{"status":"skipped","reason":"kickoff.json has no git history yet"}'
+    exit 0
+fi
+
+# Extract baseline feature_list from the first-commit version
+BASELINE=$(git show "${FIRST_COMMIT}:.claude/kickoff.json" 2>/dev/null | jq -c '.feature_list // []' 2>/dev/null || echo "[]")
+CURRENT=$(jq -c '.feature_list // []' "$STATE_FILE")
+
+# If baseline is empty, no comparison possible
+if [[ "$BASELINE" == "[]" ]]; then
+    echo '{"status":"skipped","reason":"baseline feature_list empty"}'
+    exit 0
+fi
+
+# Compare: for each id in baseline, check desc is unchanged in current
+DIFF=$(jq -n \
+    --argjson baseline "$BASELINE" \
+    --argjson current "$CURRENT" \
+    '
+    [
+      $baseline[] as $b
+      | ($current | map(select(.id == $b.id)) | first) as $c
+      | if $c == null then
+          {id: $b.id, kind: "removed", baseline_desc: $b.desc}
+        elif $c.desc != $b.desc then
+          {id: $b.id, kind: "desc_changed", baseline_desc: $b.desc, current_desc: $c.desc}
+        else empty end
+    ]
+    ')
+
+VIOLATION_COUNT=$(echo "$DIFF" | jq 'length')
+
+if [[ "$VIOLATION_COUNT" -eq 0 ]]; then
+    echo '{"status":"pass","warnings":0}'
+    exit 0
+fi
+
+# Emit warnings to stderr (non-fatal)
+echo "WARNING: kickoff.json feature_list immutability violations detected:" >&2
+echo "$DIFF" | jq -r '.[] | "  - \(.id): \(.kind) (baseline: \"\(.baseline_desc)\"\(if .current_desc then ", current: \"" + .current_desc + "\"" else "" end))"' >&2
+
+# Exit 0 (warning-only, non-fatal per design)
+jq -n --argjson warnings "$VIOLATION_COUNT" --argjson diff "$DIFF" \
+    '{status: "warning", warnings: $warnings, violations: $diff}'
+exit 0


### PR DESCRIPTION
Closes #39

## 概要

Anthropic 公式 [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) の「feature list immutability + progress file」パターンを、既存 `kickoff.json` に **schema 拡張の形で** 取り込みました。新ファイルは追加せず、書き込み口を `kickoff.json` に一元化する方針です。

## 新フィールド

| フィールド | 用途 | 可変性 |
|-----------|------|--------|
| `feature_list` | impl-plan から抽出した feature 一覧 | `status` のみ可変。`id`/`desc` は immutable |
| `progress_log` | phase 遷移・feature 完了・重要決定の narrative 記録 | append-only |
| `decisions` | 設計判断の記録（既存、init 時に空配列初期化済） | append-only |

```jsonc
{
  "feature_list": [
    { "id": "F1", "desc": "...", "status": "todo" }
  ],
  "progress_log": [
    { "ts": "2026-04-11T10:00:00Z", "phase": "3", "note": "plan 完了" }
  ],
  "decisions": [
    { "ts": "2026-04-11T10:30:00Z", "topic": "cache strategy", "decision": "Redis 採用" }
  ]
}
```

## 変更内容

### 新規ファイル

- **`dev-kickoff/references/kickoff-schema.md`** — schema 仕様書（フィールド定義・immutability ルール・後方互換ポリシー）
- **`dev-kickoff/scripts/append-progress.sh`** — `progress_log.append` 共有ヘルパー（`--worktree` / `--phase` / `--note`）
- **`dev-kickoff/scripts/update-feature.sh`** — `feature_list[i].status` 更新ヘルパー。`id` / `desc` は touch しない、未知の id はエラー
- **`dev-validate/scripts/validate-kickoff.sh`** — immutability の warning-only チェック（非致命、exit 0）

### 変更ファイル

- **`dev-kickoff/scripts/init-kickoff.sh`** — `feature_list: []` / `progress_log: []` を初期 state に追加
- **`dev-kickoff/SKILL.md`** — **Mandatory Rule** として `feature_list[i].id` / `desc` 書き換え禁止を追記。References に schema doc を追加
- **`dev-plan-impl/SKILL.md`** — Step 6 として impl-plan.md から初期 `feature_list` を jq で一度だけ書き込む手順を追加
- **`dev-implement/SKILL.md`** — Step 4 に feature 完了時の trace logging 手順（`update-feature.sh` + `append-progress.sh`）を追加
- **`dev-validate/SKILL.md`** — `validate-kickoff.sh` を紹介する immutability check セクションを追加

## 受け入れ条件

- [x] schema doc が `dev-kickoff/references/kickoff-schema.md` に存在
- [x] `init-kickoff.sh` (dev-kickoff phase 1) で `feature_list` / `progress_log` / `decisions` が空配列初期化される
- [x] `dev-implement` SKILL に、各 feature 完了時に `append-progress.sh` を呼ぶ手順を記載
- [x] `feature_list[i].desc` を書き換えると `dev-validate`（`validate-kickoff.sh`）で warning が出る
- [x] 既存 kickoff.json との後方互換（新フィールドが無ければ `// []` で空配列扱い）

## 動作確認

一時ディレクトリで以下のシナリオを手動テスト、すべて期待通りの結果:

1. `init-kickoff.sh` → `feature_list` / `progress_log` / `decisions` が空配列で初期化
2. `append-progress.sh` → `progress_log` にエントリが追加される
3. `update-feature.sh` → `feature_list[i].status` が変更される（`id` / `desc` は不変）
4. `update-feature.sh --id F99`（存在しない id）→ エラーで exit 1
5. **後方互換**: 新フィールド無しの古い `kickoff.json` に `append-progress.sh` を実行 → `progress_log` が自動生成される
6. `validate-kickoff.sh`:
   - `desc` 変更 → `status: warning` + stderr に詳細（exit 0、非致命）
   - `id` 削除 → 同上
   - `feature_list` 空 → `status: skipped`
   - `kickoff.json` 無し → `status: skipped`
   - `kickoff.json` に git 履歴無し → `status: skipped`

## 設計判断

- **strict な immutability enforcement（書き換え拒否）は実装しない**: warning のみ。理由は Gradual Rollout — 既存の kickoff.json との互換性を保ちつつ、運用上のルールとしてまず定着させる。
- **LLM に JSON を直接書き換えさせない**: `append-progress.sh` / `update-feature.sh` をスクリプト化し、jq で atomic に更新する。LLM による `Edit` ツール経由の書き込みは禁止ルールとして SKILL.md に明記。
- **SessionStart hook 連携は別 issue**: dotfiles 側の hook で `progress_log` の末尾や `decisions` を context に注入する実装は別タスクに分離。

## Dogfood

本 PR の dev-kickoff 実行中に `append-progress.sh` で自身の `kickoff.json` に progress エントリを追加することで、スクリプトの動作を dogfood 検証済み。