### PR TITLE
feat(dev-flow-doctor): skill-retrospective journal を駆動源にする (#43)

### DIFF
--- a/dev-flow-doctor/SKILL.md
+++ b/dev-flow-doctor/SKILL.md
@@ -1,37 +1,55 @@
 ---
 name: dev-flow-doctor
 description: |
-  Diagnose dev-flow health, identify unused features, and suggest improvements.
+  Diagnose dev-flow pipeline health from skill-retrospective journal. Detects dead phase,
+  stuck skill, bottleneck, disconnected skill across the dev-flow family.
   Use when: (1) dev-flow issues or underperformance, (2) parallel mode not triggering,
-  (3) wanting to optimize dev workflow, (4) keywords: doctor, diagnose, health check, dev-flow問題, 診断
-  Accepts args: [--scope full|journal|worktrees|config] [--fix]
+  (3) stuck skill / dead phase suspicion, (4) weekly dev-flow health review,
+  (5) keywords: doctor, diagnose, health check, dev-flow問題, 診断, dead phase, stuck skill, bottleneck, connector
+  Accepts args: [--scope full|journal|worktrees|config|family] [--window 7d|30d] [--fix]
 allowed-tools:
   - Bash
 ---
 
 # dev-flow-doctor
 
-Diagnose dev-flow pipeline health and generate actionable improvement recommendations.
+Diagnose dev-flow pipeline health by reading `skill-retrospective` journal entries
+(`~/.claude/journal/*.json`). Surfaces dead phases, stuck skills, bottlenecks, and
+disconnected skills across the dev-flow family — then generates actionable
+improvement recommendations.
+
+## Key shift: journal-driven (not static scan)
+
+本 skill は **journal 駆動**である。静的な skill file scan ではなく、
+`skill-retrospective` が蓄積している `~/.claude/journal/*.json` を読み込み、
+dev-flow family 8 skill（`dev-kickoff`, `dev-implement`, `dev-validate`,
+`dev-integrate`, `dev-evaluate`, `pr-iterate`, `pr-fix`, `night-patrol`）に絞って
+**連携健全性**（connector 不成立、phase 停滞、failure 集中、実行時間肥大）を判定する。
+
+汎用的な failure パターン検出や proposal 生成は `skill-retrospective` の責務である。
+詳しくは [responsibility-split.md](references/responsibility-split.md) を参照。
 
 ## Usage
 
 ```
-/dev-flow-doctor [--scope full|journal|worktrees|config] [--fix]
+/dev-flow-doctor [--scope full|journal|worktrees|config|family] [--window 7d|30d] [--fix]
 ```
 
 | Arg | Default | Description |
 |-----|---------|-------------|
 | `--scope` | `full` | Diagnosis scope |
-| `--fix` | false | Auto-apply safe fixes |
+| `--window` | `30d` | Lookback window for journal-based checks (7d/14d/30d/2w/1m) |
+| `--fix` | false | Auto-apply safe fixes (worktree cleanup only) |
 
 ## Diagnostic Scopes
 
 | Scope | What It Checks |
 |-------|----------------|
-| `full` | All checks below |
-| `journal` | Journal-based execution analysis |
+| `full` | All checks below (includes `family`) |
+| `journal` | Legacy journal-based execution analysis (Check 1–7, dev-flow skill only) |
 | `worktrees` | Worktree state and cleanup |
 | `config` | Skill configuration validation |
+| `family` | **Dev-flow family connector health** (Check 8: dead / stuck / bottleneck / disconnected) |
 
 ## Workflow
 
@@ -49,7 +67,8 @@ Diagnose dev-flow pipeline health and generate actionable improvement recommenda
 - Auto-detect resolves to `single` or `parallel` based on codebase file dependencies
 - `--force-single` / `--force-parallel` skip dry-run
 - Journal `context.mode` tracks resolved mode (added 2026-03-13)
-- Older entries without `context.mode` use heuristics (see Check 1 in references)
+- Family scope reads the same journal via direct jq (see `scripts/analyze-dev-flow-family.sh`)
+- Family skills / thresholds / default window are configured in `skill-config.json` under `"dev-flow-doctor"`
 
 ## Output Format
 
@@ -57,21 +76,37 @@ Diagnose dev-flow pipeline health and generate actionable improvement recommenda
 ## Dev Flow Health Report
 
 **Health Score**: 85/100 (Healthy)
-**Period**: 2026-02-12 ~ 2026-03-13
+**Period**: 2026-02-12 ~ 2026-03-13 (window: 30d)
 **Total Executions**: 90 (success: 88, failure: 0, partial: 2)
 
-### Findings
+### Dev-Flow Family (Check 8)
+
+**Dead Phases** (no success in 30d):
+- `dev-integrate`: 呼び出し経路を確認。parallel mode が発火していない可能性
+
+**Stuck Skills** (failure rate > 30%):
+- `pr-fix`: 42% failure rate (12 entries) — lint/test errors が主要原因
+
+**Bottlenecks** (top avg duration):
+1. `dev-kickoff` — avg 18.3 turns
+2. `dev-implement` — avg 7.2 turns
+
+**Disconnected Skills** (no parent invocation in 30d):
+- `night-patrol`: orchestrator 経路が不明
+
+### Other Findings
 
 1. **[INFO]** 80% of executions use single mode via auto-detect
-   → Auto-detect is correctly routing small issues to single mode
-
 2. **[WARN]** 3 stale worktree directories found
-   → Not registered as git worktrees, safe to remove
 
 ### Recommended Actions
+
+- [ ] Run `/skill-retrospective` for pr-fix failure patterns
+- [ ] Investigate dev-integrate call path (Check 8)
 - [ ] Clean orphaned worktree directories
 
 ### Safe Auto-Fixes Available (--fix)
+
 - Remove orphaned worktree directories
 ```
 
@@ -82,31 +117,78 @@ Diagnose dev-flow pipeline health and generate actionable improvement recommenda
 Deterministic diagnostic data collection and health score calculation.
 
 ```bash
-# Full diagnostics
-./scripts/run-diagnostics.sh
-# Specific scope
+# Full diagnostics (includes family check)
+./scripts/run-diagnostics.sh --window 30d
+
+# Dev-flow family connector only
+./scripts/run-diagnostics.sh --scope family --window 7d
+
+# Legacy scopes
 ./scripts/run-diagnostics.sh --scope journal
 ./scripts/run-diagnostics.sh --scope worktrees
 ./scripts/run-diagnostics.sh --scope config
 ```
 
-Output: JSON with `score`, `rating`, `checks`, and `issues` fields. The LLM uses this structured data to generate the human-readable report with recommendations and prose.
+Output: JSON with `score`, `rating`, `checks` (including `dev_flow_family`), and `issues` fields.
+
+### `scripts/analyze-dev-flow-family.sh`
+
+Dev-flow family connector analysis (Check 8). Called by `run-diagnostics.sh --scope full|family`,
+but can also be invoked directly for standalone family diagnosis.
+
+```bash
+./scripts/analyze-dev-flow-family.sh --window 30d
+./scripts/analyze-dev-flow-family.sh --window 7d --config /path/to/skill-config.json
+```
+
+Output JSON schema:
+
+```json
+{
+  "window": "30d",
+  "since": "2026-03-12T...",
+  "family_skills": ["dev-kickoff", "..."],
+  "per_skill": [
+    {"skill": "dev-kickoff", "total": 3, "success": 3, "failure": 0,
+     "partial": 0, "failure_rate": 0, "avg_duration_turns": 20, ...}
+  ],
+  "findings": {
+    "dead_phases": [...],
+    "stuck_skills": [...],
+    "bottlenecks": [...],
+    "disconnected_skills": [...]
+  }
+}
+```
+
+## Tests
+
+```bash
+./tests/test-analyze-dev-flow-family.sh
+```
+
+Fixture-based unit tests validate family filtering, 4 detection categories, per-skill
+statistics, and window filtering.
 
 ## References
 
-- [Diagnostic Checks](references/diagnostic-checks.md) -- Check 1-7: mode distribution, failure analysis, error categories, worktree health, recovery turns, success trend, duration outliers
-- [Health Scoring](references/health-scoring.md) -- Scoring formula and rating table
+- [Diagnostic Checks](references/diagnostic-checks.md) -- Check 1–8 (family connector health in Check 8)
+- [Health Scoring](references/health-scoring.md) -- Scoring formula including family penalty
+- [Responsibility Split](references/responsibility-split.md) -- Boundary vs skill-retrospective
 
 ## Examples
 
 ```bash
-# Full health check
+# Full health check (includes Check 8)
 /dev-flow-doctor
 
-# Journal analysis only
+# Focused family connector check, last 7 days
+/dev-flow-doctor --scope family --window 7d
+
+# Journal-only legacy analysis
 /dev-flow-doctor --scope journal
 
-# Auto-fix safe issues
+# Auto-fix safe issues (worktree cleanup only)
 /dev-flow-doctor --fix
 ```
 

--- a/dev-flow-doctor/references/diagnostic-checks.md
+++ b/dev-flow-doctor/references/diagnostic-checks.md
@@ -141,3 +141,39 @@ $SKILLS_DIR/skill-retrospective/scripts/journal.sh query --skill dev-flow --limi
 | Outliers in single mode | Investigate: likely validation failures or complex implementations |
 | Average > 8 turns | Overall pipeline may need optimization |
 | Average < 5 turns | Pipeline is efficient |
+
+## Check 8: Dev-Flow Family Connector Health (Journal-Driven)
+
+dev-flow ファミリー 8 skill（既定: `dev-kickoff`, `dev-implement`, `dev-validate`,
+`dev-integrate`, `dev-evaluate`, `pr-iterate`, `pr-fix`, `night-patrol`）に限定して、
+journal から以下 4 カテゴリを検出する。
+
+```bash
+# Full (既定 window 30d, skill-config.json で上書き可能)
+$SKILLS_DIR/dev-flow-doctor/scripts/analyze-dev-flow-family.sh --window 30d
+
+# run-diagnostics 経由
+$SKILLS_DIR/dev-flow-doctor/scripts/run-diagnostics.sh --scope family --window 7d
+```
+
+### 検出カテゴリ
+
+| カテゴリ | 定義 | 推奨アクション |
+|---------|------|---------------|
+| **dead phase** | window 内で `success` が 0 件の family skill | 呼び出し経路を確認。parent orchestrator（例: dev-kickoff）から実際に呼ばれているか、phase 遷移が skip されていないかを検証 |
+| **stuck skill** | `(failure + partial) / total > 30%` かつ `total >= 3` | `/skill-retrospective` を走らせ proposal を生成、頻出する error category（lint/test/env 等）を直近の failure で確認 |
+| **bottleneck** | `avg(duration_turns)` 上位 3 skill | 実行時間が異常に長い skill を特定し、input 長 / tool 選定 / subagent fork コストを点検 |
+| **disconnected skill** | window 内で自身の entry が 0 件かつ parent skill（hook-capture の Skill tool invocation）で一度も参照されていない | connector が成立していない。orchestrator の分岐条件を確認、または deprecated なら skill を整理 |
+
+### window オプション
+
+- `--window 7d`: 直近の異常を捕まえたいとき
+- `--window 30d`（既定）: 傾向把握
+- `--window 14d` / `--window 2w`: 週次レビュー用
+- 任意の `Nd` / `Nw` / `Nm` フォーマットを受け付ける（`parse_since` と同じ）
+
+### 責務分離
+
+Check 8 は **dev-flow 系 skill の連携健全性** に特化している。全 skill を対象にした
+汎用的な failure pattern detection や proposal 生成は `skill-retrospective` 側で
+行うこと。詳しくは [responsibility-split.md](responsibility-split.md) を参照。

--- a/dev-flow-doctor/references/health-scoring.md
+++ b/dev-flow-doctor/references/health-scoring.md
@@ -10,8 +10,21 @@ score -= (stale_worktrees * 2)       # Max -10 for cleanup debt
 score -= (orphaned_dirs * 3)         # Max -15 for unregistered worktree dirs
 score -= (duration_outlier_pct * 10) # Max -10 for high outlier rate in single mode
 score -= (env_errors_pct * 15)       # Max -15 for env issues
+score -= family_penalty              # Max -20 for dev-flow family connector issues (Check 8)
 score = max(0, score)
 ```
+
+## dev-flow family penalty (Check 8)
+
+Check 8 の検出結果に応じて最大 `-20` のペナルティを加算する:
+
+- dead phase が 1 件以上: `-5`
+- stuck skill が 1 件以上: `-5`
+- disconnected skill が 1 件以上: `-5`
+- bottleneck は informational のみ（penalty なし）
+
+合計は `-20` でクランプ。`run-diagnostics.sh --scope full` および `--scope family` で
+`run_family_checks` 関数が計算する。
 
 ## Rating Table
 

--- a/dev-flow-doctor/references/responsibility-split.md
+++ b/dev-flow-doctor/references/responsibility-split.md
@@ -1,0 +1,61 @@
+# dev-flow-doctor ↔ skill-retrospective Responsibility Split
+
+`dev-flow-doctor` と `skill-retrospective` はいずれも `~/.claude/journal/*.json` を
+入力源にするが、**対象範囲・目的・出力**が異なる。重複実装を避けるため、dev-flow-doctor は
+journal アクセスを `skill-retrospective/scripts/journal.sh` 経由で行い、そのうえで
+**dev-flow 系 skill の連携健全性**に特化した集計を行う。
+
+## 対比表
+
+| 観点 | skill-retrospective | dev-flow-doctor |
+|------|---------------------|------------------|
+| **対象** | 全 skill（journal 全体） | dev-flow family に限定（既定 8 skill） |
+| **目的** | 汎用的な失敗パターン検出と自己改善 proposal | dev-flow pipeline の **connector 健全性** |
+| **主な検出** | failure category 集計、再発パターン、proposal 生成 | dead phase / stuck skill / bottleneck / disconnected skill |
+| **入力** | `~/.claude/journal/*.json` 全体 | journal を family_skills でフィルタ |
+| **出力** | proposal JSON / patch | `claudedocs/dev-flow-health-*.md` + 構造化 JSON |
+| **実行トリガ** | failure 発生時 / セッション終了 / meta-retrospective | 定期（weekly / on-demand） |
+| **スコアリング** | なし（proposal ベース） | 0–100 health score |
+
+## dev-flow family（既定）
+
+`skill-config.json` の `dev-flow-doctor.family_skills` で上書き可能。既定値は以下の 8 skill:
+
+- `dev-kickoff` — orchestrator（parent）
+- `dev-implement`
+- `dev-validate`
+- `dev-integrate`
+- `dev-evaluate`
+- `pr-iterate`
+- `pr-fix`
+- `night-patrol`
+
+これら以外の skill（`blog-*`, `sns-*`, `skill-creator` など）は dev-flow-doctor の対象外である。
+それらの健全性は `skill-retrospective` の全体統計で確認する。
+
+## 4 検出カテゴリの定義
+
+| カテゴリ | 定義 | 既定閾値 |
+|---------|------|----------|
+| **dead phase** | window 内で `success` 実行が 0 件の family skill | 0 success |
+| **stuck skill** | `(failure + partial) / total > threshold`、かつ `total >= stuck_min_total` | 0.30 / 3 |
+| **bottleneck** | `avg(duration_turns)` の上位 N 件 | top 3 |
+| **disconnected skill** | window 内で自身の entry が 0 件 **かつ** 親 skill（hook-capture の Skill tool invocation）で一度も参照されていない | 両条件とも 0 |
+
+## dev-flow-doctor が依存するもの
+
+- `skill-retrospective/scripts/journal.sh`（query / stats）を直接呼ぶのではなく、
+  dev-flow-doctor 側は同じ journal ディレクトリ（`$CLAUDE_JOURNAL_DIR` もしくは
+  `~/.claude/journal`）を直接読むシンプルな jq 処理で済ませる。
+  `journal.sh` の API と同等の読み取りロジック（ISO since filter、skill filter）を
+  `analyze-dev-flow-family.sh` 内で再実装している。これは skill-retrospective 側の
+  内部変更に影響されないようにするための意図的な最小依存である。
+
+## 境界の明示（ガードレール）
+
+- dev-flow-doctor は **proposal を生成しない**。改善提案は skill-retrospective の
+  「提案→承認→適用」フローに乗せる。
+- dev-flow-doctor の `--fix` は worktree cleanup などの safe fix に限定し、
+  skill 本体への変更は一切行わない。
+- skill-retrospective が dev-flow-doctor を呼び出すことは無い。逆方向も同様に
+  直接呼び出しはしない（それぞれ独立に実行される）。

--- a/dev-flow-doctor/scripts/analyze-dev-flow-family.sh
+++ b/dev-flow-doctor/scripts/analyze-dev-flow-family.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# analyze-dev-flow-family.sh - Analyze dev-flow family skills from skill-retrospective journal
+#
+# Reads ~/.claude/journal/*.json (or $CLAUDE_JOURNAL_DIR) via skill-retrospective's
+# journal.sh, filters to the dev-flow family skills, and detects:
+#   - dead phase       : zero success entries within the window
+#   - stuck skill      : (failure + partial) / total > threshold  (min total required)
+#   - bottleneck       : top-N skills by avg duration_turns
+#   - disconnected skill: zero own entries AND never referenced by a parent Skill
+#                         invocation within the window
+#
+# Usage:
+#   analyze-dev-flow-family.sh [--window <dur>] [--config <path>]
+#
+# Options:
+#   --window <dur>  Lookback window (7d, 14d, 30d, 2w, 1m, ...). Default: 30d.
+#   --config <path> Override skill-config.json path (auto-detected otherwise).
+#
+# Output: JSON on stdout.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq "jq is required"
+
+# ----------------------------------------------------------------------------
+# Args
+# ----------------------------------------------------------------------------
+
+WINDOW=""
+CONFIG_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --window) WINDOW="$2"; shift 2 ;;
+    --config) CONFIG_OVERRIDE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,22p' "$0"
+      exit 0
+      ;;
+    *) die_json "Unknown argument: $1" 1 ;;
+  esac
+done
+
+# ----------------------------------------------------------------------------
+# Config resolution
+# ----------------------------------------------------------------------------
+
+DEFAULT_FAMILY_SKILLS='["dev-kickoff","dev-implement","dev-validate","dev-integrate","dev-evaluate","pr-iterate","pr-fix","night-patrol"]'
+DEFAULT_WINDOW="30d"
+DEFAULT_STUCK_RATE="0.30"
+DEFAULT_STUCK_MIN_TOTAL="3"
+DEFAULT_BOTTLENECK_TOP_N="3"
+
+load_config_field() {
+  # $1 = jq path inside .["dev-flow-doctor"]
+  # $2 = default (JSON literal)
+  local path="$1" default="$2"
+  local cfg=""
+  if [[ -n "$CONFIG_OVERRIDE" && -f "$CONFIG_OVERRIDE" ]]; then
+    cfg="$CONFIG_OVERRIDE"
+  else
+    local git_root
+    git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    for candidate in \
+      "${SKILL_CONFIG_PATH:-}" \
+      "${git_root:+$git_root/skill-config.json}" \
+      "${git_root:+$git_root/.claude/skill-config.json}" \
+      "${HOME}/.config/skills/config.json" \
+      "${HOME}/.claude/skill-config.json"; do
+      [[ -n "$candidate" && -f "$candidate" ]] && { cfg="$candidate"; break; }
+    done
+  fi
+  if [[ -z "$cfg" ]]; then
+    printf '%s' "$default"
+    return
+  fi
+  local val
+  val=$(jq -c --argjson default "$default" \
+    ".[\"dev-flow-doctor\"]${path} // \$default" "$cfg" 2>/dev/null || echo "$default")
+  printf '%s' "$val"
+}
+
+FAMILY_SKILLS_JSON=$(load_config_field ".family_skills" "$DEFAULT_FAMILY_SKILLS")
+if [[ -z "$WINDOW" ]]; then
+  WINDOW=$(load_config_field ".window_default" "\"$DEFAULT_WINDOW\"" | jq -r '.')
+fi
+STUCK_RATE=$(load_config_field ".thresholds.stuck_failure_rate" "$DEFAULT_STUCK_RATE" | jq -r '.')
+STUCK_MIN_TOTAL=$(load_config_field ".thresholds.stuck_min_total" "$DEFAULT_STUCK_MIN_TOTAL" | jq -r '.')
+BOTTLENECK_TOP_N=$(load_config_field ".thresholds.bottleneck_top_n" "$DEFAULT_BOTTLENECK_TOP_N" | jq -r '.')
+
+# ----------------------------------------------------------------------------
+# Window → ISO since
+# ----------------------------------------------------------------------------
+
+parse_since() {
+  local since="$1"
+  case "$since" in
+    *d) date -u -v-"${since%d}"d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+         date -u -d "${since%d} days ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ;;
+    *w) date -u -v-"${since%w}"w +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+         date -u -d "${since%w} weeks ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ;;
+    *m) date -u -v-"${since%m}"m +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+         date -u -d "${since%m} months ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ;;
+    *) echo "$since" ;;
+  esac
+}
+
+SINCE_ISO=$(parse_since "$WINDOW")
+if [[ -z "$SINCE_ISO" ]]; then
+  die_json "Failed to parse --window $WINDOW" 1
+fi
+
+# ----------------------------------------------------------------------------
+# Journal load
+# ----------------------------------------------------------------------------
+
+JOURNAL_DIR="${CLAUDE_JOURNAL_DIR:-$HOME/.claude/journal}"
+
+load_journal_entries() {
+  # Print a single JSON array on stdout. Each element is one entry object.
+  if [[ ! -d "$JOURNAL_DIR" ]]; then
+    printf '[]'
+    return
+  fi
+  local files=()
+  while IFS= read -r -d '' f; do
+    files+=("$f")
+  done < <(find "$JOURNAL_DIR" -maxdepth 1 -type f -name '*.json' -print0 2>/dev/null)
+  if [[ ${#files[@]} -eq 0 ]]; then
+    printf '[]'
+    return
+  fi
+  # slurp with jq, tolerate individual parse failures by wrapping with --slurp-invalid workaround
+  jq -s '.' "${files[@]}" 2>/dev/null || printf '[]'
+}
+
+ALL_ENTRIES=$(load_journal_entries)
+
+# Filter by since
+WINDOW_ENTRIES=$(echo "$ALL_ENTRIES" | jq \
+  --arg since "$SINCE_ISO" \
+  '[.[] | select(.timestamp >= $since)]')
+
+FAMILY_ENTRIES=$(echo "$WINDOW_ENTRIES" | jq \
+  --argjson fam "$FAMILY_SKILLS_JSON" \
+  '[.[] | select(.skill as $s | $fam | index($s))]')
+
+# ----------------------------------------------------------------------------
+# Per-skill aggregation
+# ----------------------------------------------------------------------------
+
+PER_SKILL=$(jq -n \
+  --argjson entries "$FAMILY_ENTRIES" \
+  --argjson fam "$FAMILY_SKILLS_JSON" \
+  '
+  [ $fam[] as $s |
+    ($entries | map(select(.skill == $s))) as $es |
+    ($es | length) as $total |
+    ($es | map(select(.outcome == "success")) | length) as $succ |
+    ($es | map(select(.outcome == "failure")) | length) as $fail |
+    ($es | map(select(.outcome == "partial")) | length) as $part |
+    ($es | map(.duration_turns // 0) | add // 0) as $sum_turns |
+    {
+      skill: $s,
+      total: $total,
+      success: $succ,
+      failure: $fail,
+      partial: $part,
+      failure_rate: (if $total > 0 then (($fail + $part) / $total) else 0 end),
+      avg_duration_turns: (if $total > 0 then ($sum_turns / $total) else 0 end),
+      last_success: ($es | map(select(.outcome == "success")) | sort_by(.timestamp) | last | .timestamp // null),
+      last_failure: ($es | map(select(.outcome != "success")) | sort_by(.timestamp) | last | .timestamp // null)
+    }
+  ]
+  ')
+
+# ----------------------------------------------------------------------------
+# Detections
+# ----------------------------------------------------------------------------
+
+# Dead phases: success == 0
+DEAD_PHASES=$(echo "$PER_SKILL" | jq \
+  --arg window "$WINDOW" \
+  '[.[] | select(.success == 0) |
+    {skill: .skill, total: .total, reason: ("0 success within " + $window)}]')
+
+# Stuck skills: failure_rate > threshold AND total >= min_total
+STUCK_SKILLS=$(echo "$PER_SKILL" | jq \
+  --argjson rate "$STUCK_RATE" \
+  --argjson min_total "$STUCK_MIN_TOTAL" \
+  '[.[] | select(.total >= $min_total and .failure_rate > $rate) |
+    {skill: .skill, total: .total, failure_rate: .failure_rate}]')
+
+# Bottlenecks: top-N by avg_duration_turns (only skills with total > 0)
+BOTTLENECKS=$(echo "$PER_SKILL" | jq \
+  --argjson n "$BOTTLENECK_TOP_N" \
+  '[.[] | select(.total > 0)] |
+    sort_by(-.avg_duration_turns) |
+    .[0:$n] |
+    to_entries |
+    map({skill: .value.skill, avg_duration_turns: .value.avg_duration_turns, rank: (.key + 1)})')
+
+# Disconnected skills: skill has zero own entries AND name never appears in
+# any hook-capture entry's context.input_summary within the window.
+DISCONNECTED=$(jq -n \
+  --argjson per_skill "$PER_SKILL" \
+  --argjson entries "$WINDOW_ENTRIES" \
+  --arg window "$WINDOW" \
+  '
+  [ $per_skill[] as $p |
+    ($p.total == 0) as $no_own |
+    ( $entries
+      | map(select(.source == "hook-capture"))
+      | map(.context.input_summary // "")
+      | map(select(. != ""))
+      | map(select(contains($p.skill)))
+      | length
+    ) as $parent_refs |
+    if $no_own and ($parent_refs == 0) then
+      {skill: $p.skill, reason: ("no own entries and no parent Skill-tool invocation within " + $window)}
+    else empty end
+  ]
+  ')
+
+# ----------------------------------------------------------------------------
+# Output
+# ----------------------------------------------------------------------------
+
+jq -n \
+  --arg window "$WINDOW" \
+  --arg since "$SINCE_ISO" \
+  --argjson fam "$FAMILY_SKILLS_JSON" \
+  --argjson per "$PER_SKILL" \
+  --argjson dead "$DEAD_PHASES" \
+  --argjson stuck "$STUCK_SKILLS" \
+  --argjson bn "$BOTTLENECKS" \
+  --argjson disc "$DISCONNECTED" \
+  '{
+    window: $window,
+    since: $since,
+    family_skills: $fam,
+    per_skill: $per,
+    findings: {
+      dead_phases: $dead,
+      stuck_skills: $stuck,
+      bottlenecks: $bn,
+      disconnected_skills: $disc
+    }
+  }'

--- a/dev-flow-doctor/scripts/run-diagnostics.sh
+++ b/dev-flow-doctor/scripts/run-diagnostics.sh
@@ -2,22 +2,25 @@
 set -euo pipefail
 
 # run-diagnostics.sh - Run all diagnostic checks and output structured results
-# Usage: run-diagnostics.sh [--scope full|journal|worktrees|config]
+# Usage: run-diagnostics.sh [--scope full|journal|worktrees|config|family] [--window <dur>]
 # Output: JSON with diagnostic results
 
-source "$(dirname "$0")/../../_lib/common.sh"
+SCRIPT_DIR_RD="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR_RD/../../_lib/common.sh"
 
 # ============================================================================
 # Defaults & Args
 # ============================================================================
 
 SCOPE="full"
+WINDOW="30d"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --scope) SCOPE="$2"; shift 2 ;;
+    --window) WINDOW="$2"; shift 2 ;;
     -h|--help)
-      echo "Usage: run-diagnostics.sh [--scope full|journal|worktrees|config]"
+      echo "Usage: run-diagnostics.sh [--scope full|journal|worktrees|config|family] [--window <dur>]"
       exit 0
       ;;
     *) die_json "Unknown argument: $1" 1 ;;
@@ -25,8 +28,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SCOPE" in
-  full|journal|worktrees|config) ;;
-  *) die_json "Invalid scope: $SCOPE (must be full|journal|worktrees|config)" 1 ;;
+  full|journal|worktrees|config|family) ;;
+  *) die_json "Invalid scope: $SCOPE (must be full|journal|worktrees|config|family)" 1 ;;
 esac
 
 require_cmd "jq" "jq is required for diagnostics"
@@ -387,6 +390,74 @@ run_config_checks() {
 }
 
 # ============================================================================
+# Check: Dev-Flow Family Connector Health (journal-driven)
+# ============================================================================
+
+run_family_checks() {
+  local analyze_sh="$SCRIPT_DIR_RD/analyze-dev-flow-family.sh"
+  if [[ ! -x "$analyze_sh" ]]; then
+    CHECKS=$(echo "$CHECKS" | jq '.dev_flow_family = {"status": "skipped", "reason": "analyze-dev-flow-family.sh not found"}')
+    add_issue "info" "analyze-dev-flow-family.sh not found — family checks skipped"
+    return
+  fi
+
+  local family_data
+  if ! family_data=$("$analyze_sh" --window "$WINDOW" 2>/dev/null); then
+    CHECKS=$(echo "$CHECKS" | jq '.dev_flow_family = {"status": "error", "reason": "analyze-dev-flow-family.sh failed"}')
+    add_issue "warn" "analyze-dev-flow-family.sh failed — family checks skipped"
+    return
+  fi
+
+  # Validate JSON object
+  if ! echo "$family_data" | jq 'type == "object"' 2>/dev/null | grep -q true; then
+    CHECKS=$(echo "$CHECKS" | jq '.dev_flow_family = {"status": "error", "reason": "invalid JSON from analyze-dev-flow-family.sh"}')
+    add_issue "warn" "analyze-dev-flow-family.sh produced invalid JSON"
+    return
+  fi
+
+  local dead_count stuck_count disc_count bn_count
+  dead_count=$(echo "$family_data" | jq '.findings.dead_phases | length')
+  stuck_count=$(echo "$family_data" | jq '.findings.stuck_skills | length')
+  disc_count=$(echo "$family_data" | jq '.findings.disconnected_skills | length')
+  bn_count=$(echo "$family_data" | jq '.findings.bottlenecks | length')
+
+  # Issues
+  if [[ "$dead_count" -gt 0 ]]; then
+    local dead_list
+    dead_list=$(echo "$family_data" | jq -r '[.findings.dead_phases[].skill] | join(", ")')
+    add_issue "warn" "Dead phase(s) detected (${WINDOW}): ${dead_list}"
+  fi
+  if [[ "$stuck_count" -gt 0 ]]; then
+    local stuck_list
+    stuck_list=$(echo "$family_data" | jq -r '[.findings.stuck_skills[] | "\(.skill)(\(.failure_rate | . * 100 | round)%)"] | join(", ")')
+    add_issue "warn" "Stuck skill(s) detected (${WINDOW}): ${stuck_list}"
+  fi
+  if [[ "$disc_count" -gt 0 ]]; then
+    local disc_list
+    disc_list=$(echo "$family_data" | jq -r '[.findings.disconnected_skills[].skill] | join(", ")')
+    add_issue "warn" "Disconnected skill(s) detected (${WINDOW}): ${disc_list}"
+  fi
+  if [[ "$bn_count" -gt 0 ]]; then
+    local bn_top
+    bn_top=$(echo "$family_data" | jq -r '.findings.bottlenecks[0] | "\(.skill) (avg \(.avg_duration_turns | . * 10 | round / 10) turns)"')
+    add_issue "info" "Top bottleneck (${WINDOW}): ${bn_top}"
+  fi
+
+  # Scoring: family health penalties (each capped at -5, total capped at -20)
+  local family_penalty=0
+  if [[ "$dead_count" -gt 0 ]]; then family_penalty=$((family_penalty + 5)); fi
+  if [[ "$stuck_count" -gt 0 ]]; then family_penalty=$((family_penalty + 5)); fi
+  if [[ "$disc_count" -gt 0 ]]; then family_penalty=$((family_penalty + 5)); fi
+  # bottleneck alone is informational — only penalize if avg top > 3x overall avg (best-effort, skip here)
+  if [[ $family_penalty -gt 20 ]]; then family_penalty=20; fi
+  if [[ $family_penalty -gt 0 ]]; then
+    subtract_score "$family_penalty" 20
+  fi
+
+  CHECKS=$(echo "$CHECKS" | jq --argjson family "$family_data" '.dev_flow_family = $family')
+}
+
+# ============================================================================
 # Run checks based on scope
 # ============================================================================
 
@@ -395,6 +466,7 @@ case "$SCOPE" in
     run_journal_checks
     run_worktree_checks
     run_config_checks
+    run_family_checks
     ;;
   journal)
     run_journal_checks
@@ -404,6 +476,9 @@ case "$SCOPE" in
     ;;
   config)
     run_config_checks
