### PR TITLE
refactor(dev-flow-doctor): PR #54 レビュー指摘を反映 (cold-start guard ほか) (#56)

### DIFF
--- a/dev-flow-doctor/references/responsibility-split.md
+++ b/dev-flow-doctor/references/responsibility-split.md
@@ -1,9 +1,10 @@
 # dev-flow-doctor ↔ skill-retrospective Responsibility Split
 
 `dev-flow-doctor` と `skill-retrospective` はいずれも `~/.claude/journal/*.json` を
-入力源にするが、**対象範囲・目的・出力**が異なる。重複実装を避けるため、dev-flow-doctor は
-journal アクセスを `skill-retrospective/scripts/journal.sh` 経由で行い、そのうえで
-**dev-flow 系 skill の連携健全性**に特化した集計を行う。
+入力源にするが、**対象範囲・目的・出力**が異なる。両者は journal ディレクトリ
+（`$CLAUDE_JOURNAL_DIR` または `~/.claude/journal`）を共通入力源として扱い、
+dev-flow-doctor は skill-retrospective の内部実装に依存せず **最小依存で直接読み取る**
+（詳細は後述）。そのうえで **dev-flow 系 skill の連携健全性**に特化した集計を行う。
 
 ## 対比表
 

--- a/dev-flow-doctor/scripts/analyze-dev-flow-family.sh
+++ b/dev-flow-doctor/scripts/analyze-dev-flow-family.sh
@@ -134,8 +134,27 @@ load_journal_entries() {
     printf '[]'
     return
   fi
-  # slurp with jq, tolerate individual parse failures by wrapping with --slurp-invalid workaround
-  jq -s '.' "${files[@]}" 2>/dev/null || printf '[]'
+  # Slurp all entries at once. If any single file is malformed, jq -s fails
+  # for the whole batch, which previously produced an empty [] and caused a
+  # false-positive "all family skills dead" result. Fall back to per-file
+  # parsing so one bad file never blanks the whole journal.
+  local slurped=""
+  if slurped=$(jq -s '.' "${files[@]}" 2>/dev/null); then
+    printf '%s' "$slurped"
+    return
+  fi
+  local rescued=""
+  if rescued=$(
+    for f in "${files[@]}"; do
+      jq -c '.' "$f" 2>/dev/null || true
+    done | jq -s '.' 2>/dev/null
+  ); then
+    if [[ -n "$rescued" ]]; then
+      printf '%s' "$rescued"
+      return
+    fi
+  fi
+  printf '[]'
 }
 
 ALL_ENTRIES=$(load_journal_entries)
