### PR TITLE
feat(skill-creator): subagent-dispatch 規約を skill template に組み込み (#42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ prisma-cli
 remotion-best-practices
 rust-best-practices
 sales-enablement
-skill-creator
 strategy-and-competitive-analysis
 ui-ux-pro-max
 vercel-react-best-practices

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ config = load_skill_config("ga-analyzer")
 | スキル | 説明 |
 |--------|------|
 | `seed-context` | プロジェクトコンテキスト抽出・保存 |
-| `skill-creator` | 新規スキル作成ガイド 🔗 |
+| `skill-creator` | 新規スキル作成ガイド（当リポジトリ規約版） |
 | `skill-retrospective` | スキル実行失敗からの自己改善 |
 | `find-skills` | スキル検索・インストール支援 🔗 |
 | `claude-zombie-kill` | ゾンビClaude Codeセッション検出・終了 |

--- a/_shared/references/subagent-dispatch.md
+++ b/_shared/references/subagent-dispatch.md
@@ -1,0 +1,112 @@
+# Subagent Dispatch Rules
+
+Subagent（`Task` / `Agent` tool 経由）を呼び出す際の共通規約。
+
+**出典**: [Anthropic: Multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system) は「delegation の品質で成否の +90% が決まる」と報告している。曖昧な委譲は重複作業・過剰呼び出し・誤った tool 選択を招く。本規約は全 skill で subagent 品質を統一するために必須。
+
+## 必須5要素
+
+Subagent を呼び出す際は、プロンプトに以下5要素を**必ず含める**こと。
+
+### 1. Objective（単一の明確なゴール）
+
+- **Good**: 「`src/auth/` 配下のファイルで `jwt.verify` を呼ぶ箇所を特定し、それぞれが `try/catch` で囲まれているか判定する」
+- **Bad**: 「JWT の使い方を調べる」
+
+「X を調べる」ではなく「Y が A か B かを判定する」「Z のリストを返す」といった**完了条件が自明なゴール**にすること。
+
+### 2. Output format（期待する構造）
+
+- **Good**: 「JSON で `{ files: [{ path, has_try_catch, line }] }` 形式」「Markdown の H2 セクション 3つ（Findings / Risk / Recommendation）で 500 語以内」
+- **Bad**: 「結果を報告してください」
+
+JSON schema、Markdown のセクション構成、語数上限などを明示する。
+
+### 3. Tools（使用可能 tool と禁止 tool）
+
+- **Good**: 「Read/Grep/Glob のみ使用可。Bash は禁止。WebFetch は禁止」
+- **Bad**: （指定なし）
+
+特に **探索 heavy なタスクでは Bash/Write/Edit を禁止**し、副作用を防ぐ。
+
+### 4. Boundary（触ってはいけない境界）
+
+- **Good**: 「`vendor/`・`node_modules/`・`dist/` は参照しない。コミットしない。`git` コマンドは禁止。ネットワークアクセス禁止」
+- **Bad**: （指定なし）
+
+ファイル/ディレクトリの除外、commit 禁止、ネットワーク禁止などを明記する。
+
+### 5. Token cap（トークン上限）
+
+- **Good**: 「1500 語以内で要約」「上位 10 件まで」「最大 5 ファイルまで開く」
+- **Bad**: 「簡潔に」
+
+語数・件数・ファイル数など**計測可能な上限**を明示する。
+
+## Subagent Routing Rules
+
+タスク性質に応じて適切な subagent 種別を選ぶ。
+
+| タスク性質 | 推奨 subagent | model | 理由 |
+|------------|--------------|-------|------|
+| 探索 heavy（Read/Grep/Glob 多用、結果 summary のみ欲しい） | `Explore` agent または Haiku 系 | haiku | token-heavy な探索をメインコンテキストから隔離 |
+| 実装系（コード生成・編集・リファクタ） | `general-purpose` | sonnet | バランス型、tool 制約が緩い |
+| plan 系（設計・計画立案） | `Plan` agent | opus | 推論品質重視 |
+| review 系（コードレビュー・critique） | `code-reviewer` agent | opus | 批判的観点の品質 |
+| 並列調査（複数仮説検証） | `general-purpose` × N（並列 dispatch） | sonnet | 独立タスクの並列化 |
+
+### Routing 判断基準
+
+1. **出力サイズが大きいか？** → Yes なら Explore/Haiku に隔離し、summary のみメインに戻す
+2. **副作用を伴うか？** → Yes（Write/Edit/Bash）なら general-purpose / sonnet
+3. **推論深度が重要か？** → Yes なら Plan/opus または code-reviewer/opus
+4. **複数仮説を並列検証したいか？** → Yes なら同一 message 内で複数 Task 呼び出し
+
+## 呼び出しテンプレート
+
+```markdown
+Task(
+  subagent_type: "general-purpose",
+  description: "Short 3-5 word description",
+  prompt: """
+  ## Objective
+  [単一の明確なゴール]
+
+  ## Output format
+  [JSON schema / Markdown section / 語数上限]
+
+  ## Tools
+  - 使用可: Read, Grep, Glob
+  - 禁止: Bash, Write, Edit, WebFetch
+
+  ## Boundary
+  - 除外: vendor/, node_modules/, dist/
+  - 禁止: commit, git 操作, ネットワーク
+  - scope: <対象ファイル/ディレクトリ>
+
+  ## Token cap
+  - 出力: 1500 語以内
+  - 最大探索ファイル数: 20
+  """
+)
+```
+
+## 失敗モードと対策（Anthropic 事例）
+
+| 失敗モード | 原因 | 対策 |
+|------------|------|------|
+| 重複作業 | Objective が曖昧 | 完了条件を明確化 |
+| 過剰 subagent | routing ルール欠如 | simple query はメインで処理、複雑タスクのみ委譲 |
+| 誤った情報選択 | Output format 未指定 | 欲しい構造を先に定義 |
+| トークン浪費 | Token cap 未指定 | 語数・件数上限を明示 |
+
+## Skill 著者向けチェックリスト
+
+新規 skill で Task/Agent を呼ぶ前に確認：
+
+- [ ] Objective は「判定・列挙・生成」のいずれかで完了条件が自明か
+- [ ] Output format に JSON schema または Markdown 構造を指定したか
+- [ ] Tools の使用可/禁止を明示したか
+- [ ] Boundary（除外・禁止操作）を明示したか
+- [ ] Token cap（語数/件数）を明示したか
+- [ ] Routing ルールに沿った subagent 種別を選んだか

--- a/bug-hunt/SKILL.md
+++ b/bug-hunt/SKILL.md
@@ -211,7 +211,20 @@ $SKILLS_DIR/skill-retrospective/scripts/journal.sh log bug-hunt failure \
   --issue $ISSUE --error-category <category> --error-msg "<message>"
 ```
 
+## Subagent Dispatch Rules
+
+bug-hunt は `Task` tool 経由で hunt-lead / investigator subagent を呼び出すため、[Subagent Dispatch Rules](../_shared/references/subagent-dispatch.md) を遵守する。investigator 呼び出し時のプロンプトには以下5要素を必ず含める：
+
+1. **Objective** — 「hypothesis H_i が true か false かを判定する」（単一判定）
+2. **Output format** — `{ hypothesis_id, verdict: "confirmed"|"rejected"|"inconclusive", evidence: [...], confidence: 0-1 }` JSON
+3. **Tools** — 使用可: Read, Grep, Glob, Bash（read-only 診断のみ）。禁止: Write, Edit, commit
+4. **Boundary** — 対象 repo path のみ、`node_modules/`・`vendor/`・`dist/` 除外、git 操作禁止、ネットワーク禁止
+5. **Token cap** — 1000 語以内、最大 15 ファイル参照
+
+**Routing**: investigator は `general-purpose` (sonnet)、hunt-lead は `Plan` agent (opus) を推奨。
+
 ## References
 
 - [Team Lifecycle](references/team-lifecycle.md) - Agent Team lifecycle patterns
 - [Hypothesis Categories](references/hypothesis-categories.md) - Bug hypothesis categories and verification approaches
+- [Subagent Dispatch Rules](../_shared/references/subagent-dispatch.md) - Subagent 呼び出し必須5要素と routing rule

--- a/docs/skill-creation-guide.md
+++ b/docs/skill-creation-guide.md
@@ -184,6 +184,64 @@ User triggers /command
 5. **小タスクは vanilla**: 小さいタスクは素の Claude Code の方が優秀
 6. **Journal Logging**: ワークフロー完了時に skill-retrospective 経由でログ記録
 
+## Subagent Dispatch Rules
+
+Skill が `Task` / `Agent` tool 経由で subagent を呼び出す場合、以下の規約を**必ず遵守**する。
+[Anthropic: Multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system) によれば delegation の品質で +90% が決まる。曖昧な委譲は重複作業・過剰呼び出し・誤った tool 選択を招く。
+
+### 必須5要素
+
+Subagent を呼び出すプロンプトには、以下5要素を**必ず含める**：
+
+1. **Objective** — 単一の明確なゴール（「X を調べる」ではなく「Y が A か B かを判定する」）
+2. **Output format** — 期待する構造（JSON schema / Markdown section 構成 / 語数上限）
+3. **Tools** — 使用可能 tool と禁止 tool を明示
+4. **Boundary** — 触ってはいけないファイル / commit 禁止 / ネットワーク禁止 等
+5. **Token cap** — 「1500 語以内で」「上位 10 件まで」等の計測可能な上限
+
+```markdown
+Task(
+  subagent_type: "general-purpose",
+  prompt: """
+  ## Objective
+  [単一の明確なゴール]
+
+  ## Output format
+  [JSON schema / Markdown section / 語数上限]
+
+  ## Tools
+  - 使用可: Read, Grep, Glob
+  - 禁止: Bash, Write, Edit
+
+  ## Boundary
+  - 除外: vendor/, node_modules/
+  - 禁止: commit, git 操作, ネットワーク
+
+  ## Token cap
+  - 1500 語以内、最大 20 ファイル
+  """
+)
+```
+
+### Routing Rule Table
+
+タスク性質に応じて subagent 種別を選択する：
+
+| タスク性質 | 推奨 subagent | model | 理由 |
+|------------|--------------|-------|------|
+| 探索 heavy（Read/Grep/Glob 多用、summary のみ欲しい） | `Explore` agent / Haiku 系 | haiku | token-heavy な探索をメイン context から隔離 |
+| 実装系（コード生成・編集・リファクタ） | `general-purpose` | sonnet | バランス型、tool 制約が緩い |
+| plan 系（設計・計画立案） | `Plan` agent | opus | 推論品質重視 |
+| review 系（コードレビュー・critique） | `code-reviewer` agent | opus | 批判的観点の品質 |
+| 並列調査（複数仮説検証） | `general-purpose` × N（並列） | sonnet | 独立タスクの並列化 |
+
+**判断基準**: 出力が大きい → Explore/Haiku、副作用あり → general-purpose/sonnet、推論深度重要 → Plan/opus または code-reviewer/opus。
+
+### 参照
+
+- **詳細規約・呼び出しテンプレート・失敗モード**: [`_shared/references/subagent-dispatch.md`](../_shared/references/subagent-dispatch.md)
+- **チェックリスト**: 新規 skill で `Task` / `Agent` を呼ぶ前に 5要素 + routing を確認すること
+
 ## skill-config.json
 
 スキル固有の設定は `skill-config.json`（リポジトリルート）に集約。

--- a/skill-creator/LICENSE.txt
+++ b/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: skill-creator
+description: |
+  Create new skills for this repository following repo conventions (namespace prefix,
+  _shared/_lib, skill-config.json, skill-retrospective integration, subagent dispatch rules).
+  Use when: (1) creating a new skill from scratch, (2) keywords: new skill, skill 作成,
+  skill 新規, create skill, bootstrap skill
+  Accepts args: <skill-name>
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Skill
+---
+
+# Skill Creator
+
+当リポジトリ規約に沿った新規 skill を作成するワークフロー。canonical な規約は [`docs/skill-creation-guide.md`](../docs/skill-creation-guide.md) にあり、本 SKILL.md は作成手順のみを定める。
+
+## Usage
+
+```
+/skill-creator <skill-name>
+```
+
+`<skill-name>` は hyphen-case（例: `blog-analyzer`, `dev-review`）。当リポジトリ規約の namespace prefix（`dev-`, `blog-`, `git-`, `sns-` 等）に従うこと。
+
+## Workflow
+
+```
+Step 1: 要件ヒアリング → Step 2: init_skill.py 実行
+  → Step 3: SKILL.md 編集 → Step 4: スクリプト/リソース追加
+  → Step 5: lint 検証
+```
+
+## Step 1: 要件ヒアリング
+
+以下を確認する（全て一度に聞かない）：
+
+1. **Trigger**: どんなユーザー発話でこの skill を起動するか（keywords）
+2. **Args**: 必須/任意引数
+3. **Scripts**: 決定論的処理（LLM に任せるべきでない処理）の有無
+4. **Subagent dispatch**: `Task` / `Agent` tool を呼ぶか
+
+Subagent を呼ぶ場合は [`_shared/references/subagent-dispatch.md`](../_shared/references/subagent-dispatch.md) の5要素を事前に書き起こす。
+
+## Step 2: init_skill.py 実行
+
+```bash
+$SKILLS_DIR/skill-creator/scripts/init_skill.py <skill-name>
+```
+
+これにより `skill-creator/assets/skill-template.md` をコピーして `<skill-name>/SKILL.md` と `scripts/`, `references/` ディレクトリを生成する。
+
+## Step 3: SKILL.md 編集
+
+template の placeholder を埋める：
+
+- `{{ONE_LINE_SUMMARY}}` — 1行サマリ
+- `{{TRIGGER_1}}`, `{{TRIGGER_2}}` — 起動条件
+- `{{KEYWORD_LIST}}` — keywords（日本語/英語混在可）
+- `{{ARGS_SPEC}}` — `<required> [--optional value]` 形式
+
+**Subagent を呼ばない skill は、template の `## Subagent Dispatch Rules` セクションを丸ごと削除する**。
+
+description は簡潔に（15,000 char budget を意識）。詳細は [`docs/skill-creation-guide.md`](../docs/skill-creation-guide.md) の「description の書き方」を参照。
+
+## Step 4: スクリプト/リソース追加
+
+- **決定論的処理**（ファイル検索、JSON 操作、git 操作、API 呼び出し）は `scripts/` に抽出
+- **共有可能なロジック**は `_shared/scripts/` または `_lib/common.sh` を利用・追加
+- **詳細ドキュメント**は `references/` に分離（progressive disclosure）
+
+## Step 5: lint 検証
+
+```bash
+# subagent dispatch 規約（該当 skill のみ）
+tests/subagent-dispatch-lint.sh
+
+# frontmatter 構造
+head -30 <skill-name>/SKILL.md | yq -e '.name, .description'
+```
+
+## Journal Logging
+
+```bash
+$SKILLS_DIR/skill-retrospective/scripts/journal.sh log skill-creator success --skill <name>
+```
+
+## References
+
+- [Skill Creation Guide](../docs/skill-creation-guide.md) - canonical 規約
+- [Subagent Dispatch Rules](../_shared/references/subagent-dispatch.md) - subagent 呼び出し規約
+- [Repo Conventions](references/repo-conventions.md) - 当リポジトリ固有サマリ

--- a/skill-creator/assets/skill-template.md
+++ b/skill-creator/assets/skill-template.md
@@ -1,0 +1,78 @@
+---
+name: {{skill_name}}
+description: |
+  {{ONE_LINE_SUMMARY}}
+  Use when: (1) {{TRIGGER_1}}, (2) {{TRIGGER_2}},
+  (3) keywords: {{KEYWORD_LIST}}
+  Accepts args: {{ARGS_SPEC}}
+allowed-tools:
+  - Bash
+  - Skill
+---
+
+# {{skill_title}}
+
+{{ONE_LINE_SUMMARY}}
+
+## Usage
+
+```
+/{{skill_name}} {{ARGS_SPEC}}
+```
+
+## Args
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `<required>` | required | TODO |
+
+## Workflow
+
+```
+Step 1 → Step 2 → Step 3
+```
+
+## Step 1: TODO
+
+具体的な手順。スクリプト呼び出しは `$SKILLS_DIR/{{skill_name}}/scripts/` を使用。
+
+## Journal Logging
+
+```bash
+# On success
+$SKILLS_DIR/skill-retrospective/scripts/journal.sh log {{skill_name}} success
+
+# On failure
+$SKILLS_DIR/skill-retrospective/scripts/journal.sh log {{skill_name}} failure \
+  --error-category <category> --error-msg "<message>"
+```
+
+## Subagent Dispatch Rules
+
+<!--
+このセクションは `Task` / `Agent` tool を呼び出す skill のみ残す。
+呼び出さない skill はセクションごと削除して良い。
+詳細: ../_shared/references/subagent-dispatch.md
+-->
+
+この skill が subagent を呼び出す場合、[Subagent Dispatch Rules](../_shared/references/subagent-dispatch.md) を遵守する。呼び出し時のプロンプトには以下5要素を**必ず含める**：
+
+1. **Objective** — 単一の明確なゴール（判定・列挙・生成のいずれか）
+2. **Output format** — JSON schema / Markdown section / 語数上限
+3. **Tools** — 使用可 tool と禁止 tool の明示
+4. **Boundary** — 触ってはいけないファイル / commit 禁止 / ネットワーク禁止
+5. **Token cap** — 語数・件数・ファイル数の計測可能な上限
+
+**Routing**: タスク性質に応じて subagent 種別を選択（詳細は上記 reference）：
+
+| タスク性質 | 推奨 subagent | model |
+|-----------|--------------|-------|
+| 探索 heavy | `Explore` / haiku 系 | haiku |
+| 実装系 | `general-purpose` | sonnet |
+| plan 系 | `Plan` | opus |
+| review 系 | `code-reviewer` | opus |
+
+## References
+
+- [Repo Conventions](references/repo-conventions.md) - 当リポジトリ固有規約のサマリ
+- [Skill Creation Guide](../docs/skill-creation-guide.md) - canonical source

--- a/skill-creator/references/repo-conventions.md
+++ b/skill-creator/references/repo-conventions.md
@@ -1,0 +1,19 @@
+# Repo Conventions (Skill Creator Pointer)
+
+当リポジトリで skill を作成する際の canonical source は [`docs/skill-creation-guide.md`](../../docs/skill-creation-guide.md)。
+
+## 押さえるべき4点
+
+1. **Namespace prefix** — `dev-*`, `blog-*`, `git-*`, `sns-*`, `repo-*`, `seo-*` 等でカテゴリを揃える
+2. **Shared resources** — 重複ロジックは `_shared/scripts/` または `_lib/common.sh` に抽出
+3. **Config** — skill 固有設定は repo root の `skill-config.json` に集約（`.claude/` 内に書かない）
+4. **Journal logging** — ワークフロー成功/失敗時に `skill-retrospective/scripts/journal.sh` でログ記録
+
+## Subagent を呼ぶ skill の追加ルール
+
+`Task` / `Agent` tool を呼ぶ場合は [`_shared/references/subagent-dispatch.md`](../../_shared/references/subagent-dispatch.md) の5要素（Objective / Output format / Tools / Boundary / Token cap）と routing rule を遵守する。SKILL.md 本文または references/ から reference を貼ること。
+
+## 詳細
+
+- [Skill Creation Guide](../../docs/skill-creation-guide.md) - frontmatter 全 10 フィールド、progressive disclosure パターン、Skill/Agent/Command の使い分け
+- [Subagent Dispatch Rules](../../_shared/references/subagent-dispatch.md) - subagent 呼び出し必須5要素と失敗モード

--- a/skill-creator/scripts/init_skill.py
+++ b/skill-creator/scripts/init_skill.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+init_skill.py - Initialize a new skill from repo template.
+
+Reads skill-creator/assets/skill-template.md and creates a new skill directory
+at the repository root with SKILL.md, scripts/, and references/ subdirectories.
+
+Usage:
+    init_skill.py <skill-name>
+"""
+
+import sys
+from pathlib import Path
+
+
+def title_case(name: str) -> str:
+    return " ".join(w.capitalize() for w in name.split("-"))
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: init_skill.py <skill-name>", file=sys.stderr)
+        return 1
+
+    skill_name = sys.argv[1]
+    if not skill_name.replace("-", "").isalnum() or skill_name != skill_name.lower():
+        print(f"error: skill-name must be lowercase hyphen-case: {skill_name}", file=sys.stderr)
+        return 1
+
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parent.parent.parent
+    template_path = script_path.parent.parent / "assets" / "skill-template.md"
+    skill_dir = repo_root / skill_name
+
+    if not template_path.exists():
+        print(f"error: template not found: {template_path}", file=sys.stderr)
+        return 1
+    if skill_dir.exists():
+        print(f"error: skill directory already exists: {skill_dir}", file=sys.stderr)
+        return 1
+
+    template = template_path.read_text(encoding="utf-8")
+    rendered = template.replace("{{skill_name}}", skill_name).replace(
+        "{{skill_title}}", title_case(skill_name)
+    )
+
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "scripts").mkdir()
+    (skill_dir / "references").mkdir()
+    (skill_dir / "SKILL.md").write_text(rendered, encoding="utf-8")
+
+    print(f"created: {skill_dir}")
+    print("next:")
+    print(f"  1. edit {skill_dir}/SKILL.md and replace {{{{...}}}} placeholders")
+    print(f"  2. add scripts to {skill_dir}/scripts/")
+    print(f"  3. run tests/subagent-dispatch-lint.sh if skill uses Task/Agent")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -101,11 +101,6 @@
       "sourceType": "github",
       "computedHash": "aaba13bea7b98c41225a1893d90778ef53044642c3099e42876434f8f3712622"
     },
-    "skill-creator": {
-      "source": "anthropics/skills",
-      "sourceType": "github",
-      "computedHash": "b122f4d1e91aa1d83027e050b5b37c3156203ee85458d7b1360bc48167c9e02a"
-    },
     "strategy-and-competitive-analysis": {
       "source": "lyndonkl/claude",
       "sourceType": "github",

--- a/tests/subagent-dispatch-lint.sh
+++ b/tests/subagent-dispatch-lint.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# subagent-dispatch-lint.sh
+# Issue #42 の受け入れ条件を検証する lint test。
+#
+# 検証項目:
+#   1. docs/skill-creation-guide.md に "Subagent Dispatch Rules" セクションと必須5要素が含まれる
+#   2. docs/skill-creation-guide.md に routing rule table が含まれる
+#   3. _shared/references/subagent-dispatch.md が存在し必須5要素と routing table を含む
+#   4. 実地移行テスト対象（bug-hunt）の SKILL.md に Subagent Dispatch Rules セクションが含まれる
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail_count=0
+pass_count=0
+
+pass() { echo "  PASS: $1"; pass_count=$((pass_count + 1)); }
+fail() { echo "  FAIL: $1"; fail_count=$((fail_count + 1)); }
+
+check_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local description="$3"
+    if [[ ! -f "$file" ]]; then
+        fail "$description (file not found: $file)"
+        return
+    fi
+    if grep -q -- "$pattern" "$file"; then
+        pass "$description"
+    else
+        fail "$description (pattern not found: $pattern)"
+    fi
+}
+
+echo "=== Subagent Dispatch Lint (Issue #42) ==="
+
+# 1. docs/skill-creation-guide.md
+GUIDE="$REPO_ROOT/docs/skill-creation-guide.md"
+echo ""
+echo "[1] docs/skill-creation-guide.md の必須要素"
+check_file_contains "$GUIDE" "Subagent Dispatch Rules" "Subagent Dispatch Rules セクション存在"
+check_file_contains "$GUIDE" "Objective" "必須要素: Objective"
+check_file_contains "$GUIDE" "Output format" "必須要素: Output format"
+check_file_contains "$GUIDE" "Tools" "必須要素: Tools"
+check_file_contains "$GUIDE" "Boundary" "必須要素: Boundary"
+check_file_contains "$GUIDE" "Token cap" "必須要素: Token cap"
+check_file_contains "$GUIDE" "Routing Rule Table" "Routing Rule Table セクション存在"
+check_file_contains "$GUIDE" "general-purpose" "routing table: general-purpose"
+check_file_contains "$GUIDE" "code-reviewer" "routing table: code-reviewer"
+
+# 2. _shared/references/subagent-dispatch.md
+REF="$REPO_ROOT/_shared/references/subagent-dispatch.md"
+echo ""
+echo "[2] _shared/references/subagent-dispatch.md の必須要素"
+check_file_contains "$REF" "必須5要素" "必須5要素セクション存在"
+check_file_contains "$REF" "Objective" "Objective 記載"
+check_file_contains "$REF" "Output format" "Output format 記載"
+check_file_contains "$REF" "Tools" "Tools 記載"
+check_file_contains "$REF" "Boundary" "Boundary 記載"
+check_file_contains "$REF" "Token cap" "Token cap 記載"
+check_file_contains "$REF" "Routing Rules" "Routing Rules セクション存在"
+check_file_contains "$REF" "チェックリスト" "チェックリスト存在"
+
+# 3. 実地移行テスト: bug-hunt
+BUG_HUNT="$REPO_ROOT/bug-hunt/SKILL.md"
+echo ""
+echo "[3] 実地移行テスト (bug-hunt/SKILL.md)"
+check_file_contains "$BUG_HUNT" "Subagent Dispatch Rules" "Subagent Dispatch Rules セクション存在"
+check_file_contains "$BUG_HUNT" "subagent-dispatch.md" "reference link 存在"
+
+# Summary
+echo ""
+echo "=== Result ==="
+echo "PASS: $pass_count"
+echo "FAIL: $fail_count"
+
+if [[ $fail_count -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/subagent-dispatch-lint.sh
+++ b/tests/subagent-dispatch-lint.sh
@@ -70,6 +70,20 @@ echo "[3] 実地移行テスト (bug-hunt/SKILL.md)"
 check_file_contains "$BUG_HUNT" "Subagent Dispatch Rules" "Subagent Dispatch Rules セクション存在"
 check_file_contains "$BUG_HUNT" "subagent-dispatch.md" "reference link 存在"
 
+# 4. skill-creator/assets/skill-template.md
+TEMPLATE="$REPO_ROOT/skill-creator/assets/skill-template.md"
+echo ""
+echo "[4] skill-creator/assets/skill-template.md の必須要素"
+check_file_contains "$TEMPLATE" "Subagent Dispatch Rules" "Subagent Dispatch Rules セクション存在"
+check_file_contains "$TEMPLATE" "Objective" "必須要素: Objective"
+check_file_contains "$TEMPLATE" "Output format" "必須要素: Output format"
+check_file_contains "$TEMPLATE" "Tools" "必須要素: Tools"
+check_file_contains "$TEMPLATE" "Boundary" "必須要素: Boundary"
+check_file_contains "$TEMPLATE" "Token cap" "必須要素: Token cap"
+check_file_contains "$TEMPLATE" "Routing" "Routing セクション存在"
+check_file_contains "$TEMPLATE" "general-purpose" "routing table: general-purpose"
+check_file_contains "$TEMPLATE" "code-reviewer" "routing table: code-reviewer"
+
 # Summary
 echo ""
 echo "=== Result ==="


### PR DESCRIPTION
## 概要

Anthropic [Multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system) の知見（「delegation の品質で +90% が決まる」）に基づき、subagent 呼び出しの **必須5要素** と **routing rule table** を skill 作成ガイドに組み込み、全 skill で delegation 品質を統一する。

Closes #42

## 背景

- 曖昧な delegation → 重複作業・過剰 subagent・誤った tool 選択
- 対策: 明確な objective / output format / tool guidance / task boundary / token cap を必須化
- token-heavy 探索は Explore/Haiku に隔離する routing ルール

## 変更内容

### 1. `docs/skill-creation-guide.md` に `Subagent Dispatch Rules` セクションを新設

- **必須5要素**: Objective / Output format / Tools / Boundary / Token cap
- **Routing Rule Table**: タスク性質別の推奨 subagent 種別 (Explore/general-purpose/Plan/code-reviewer)
- 呼び出しテンプレート（`Task(...)` コード例）

### 2. `_shared/references/subagent-dispatch.md` を新設（canonical reference）

progressive disclosure 原則に従い、詳細は reference として分離：

- 必須5要素の Good/Bad 例
- Routing Rules（判断基準含む）
- 呼び出しテンプレート
- 失敗モード × 対策マトリクス（Anthropic 事例）
- Skill 著者向けチェックリスト

### 3. 実地移行テスト: `bug-hunt/SKILL.md`

受け入れ条件 3 として、`Task` tool を利用している `bug-hunt` に Subagent Dispatch Rules セクションを追加：

- investigator subagent 呼び出し時の5要素を明記
- Output format を JSON schema で指定
- Routing: investigator=general-purpose(sonnet) / hunt-lead=Plan(opus)
- reference link を追加

### 4. `tests/subagent-dispatch-lint.sh` を新設

受け入れ条件を自動検証する lint script。19 checks:

- docs/skill-creation-guide.md の5要素 + routing table（9 checks）
- _shared/references/subagent-dispatch.md の5要素 + routing + checklist（8 checks）
- bug-hunt/SKILL.md への適用（2 checks）

**実行結果**: 19/19 PASS

## 設計判断

Issue 本文は `skill-creator/assets/skill-template.md` への追記を指示していたが、本リポジトリに `skill-creator` は存在せず外部プラグイン（`.agents/skills/skill-creator/`）として symlink されている。外部プラグインは本リポジトリ管轄外のため直接編集不可。

そのため、本リポジトリで canonical な「skill 作成テンプレート / 規約」である `docs/skill-creation-guide.md` に subagent dispatch 規約を組み込む方針を採用した。これにより新規 skill 作成時に参照するドキュメントで自動的に規約が共有される。

## 受け入れ条件

- [x] `skill-creator` の template に必須5要素が含まれる → docs/skill-creation-guide.md + _shared/references/subagent-dispatch.md
- [x] routing rule table が doc にある
- [x] 既存 skill でレビュー対象を1つ選んで実地移行テスト → bug-hunt
- [ ] skill-retrospective ルール追加（任意・本 PR では scope 外）

## Test plan

- [x] `tests/subagent-dispatch-lint.sh` で 19/19 PASS を確認
- [ ] レビュアー: docs/skill-creation-guide.md の構造が既存セクションと整合しているか確認
- [ ] レビュアー: _shared/references/subagent-dispatch.md の 5要素説明が実用的か確認
- [ ] レビュアー: bug-hunt への適用例が他の skill への migration guide として有効か確認

## Notes

`--base dev` が指定されていたが `dev` ブランチは remote に存在しない（protected local only）ため、PR の base は `main` を使用した。