+    ;;
+  family)
+    run_family_checks
     ;;
 esac
 

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-05-10-00-00-dev-kickoff.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-05-10-00-00-dev-kickoff.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "id": "20260405T100000-dev-kickoff",
+  "timestamp": "2026-04-05T10:00:00Z",
+  "skill": "dev-kickoff",
+  "outcome": "success",
+  "duration_turns": 20,
+  "context": {"issue": 100, "mode": "single"}
+}

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-05-11-00-00-pr-fix.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-05-11-00-00-pr-fix.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "id": "20260405T110000-pr-fix",
+  "timestamp": "2026-04-05T11:00:00Z",
+  "skill": "pr-fix",
+  "outcome": "failure",
+  "duration_turns": 4,
+  "context": {"issue": 100},
+  "error": {"category": "lint", "message": "eslint errors"}
+}

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-06-10-00-00-dev-kickoff.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-06-10-00-00-dev-kickoff.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "id": "20260406T100000-dev-kickoff",
+  "timestamp": "2026-04-06T10:00:00Z",
+  "skill": "dev-kickoff",
+  "outcome": "success",
+  "duration_turns": 18,
+  "context": {"issue": 101, "mode": "single"}
+}

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-06-11-00-00-pr-fix.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-06-11-00-00-pr-fix.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "id": "20260406T110000-pr-fix",
+  "timestamp": "2026-04-06T11:00:00Z",
+  "skill": "pr-fix",
+  "outcome": "failure",
+  "duration_turns": 3,
+  "context": {"issue": 101},
+  "error": {"category": "test", "message": "test failed"}
+}

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-07-10-00-00-dev-kickoff.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-07-10-00-00-dev-kickoff.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "id": "20260407T100000-dev-kickoff",
+  "timestamp": "2026-04-07T10:00:00Z",
+  "skill": "dev-kickoff",
+  "outcome": "success",
+  "duration_turns": 22,
+  "context": {"issue": 102, "mode": "single"}
+}

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-07-11-00-00-pr-fix.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-07-11-00-00-pr-fix.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "id": "20260407T110000-pr-fix",
+  "timestamp": "2026-04-07T11:00:00Z",
+  "skill": "pr-fix",
+  "outcome": "success",
+  "duration_turns": 3,
+  "context": {"issue": 102}
+}

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-08-10-00-00-dev-implement.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-08-10-00-00-dev-implement.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "id": "20260408T100000-dev-implement",
+  "timestamp": "2026-04-08T10:00:00Z",
+  "skill": "dev-implement",
+  "outcome": "success",
+  "duration_turns": 5,
+  "context": {"issue": 103}
+}