@@ -204,20 +223,26 @@ BOTTLENECKS=$(echo "$PER_SKILL" | jq \
     to_entries |
     map({skill: .value.skill, avg_duration_turns: .value.avg_duration_turns, rank: (.key + 1)})')
 
-# Disconnected skills: skill has zero own entries AND name never appears in
-# any hook-capture entry's context.input_summary within the window.
+# Disconnected skills: skill has zero own entries AND name never appears as
+# a word-bounded reference in any hook-capture entry's context.input_summary
+# within the window. We match against "Skill: <name>" / "Task: <name>" and
+# also allow a generic non-word-character boundary so that e.g. "dev-integrate"
+# is not accidentally satisfied by "dev-integrate-extra".
 DISCONNECTED=$(jq -n \
   --argjson per_skill "$PER_SKILL" \
   --argjson entries "$WINDOW_ENTRIES" \
   --arg window "$WINDOW" \
   '
+  def escape_regex(s): s | gsub("([.+*?^$()\\[\\]{}|\\\\])"; "\\\\\(.)");
   [ $per_skill[] as $p |
     ($p.total == 0) as $no_own |
+    (escape_regex($p.skill)) as $esc |
+    ("(^|[^A-Za-z0-9_-])" + $esc + "([^A-Za-z0-9_-]|$)") as $re |
     ( $entries
       | map(select(.source == "hook-capture"))
       | map(.context.input_summary // "")
       | map(select(. != ""))
-      | map(select(contains($p.skill)))
+      | map(select(test($re)))
       | length
     ) as $parent_refs |
     if $no_own and ($parent_refs == 0) then

--- a/dev-flow-doctor/scripts/run-diagnostics.sh
+++ b/dev-flow-doctor/scripts/run-diagnostics.sh
@@ -85,7 +85,7 @@ run_journal_checks() {
   journal_data=$("$JOURNAL_SH" query --skill dev-flow --limit 200 2>/dev/null || echo "[]")
 
   # Validate journal_data is valid JSON array
-  if ! echo "$journal_data" | jq 'type == "array"' 2>/dev/null | grep -q true; then
+  if ! echo "$journal_data" | jq -e 'type == "array"' >/dev/null 2>&1; then
     journal_data="[]"
   fi
 
@@ -121,7 +121,7 @@ run_journal_checks() {
   # --- Check 3: Error Categories (via stats) ---
   local stats_data=""
   stats_data=$("$JOURNAL_SH" stats 2>/dev/null || echo "{}")
-  if ! echo "$stats_data" | jq 'type == "object"' 2>/dev/null | grep -q true; then
+  if ! echo "$stats_data" | jq -e 'type == "object"' >/dev/null 2>&1; then
     stats_data="{}"
   fi
 
@@ -135,7 +135,7 @@ run_journal_checks() {
   # --- Check 6: Success Rate Trend ---
   local recent_stats=""
   recent_stats=$("$JOURNAL_SH" stats --since 7d 2>/dev/null || echo "{}")
-  if ! echo "$recent_stats" | jq 'type == "object"' 2>/dev/null | grep -q true; then
+  if ! echo "$recent_stats" | jq -e 'type == "object"' >/dev/null 2>&1; then
     recent_stats="{}"
   fi
 
@@ -409,9 +409,20 @@ run_family_checks() {
   fi
 
   # Validate JSON object
-  if ! echo "$family_data" | jq 'type == "object"' 2>/dev/null | grep -q true; then
+  if ! echo "$family_data" | jq -e 'type == "object"' >/dev/null 2>&1; then
     CHECKS=$(echo "$CHECKS" | jq '.dev_flow_family = {"status": "error", "reason": "invalid JSON from analyze-dev-flow-family.sh"}')
     add_issue "warn" "analyze-dev-flow-family.sh produced invalid JSON"
+    return
+  fi
+
+  # Cold-start guard: if the dev-flow family has zero total entries in the
+  # window, skip the dead/disconnected/stuck penalties entirely to avoid a
+  # false-positive -10 baseline on new or long-idle environments.
+  local total_family_entries
+  total_family_entries=$(echo "$family_data" | jq '[.per_skill[].total] | add // 0')
+  if [[ "$total_family_entries" -eq 0 ]]; then
+    add_issue "info" "Dev-flow family has no entries in ${WINDOW} — insufficient data, family checks skipped"
+    CHECKS=$(echo "$CHECKS" | jq --argjson f "$family_data" '.dev_flow_family = ($f + {status: "insufficient_data"})')
     return
   fi
 
@@ -509,6 +520,7 @@ jq -n \
     score: $score,
     rating: $rating,
     scope: $scope,
+    score_scope: $scope,
     checks: $checks,
     issues: $issues
   }'

--- a/dev-flow-doctor/tests/test-analyze-dev-flow-family.sh
+++ b/dev-flow-doctor/tests/test-analyze-dev-flow-family.sh
@@ -152,6 +152,126 @@ DEAD_1D=$(echo "$RESULT_1D" | jq '.findings.dead_phases | length')
 assert_eq "all 8 family skills dead in 1d window" "8" "$DEAD_1D"
 
 # ----------------------------------------------------------------------------
+# Test 9: cold-start — empty journal dir triggers insufficient_data in
+# run-diagnostics.sh --scope family and family penalty stays at 0.
+# ----------------------------------------------------------------------------
+printf '\nTest 9: cold-start guard (empty journal)\n'
+EMPTY_JOURNAL="$WORKDIR/empty-journal"
+mkdir -p "$EMPTY_JOURNAL"
+
+# analyze script on empty dir: every family skill has total=0 → all dead,
+# all disconnected. This is the raw behaviour the cold-start guard must
+# translate into insufficient_data at the diagnostics layer.
+COLD_RAW=$(CLAUDE_JOURNAL_DIR="$EMPTY_JOURNAL" SKILL_CONFIG_PATH="$EMPTY_CONFIG" \
+  "$ANALYZE_SH" --window 30d 2>&1)
+if ! echo "$COLD_RAW" | jq empty 2>/dev/null; then
+  fail "analyze produces valid JSON on empty journal" "$COLD_RAW"
+else
+  pass "analyze produces valid JSON on empty journal"
+fi
+COLD_TOTAL=$(echo "$COLD_RAW" | jq '[.per_skill[].total] | add // 0')
+assert_eq "empty journal → family total entries = 0" "0" "$COLD_TOTAL"
+
+# Diagnostics layer: run-diagnostics.sh should skip family penalty.
+DIAG_SH="$SCRIPT_DIR/../scripts/run-diagnostics.sh"
+COLD_DIAG=$(CLAUDE_JOURNAL_DIR="$EMPTY_JOURNAL" SKILL_CONFIG_PATH="$EMPTY_CONFIG" \
+  "$DIAG_SH" --scope family --window 30d 2>&1)
+if ! echo "$COLD_DIAG" | jq empty 2>/dev/null; then
+  fail "run-diagnostics cold-start produces valid JSON" "$COLD_DIAG"
+else
+  pass "run-diagnostics cold-start produces valid JSON"
+fi
+COLD_STATUS=$(echo "$COLD_DIAG" | jq -r '.checks.dev_flow_family.status // ""')
+assert_eq "cold-start family status = insufficient_data" "insufficient_data" "$COLD_STATUS"
+COLD_SCORE=$(echo "$COLD_DIAG" | jq '.score')
+assert_eq "cold-start score stays 100 (no family penalty)" "100" "$COLD_SCORE"
+COLD_SCORE_SCOPE=$(echo "$COLD_DIAG" | jq -r '.score_scope // ""')
+assert_eq "cold-start score_scope = family" "family" "$COLD_SCORE_SCOPE"
+
+# ----------------------------------------------------------------------------
+# Test 10: broken JSON mix — one malformed file must not blank the whole
+# journal. Valid entries should still be aggregated.
+# ----------------------------------------------------------------------------
+printf '\nTest 10: parse error fallback (broken JSON mix)\n'
+MIXED_JOURNAL="$WORKDIR/mixed-journal"
+mkdir -p "$MIXED_JOURNAL"
+# Copy all existing fixtures
+cp "$FIXTURES"/*.json "$MIXED_JOURNAL"/
+# Add a malformed file that would break `jq -s '.' "${files[@]}"`
+printf '{"broken": ' > "$MIXED_JOURNAL/2026-04-09-10-00-00-broken.json"
+
+MIXED_RESULT=$(CLAUDE_JOURNAL_DIR="$MIXED_JOURNAL" SKILL_CONFIG_PATH="$EMPTY_CONFIG" \
+  "$ANALYZE_SH" --window 30d 2>&1)
+if ! echo "$MIXED_RESULT" | jq empty 2>/dev/null; then
+  fail "mixed journal produces valid JSON" "$MIXED_RESULT"
+else
+  pass "mixed journal produces valid JSON"
+fi
+# dev-kickoff still has its 3 valid entries
+MIXED_DK_TOTAL=$(echo "$MIXED_RESULT" | jq '[.per_skill[] | select(.skill == "dev-kickoff")][0].total')
+assert_eq "broken file ignored: dev-kickoff total = 3" "3" "$MIXED_DK_TOTAL"
+# pr-fix still has its 3 entries
+MIXED_PF_TOTAL=$(echo "$MIXED_RESULT" | jq '[.per_skill[] | select(.skill == "pr-fix")][0].total')
+assert_eq "broken file ignored: pr-fix total = 3" "3" "$MIXED_PF_TOTAL"
+
+# ----------------------------------------------------------------------------
+# Test 11: parent_refs — a hook-capture entry referencing a family skill
+# excludes that skill from disconnected_skills, and substring lookalikes
+# (e.g. "dev-validate-extra") do NOT count as a reference to "dev-validate".
+# ----------------------------------------------------------------------------
+printf '\nTest 11: parent_refs & word-boundary match\n'
+PARENT_JOURNAL="$WORKDIR/parent-journal"
+mkdir -p "$PARENT_JOURNAL"
+cp "$FIXTURES"/*.json "$PARENT_JOURNAL"/
+# hook-capture entry that references dev-integrate (via "Skill: dev-integrate")
+cat > "$PARENT_JOURNAL/2026-04-09-12-00-00-hook-capture.json" <<'JSON'
+{
+  "version": "1.0.0",
+  "id": "20260409T120000-hook-capture",
+  "timestamp": "2026-04-09T12:00:00Z",
+  "skill": "hook-capture",
+  "source": "hook-capture",
+  "outcome": "success",
+  "duration_turns": 0,
+  "context": {
+    "input_summary": "Skill: dev-integrate --subtask A"
+  }
+}
+JSON
+# hook-capture entry that mentions ONLY a substring lookalike of dev-validate
+cat > "$PARENT_JOURNAL/2026-04-09-12-05-00-hook-capture.json" <<'JSON'
+{
+  "version": "1.0.0",
+  "id": "20260409T120500-hook-capture",
+  "timestamp": "2026-04-09T12:05:00Z",
+  "skill": "hook-capture",
+  "source": "hook-capture",
+  "outcome": "success",
+  "duration_turns": 0,
+  "context": {
+    "input_summary": "Skill: dev-validate-extra --foo bar"
+  }
+}
+JSON
+
+PARENT_RESULT=$(CLAUDE_JOURNAL_DIR="$PARENT_JOURNAL" SKILL_CONFIG_PATH="$EMPTY_CONFIG" \
+  "$ANALYZE_SH" --window 30d 2>&1)
+if ! echo "$PARENT_RESULT" | jq empty 2>/dev/null; then
+  fail "parent-ref journal produces valid JSON" "$PARENT_RESULT"
+else
+  pass "parent-ref journal produces valid JSON"
+fi
+
+# dev-integrate has no own entries but IS referenced → should NOT be disconnected
+DI_DISC=$(echo "$PARENT_RESULT" | jq '[.findings.disconnected_skills[] | select(.skill == "dev-integrate")] | length')
+assert_eq "dev-integrate not disconnected (parent ref matched)" "0" "$DI_DISC"
+
+# dev-validate has no own entries and only a substring-lookalike reference
+# → substring must NOT count, so it should still be disconnected.
+DV_DISC=$(echo "$PARENT_RESULT" | jq '[.findings.disconnected_skills[] | select(.skill == "dev-validate")] | length')
+assert_eq "dev-validate still disconnected (substring lookalike)" "1" "$DV_DISC"
+
+# ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 printf '\n----------------------------------------\n'


### PR DESCRIPTION
## 概要

PR #54 のセルフレビューで non-blocking として積まれていた 6 件の改善点 + 3 件の unit test 追加を一括で反映する refactor PR。

Closes #56 / Refs #54 / 元 issue #43

## 変更点

### 1. cold-start guard (`scripts/run-diagnostics.sh`)
`run_family_checks` で `family_data.per_skill[].total` の合計が 0 のとき、
- `dev_flow_family.status` を `insufficient_data` に設定
- family penalty (`-10`) を加算せず即 return

これにより、journal が空 or window 内に family skill entry が 0 件の新規 / 長期休止環境で health score が常時 90 始まりになる false positive が解消される。

### 2. parse error fallback (`scripts/analyze-dev-flow-family.sh`)
`load_journal_entries` で `jq -s '.' "${files[@]}"` が失敗した場合、ファイル単位で `jq -c '.'` に fallback してから再度 slurp するようにした。1 ファイルでも壊れた JSON があると全体が `[]` に落ち、指摘 1 と同じ「全 family skill dead」false positive を引き起こしていた問題を解消。

### 3. disconnected_skill 単語境界マッチ (`scripts/analyze-dev-flow-family.sh`)
parent_refs 判定を `contains($p.skill)` から単語境界 regex (`(^|[^A-Za-z0-9_-])<name>([^A-Za-z0-9_-]|$)`) に変更。`dev-integrate-extra` のような skill 名が `dev-integrate` の誤一致を引き起こす問題を排除。`escape_regex` helper で skill 名中の meta 文字もエスケープ。

### 4. `responsibility-split.md` と実装の整合
先頭の「journal アクセスを `skill-retrospective/scripts/journal.sh` 経由で行い」記述を削除し、「journal ディレクトリを共通入力源として扱い、dev-flow-doctor は最小依存で直接読み取る」に書き換え。L47-L52 の後段説明と整合。

### 5. `--scope family` の `score_scope` フィールド追加 (`scripts/run-diagnostics.sh`)
出力 JSON に `score_scope` を追加。`--scope family` 単体実行時の score が「family penalty のみ反映した partial score」であることを機械可読な形で明示。

### 6. `jq -e` リファクタ (`scripts/run-diagnostics.sh`)
`jq 'type == "..."' ... | grep -q true` パターン 4 箇所を `jq -e 'type == "..."' >/dev/null 2>&1` に置換。fork 1 回分 + pipeline 1 段分高速化、意図も明快に。

### 7. Unit test 追加 (`tests/test-analyze-dev-flow-family.sh`)

- **Test 9: cold-start ケース** — 空 journal で `analyze-dev-flow-family.sh` が空結果を返し、`run-diagnostics.sh --scope family` が `status: insufficient_data` / `score: 100` / `score_scope: family` を返すことを検証
- **Test 10: 壊れた JSON 混在ケース** — 既存 fixture + 壊れた `.json` 1 件で `analyze-dev-flow-family.sh` が `dev-kickoff.total == 3` / `pr-fix.total == 3` を維持することを検証
- **Test 11: parent_refs 正ケース** — `hook-capture` entry が `Skill: dev-integrate` を参照しているとき `dev-integrate` が `disconnected_skills` から除外されること、および `Skill: dev-validate-extra` の substring lookalike では `dev-validate` が依然として disconnected と判定されることを検証

## テスト結果

\`\`\`
Summary: 30 passed, 0 failed
\`\`\`

18 既存 assertion + 12 新規 assertion、全 PASS。

## 受け入れ条件

- [x] cold-start guard が実装され、空 journal で family penalty が 0 になる
- [x] parse error fallback が実装され、壊れた JSON 混在でも有効 entry のみで診断が走る
- [x] disconnected_skill 検出が substring 一致の罠を回避している（単語境界 regex）
- [x] `responsibility-split.md` の記述と実装が整合している
- [x] `--scope family` の score 解釈が output JSON に `score_scope` として明示されている
- [x] `jq -e` ベースへのリファクタが完了
- [x] 3 ケースの unit test が追加され全件 PASS

## 動作確認

\`\`\`bash
# cold-start guard 動作確認（空ディレクトリ）
CLAUDE_JOURNAL_DIR=/tmp/empty ./dev-flow-doctor/scripts/run-diagnostics.sh --scope family --window 30d
# → {"score":100,"scope":"family","score_scope":"family","checks":{"dev_flow_family":{"status":"insufficient_data",...}},...}

# unit test 全件
bash ./dev-flow-doctor/tests/test-analyze-dev-flow-family.sh
# → Summary: 30 passed, 0 failed
\`\`\`

## References

- PR #54: https://github.com/it-all-playpark/skills/pull/54
- 元 issue: #43