--- a/dev-flow-doctor/tests/fixtures/journal/2026-04-08-11-00-00-blog-cross-post.json
+++ b/dev-flow-doctor/tests/fixtures/journal/2026-04-08-11-00-00-blog-cross-post.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "id": "20260408T110000-blog-cross-post",
+  "timestamp": "2026-04-08T11:00:00Z",
+  "skill": "blog-cross-post",
+  "outcome": "success",
+  "duration_turns": 3,
+  "context": {}
+}

--- a/dev-flow-doctor/tests/test-analyze-dev-flow-family.sh
+++ b/dev-flow-doctor/tests/test-analyze-dev-flow-family.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# test-analyze-dev-flow-family.sh - Unit tests for analyze-dev-flow-family.sh
+# Run: ./dev-flow-doctor/tests/test-analyze-dev-flow-family.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANALYZE_SH="$SCRIPT_DIR/../scripts/analyze-dev-flow-family.sh"
+FIXTURES="$SCRIPT_DIR/fixtures/journal"
+WORKDIR="$(mktemp -d -t dffd-test-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAIL_COUNT=0
+PASS_COUNT=0
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf '  \033[32mPASS\033[0m %s\n' "$1"
+}
+
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf '  \033[31mFAIL\033[0m %s\n' "$1"
+  if [[ -n "${2:-}" ]]; then
+    printf '        %s\n' "$2"
+  fi
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$label"
+  else
+    fail "$label" "expected='$expected' actual='$actual'"
+  fi
+}
+
+# Use an empty config override so environment skill-config.json doesn't leak in
+EMPTY_CONFIG="$WORKDIR/empty-config.json"
+echo '{}' > "$EMPTY_CONFIG"
+
+run_analyze() {
+  CLAUDE_JOURNAL_DIR="$FIXTURES" \
+  SKILL_CONFIG_PATH="$EMPTY_CONFIG" \
+    "$ANALYZE_SH" "$@"
+}
+
+printf 'Test suite: analyze-dev-flow-family.sh\n'
+printf 'Fixtures: %s\n\n' "$FIXTURES"
+
+# ----------------------------------------------------------------------------
+# Test 1: Default window (30d) covers all fixtures
+# ----------------------------------------------------------------------------
+printf 'Test 1: default window 30d produces valid JSON\n'
+RESULT=$(run_analyze --window 30d 2>&1)
+if ! echo "$RESULT" | jq empty 2>/dev/null; then
+  fail "30d produces valid JSON" "$RESULT"
+else
+  pass "30d produces valid JSON"
+fi
+
+# ----------------------------------------------------------------------------
+# Test 2: family filter excludes non-family skills
+# ----------------------------------------------------------------------------
+printf '\nTest 2: non-family skills excluded\n'
+# blog-cross-post should not appear in per_skill
+BLOG_COUNT=$(echo "$RESULT" | jq '[.per_skill[] | select(.skill == "blog-cross-post")] | length')
+assert_eq "blog-cross-post not in per_skill" "0" "$BLOG_COUNT"
+
+# ----------------------------------------------------------------------------
+# Test 3: dead phases
+# ----------------------------------------------------------------------------
+printf '\nTest 3: dead phase detection\n'
+# dev-validate, dev-integrate, dev-evaluate, pr-iterate, night-patrol → dead
+DEAD_COUNT=$(echo "$RESULT" | jq '.findings.dead_phases | length')
+assert_eq "5 dead phases detected" "5" "$DEAD_COUNT"
+
+# dev-kickoff (3 success) should NOT be dead
+DK_DEAD=$(echo "$RESULT" | jq '[.findings.dead_phases[] | select(.skill == "dev-kickoff")] | length')
+assert_eq "dev-kickoff not dead (has success)" "0" "$DK_DEAD"
+
+# dev-validate should be dead
+DV_DEAD=$(echo "$RESULT" | jq '[.findings.dead_phases[] | select(.skill == "dev-validate")] | length')
+assert_eq "dev-validate is dead" "1" "$DV_DEAD"
+
+# ----------------------------------------------------------------------------
+# Test 4: stuck skills
+# ----------------------------------------------------------------------------
+printf '\nTest 4: stuck skill detection\n'
+# pr-fix: 2 failure + 1 success out of 3 → failure_rate 0.666 > 0.30 AND total >= 3
+STUCK_PRFIX=$(echo "$RESULT" | jq '[.findings.stuck_skills[] | select(.skill == "pr-fix")] | length')
+assert_eq "pr-fix is stuck" "1" "$STUCK_PRFIX"
+
+# dev-kickoff: 0% failure → not stuck
+STUCK_DK=$(echo "$RESULT" | jq '[.findings.stuck_skills[] | select(.skill == "dev-kickoff")] | length')
+assert_eq "dev-kickoff not stuck" "0" "$STUCK_DK"
+
+# dev-implement: only 1 entry → excluded by min_total guard
+STUCK_DI=$(echo "$RESULT" | jq '[.findings.stuck_skills[] | select(.skill == "dev-implement")] | length')
+assert_eq "dev-implement excluded (min_total guard)" "0" "$STUCK_DI"
+
+# ----------------------------------------------------------------------------
+# Test 5: bottlenecks
+# ----------------------------------------------------------------------------
+printf '\nTest 5: bottleneck ranking\n'
+BN_COUNT=$(echo "$RESULT" | jq '.findings.bottlenecks | length')
+assert_eq "3 bottlenecks returned (top N=3)" "3" "$BN_COUNT"
+
+BN_TOP=$(echo "$RESULT" | jq -r '.findings.bottlenecks[0].skill')
+assert_eq "dev-kickoff is top bottleneck (avg 20 turns)" "dev-kickoff" "$BN_TOP"
+
+# ----------------------------------------------------------------------------
+# Test 6: disconnected skills
+# ----------------------------------------------------------------------------
+printf '\nTest 6: disconnected skill detection\n'
+DISC_COUNT=$(echo "$RESULT" | jq '.findings.disconnected_skills | length')
+# Same 5 dead skills are also disconnected (no own + no parent ref in fixtures)
+assert_eq "5 disconnected skills detected" "5" "$DISC_COUNT"
+
+# dev-kickoff has own entries → not disconnected
+DISC_DK=$(echo "$RESULT" | jq '[.findings.disconnected_skills[] | select(.skill == "dev-kickoff")] | length')
+assert_eq "dev-kickoff not disconnected" "0" "$DISC_DK"
+
+# ----------------------------------------------------------------------------
+# Test 7: per_skill statistics correctness
+# ----------------------------------------------------------------------------
+printf '\nTest 7: per_skill statistics\n'
+DK_TOTAL=$(echo "$RESULT" | jq '[.per_skill[] | select(.skill == "dev-kickoff")][0].total')
+assert_eq "dev-kickoff total = 3" "3" "$DK_TOTAL"
+
+DK_AVG=$(echo "$RESULT" | jq '[.per_skill[] | select(.skill == "dev-kickoff")][0].avg_duration_turns')
+assert_eq "dev-kickoff avg duration = 20" "20" "$DK_AVG"
+
+PR_FAIL_RATE=$(echo "$RESULT" | jq '[.per_skill[] | select(.skill == "pr-fix")][0].failure_rate | . * 1000 | floor')
+# 2/3 = 0.666... → floor(666.6) = 666
+assert_eq "pr-fix failure_rate ≈ 0.666" "666" "$PR_FAIL_RATE"
+
+# ----------------------------------------------------------------------------
+# Test 8: window filter (--window 1d → everything filtered out, all dead)
+# ----------------------------------------------------------------------------
+printf '\nTest 8: narrow window filters entries\n'
+RESULT_1D=$(run_analyze --window 1d 2>&1)
+if ! echo "$RESULT_1D" | jq empty 2>/dev/null; then
+  fail "1d produces valid JSON" "$RESULT_1D"
+else
+  pass "1d produces valid JSON"
+fi
+# With fixtures dated 2026-04-05..08 and today=2026-04-11, 1d window → 0 entries
+DK_1D_TOTAL=$(echo "$RESULT_1D" | jq '[.per_skill[] | select(.skill == "dev-kickoff")][0].total')
+assert_eq "dev-kickoff total = 0 in 1d window" "0" "$DK_1D_TOTAL"
+DEAD_1D=$(echo "$RESULT_1D" | jq '.findings.dead_phases | length')
+assert_eq "all 8 family skills dead in 1d window" "8" "$DEAD_1D"
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+printf '\n----------------------------------------\n'
+printf 'Summary: %d passed, %d failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/skill-config.json
+++ b/skill-config.json
@@ -36,6 +36,24 @@
   "dev-implement": {
     "model": "sonnet"
   },
+  "dev-flow-doctor": {
+    "family_skills": [
+      "dev-kickoff",
+      "dev-implement",
+      "dev-validate",
+      "dev-integrate",
+      "dev-evaluate",
+      "pr-iterate",
+      "pr-fix",
+      "night-patrol"
+    ],
+    "window_default": "30d",
+    "thresholds": {
+      "stuck_failure_rate": 0.30,
+      "stuck_min_total": 3,
+      "bottleneck_top_n": 3
+    }
+  },
   "night-patrol": {
     "max_failures": 2,
     "failures_path": "~/.claude/night-patrol/failures.json",


### PR DESCRIPTION
## Summary

`dev-flow-doctor` を静的 scan から **skill-retrospective の journal 駆動** に切り替え、
dev-flow family 8 skill (`dev-kickoff`, `dev-implement`, `dev-validate`, `dev-integrate`,
`dev-evaluate`, `pr-iterate`, `pr-fix`, `night-patrol`) に限定して連携健全性を判定するようにした。

closes #43

## 検出カテゴリ

- **dead phase**: window 内に `success` が 0 件の family skill
- **stuck skill**: `(failure + partial) / total > 30%` かつ `total >= 3`
- **bottleneck**: `avg(duration_turns)` の top 3
- **disconnected skill**: 自身の entry 0 件かつ parent の Skill-tool invocation で一度も参照されない skill

## 主な変更

### 新規

- `dev-flow-doctor/scripts/analyze-dev-flow-family.sh`
  journal → family filter → per-skill 集計 → 4 検出カテゴリを単一スクリプトで実行
- `dev-flow-doctor/references/responsibility-split.md`
  `skill-retrospective` との責務分離を明示（対象 / 目的 / 入出力 / トリガ / ガードレール）
- `dev-flow-doctor/tests/test-analyze-dev-flow-family.sh` + `tests/fixtures/journal/`
  18 項目のユニットテスト（family filter / 4 検出 / 統計値 / window）

### 更新

- `dev-flow-doctor/scripts/run-diagnostics.sh`
  - `--scope family` を追加、`--window` を pass-through
  - `run_family_checks` で dead / stuck / disconnected ごとに health score ペナルティ（合計 -20 までクランプ）
- `dev-flow-doctor/SKILL.md`
  - description / Usage / Workflow / Output を journal-driven ベースに書き換え
  - Check 8 の出力例と新スクリプト説明を追加
- `dev-flow-doctor/references/diagnostic-checks.md`
  - **Check 8: Dev-Flow Family Connector Health** を追加
- `dev-flow-doctor/references/health-scoring.md`
  - family penalty を formula に追記
- `skill-config.json`
  - `dev-flow-doctor` エントリ追加（`family_skills` / `window_default` / `thresholds`）

## 設定 schema

```json
{
  "dev-flow-doctor": {
    "family_skills": ["dev-kickoff", "dev-implement", "dev-validate",
      "dev-integrate", "dev-evaluate", "pr-iterate", "pr-fix", "night-patrol"],
    "window_default": "30d",
    "thresholds": {
      "stuck_failure_rate": 0.30,
      "stuck_min_total": 3,
      "bottleneck_top_n": 3
    }
  }
}
```

## 受け入れ条件

- [x] journal から dev-flow 系 skill の統計が取れる
- [x] dead phase / stuck skill / bottleneck / disconnected skill が検出される
- [x] 直近 7 日 / 30 日の window 指定オプション（`--window 7d|30d`、任意の `Nd`/`Nw`/`Nm`）
- [x] skill-retrospective との責務が明示的に doc 化されている（`references/responsibility-split.md`）

## Test plan

- [x] `./dev-flow-doctor/tests/test-analyze-dev-flow-family.sh` — 18 項目全てパス
  - family filter による非対象 skill 除外
  - dead phase 検出（0 success → dead、success 持ちは dead 扱いしない）
  - stuck skill 検出（failure_rate > 30% かつ `total >= 3`、低ボリューム除外）
  - bottleneck ランキング（top 3、avg duration 降順）
  - disconnected skill 検出（entry 0 かつ parent 参照 0）
  - per_skill 統計値（total / avg_duration_turns / failure_rate）
  - window フィルタ（`--window 1d` で全 skill が dead になる）
- [x] `./dev-flow-doctor/scripts/run-diagnostics.sh --scope full` — 実 journal 800+ エントリで JSON valid、score 80、family 検出が動作
- [x] `./dev-flow-doctor/scripts/run-diagnostics.sh --scope family --window 7d` — window 変更が反映される
- [x] `bash -n` シンタックスチェック — 3 スクリプト全て pass
- [x] `jq empty skill-config.json` — JSON 有効