### PR TITLE
feat(dev-kickoff): Generator-Verifier loop の termination schema を統一 (#53)

### DIFF
--- a/_shared/scripts/termination-record.sh
+++ b/_shared/scripts/termination-record.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# termination-record.sh - Record termination block for Generator-Verifier loops
+#
+# Unified interface for recording the termination state of the two
+# evaluator-optimizer loops inside dev-kickoff:
+#   - phases.3b_plan_review (Phase 3 ⇄ 3b: dev-plan-impl ⇄ dev-plan-review)
+#   - phases.6_evaluate     (Phase 4-5 ⇄ 6: dev-implement/validate ⇄ dev-evaluate)
+#
+# Writes `phases[<phase>].termination` with the unified schema and
+# mirrors legacy fields for backward compatibility (deprecated, 1 release).
+# See: dev-kickoff/references/kickoff-schema.md `termination` block.
+#
+# Usage:
+#   termination-record.sh <phase> <reason> \
+#     --worktree PATH \
+#     [--final-iteration N] \
+#     [--final-verdict VERDICT] \
+#     [--verdict-history JSON]        # replace whole array
+#     [--append-verdict JSON]         # push single verdict object
+#
+# <phase>  : 3b_plan_review | 6_evaluate
+# <reason> : converged | max_iterations | stuck | fork_failure
+#
+# Output: {"status":"recorded","phase":"<phase>","reason":"<reason>","final_iteration":N}
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+VALID_PHASES="3b_plan_review 6_evaluate"
+VALID_REASONS="converged max_iterations stuck fork_failure"
+
+PHASE=""
+REASON=""
+WORKTREE=""
+FINAL_ITERATION=""
+FINAL_VERDICT=""
+VERDICT_HISTORY=""
+APPEND_VERDICT=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree) WORKTREE="$2"; shift 2 ;;
+        --final-iteration) FINAL_ITERATION="$2"; shift 2 ;;
+        --final-verdict) FINAL_VERDICT="$2"; shift 2 ;;
+        --verdict-history) VERDICT_HISTORY="$2"; shift 2 ;;
+        --append-verdict) APPEND_VERDICT="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,27p' "$0"
+            exit 0
+            ;;
+        -*)
+            die_json "Unknown option: $1" 1
+            ;;
+        *)
+            if [[ -z "$PHASE" ]]; then
+                PHASE="$1"
+            elif [[ -z "$REASON" ]]; then
+                REASON="$1"
+            else
+                die_json "Unexpected positional argument: $1" 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+[[ -n "$PHASE" ]] || die_json "Phase required ($VALID_PHASES)" 1
+[[ -n "$REASON" ]] || die_json "Reason required ($VALID_REASONS)" 1
+
+# Validate enums
+if ! echo "$VALID_PHASES" | grep -qw "$PHASE"; then
+    die_json "Invalid phase: $PHASE. Must be one of: $VALID_PHASES" 1
+fi
+if ! echo "$VALID_REASONS" | grep -qw "$REASON"; then
+    die_json "Invalid reason: $REASON. Must be one of: $VALID_REASONS" 1
+fi
+
+# Find state file
+if [[ -n "$WORKTREE" ]]; then
+    [[ -d "$WORKTREE" ]] || die_json "Worktree path does not exist: $WORKTREE" 1
+    WORKTREE=$(cd "$WORKTREE" && pwd) || die_json "Cannot resolve worktree path" 1
+    STATE_FILE="$WORKTREE/.claude/kickoff.json"
+else
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [[ -n "$GIT_ROOT" && -f "$GIT_ROOT/.claude/kickoff.json" ]]; then
+        STATE_FILE="$GIT_ROOT/.claude/kickoff.json"
+    else
+        die_json "State file not found. Use --worktree or run from worktree directory." 1
+    fi
+fi
+
+[[ -f "$STATE_FILE" ]] || die_json "State file not found: $STATE_FILE" 1
+
+# Validate JSON payloads if provided
+if [[ -n "$VERDICT_HISTORY" ]]; then
+    if ! echo "$VERDICT_HISTORY" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        die_json "--verdict-history must be a JSON array" 1
+    fi
+fi
+if [[ -n "$APPEND_VERDICT" ]]; then
+    if ! echo "$APPEND_VERDICT" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        die_json "--append-verdict must be a JSON object" 1
+    fi
+fi
+
+if [[ -n "$FINAL_ITERATION" ]]; then
+    if ! [[ "$FINAL_ITERATION" =~ ^[0-9]+$ ]]; then
+        die_json "--final-iteration must be a non-negative integer" 1
+    fi
+fi
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Build jq filter
+JQ_ARGS=(
+    --arg now "$NOW"
+    --arg phase "$PHASE"
+    --arg reason "$REASON"
+)
+
+# Ensure phase object exists, then ensure termination object exists
+JQ_FILTER='
+  .updated_at = $now
+  | .phases[$phase] = (.phases[$phase] // {})
+  | .phases[$phase].termination = (.phases[$phase].termination // {"verdict_history": []})
+  | .phases[$phase].termination.reason = $reason
+  | .phases[$phase].termination.recorded_at = $now
+'
+
+# verdict_history: replace takes priority over append
+if [[ -n "$VERDICT_HISTORY" ]]; then
+    JQ_ARGS+=(--argjson history "$VERDICT_HISTORY")
+    JQ_FILTER+='
+      | .phases[$phase].termination.verdict_history = $history
+    '
+elif [[ -n "$APPEND_VERDICT" ]]; then
+    JQ_ARGS+=(--argjson verdict "$APPEND_VERDICT")
+    JQ_FILTER+='
+      | .phases[$phase].termination.verdict_history =
+          ((.phases[$phase].termination.verdict_history // []) + [$verdict])
+    '
+fi
+
+# final_iteration: explicit value OR derived from history length
+if [[ -n "$FINAL_ITERATION" ]]; then
+    JQ_ARGS+=(--argjson final_iteration "$FINAL_ITERATION")
+    JQ_FILTER+='
+      | .phases[$phase].termination.final_iteration = $final_iteration
+    '
+else
+    JQ_FILTER+='
+      | .phases[$phase].termination.final_iteration =
+          (.phases[$phase].termination.verdict_history | length)
+    '
+fi
+
+if [[ -n "$FINAL_VERDICT" ]]; then
+    JQ_ARGS+=(--arg final_verdict "$FINAL_VERDICT")
+    JQ_FILTER+='
+      | .phases[$phase].termination.final_verdict = $final_verdict
+    '
+fi
+
+# -----------------------------------------------------------------
+# Legacy / mirror fields (deprecated, 1 release backward-compat)
+# -----------------------------------------------------------------
+
+case "$PHASE" in
+    3b_plan_review)
+        # Mirror escalation state based on reason
+        if [[ "$REASON" == "converged" ]]; then
+            JQ_FILTER+='
+              | .phases[$phase].escalated = false
+            '
+        else
+            JQ_FILTER+='
+              | .phases[$phase].escalated = true
+              | .phases[$phase].escalation_reason = $reason
+            '
+        fi
+        # Mirror last_verdict / last_score from the most recent verdict if present
+        JQ_FILTER+='
+          | (.phases[$phase].termination.verdict_history | last) as $lv
+          | if $lv then
+              (.phases[$phase].last_verdict = (if $lv.verdict then $lv.verdict else (.phases[$phase].last_verdict // null) end))
+              | (.phases[$phase].last_score = (if $lv.score then $lv.score else (.phases[$phase].last_score // null) end))
+            else . end
+          | .phases[$phase].current_iteration = .phases[$phase].termination.final_iteration
+        '
+        ;;
+    6_evaluate)
+        # Mirror current_iteration (state machine reads it)
+        JQ_FILTER+='
+          | .phases[$phase].current_iteration = .phases[$phase].termination.final_iteration
+        '
+        ;;
+esac
+
+# Apply update atomically
+TMP_FILE=$(mktemp)
+if jq "${JQ_ARGS[@]}" "$JQ_FILTER" "$STATE_FILE" > "$TMP_FILE"; then
+    mv "$TMP_FILE" "$STATE_FILE"
+    # Read final_iteration back for the response
+    FI=$(jq -r ".phases[\"$PHASE\"].termination.final_iteration // 0" "$STATE_FILE")
+    printf '{"status":"recorded","phase":"%s","reason":"%s","final_iteration":%s}\n' "$PHASE" "$REASON" "$FI"
+else
+    rm -f "$TMP_FILE"
+    die_json "Failed to record termination state" 1
+fi

--- a/dev-flow-doctor/SKILL.md
+++ b/dev-flow-doctor/SKILL.md
@@ -131,6 +131,23 @@ Deterministic diagnostic data collection and health score calculation.
 
 Output: JSON with `score`, `rating`, `checks` (including `dev_flow_family`), and `issues` fields.
 
+### `scripts/analyze-termination-loops.sh`
+
+Cross-worktree Generator-Verifier loop analysis (Check 9, issue #53). Reads
+`phases.3b_plan_review.termination` / `phases.6_evaluate.termination` from each
+worktree's `.claude/kickoff.json` to detect:
+
+- `repeated_feedback_target` — same Phase 6 `feedback_target` in 2+ consecutive iterations
+- `max_iterations` — loop exhausted iteration budget
+- `stuck` — Phase 3b plan-review findings unresolved across iterations
+- `fork_failure` — verifier fork failed
+
+```bash
+./scripts/analyze-termination-loops.sh [--worktree-base <dir>]
+```
+
+Called by `run-diagnostics.sh --scope full|family`; can also be invoked directly.
+
 ### `scripts/analyze-dev-flow-family.sh`
 
 Dev-flow family connector analysis (Check 8). Called by `run-diagnostics.sh --scope full|family`,
@@ -165,14 +182,17 @@ Output JSON schema:
 
 ```bash
 ./tests/test-analyze-dev-flow-family.sh
+./tests/test-analyze-termination-loops.sh
 ```
 
 Fixture-based unit tests validate family filtering, 4 detection categories, per-skill
-statistics, and window filtering.
+statistics, and window filtering. `test-analyze-termination-loops.sh` covers Check 9
+(termination-loop health): repeated_feedback_target, max_iterations, stuck, fork_failure,
+and converged cases.
 
 ## References
 
-- [Diagnostic Checks](references/diagnostic-checks.md) -- Check 1–8 (family connector health in Check 8)
+- [Diagnostic Checks](references/diagnostic-checks.md) -- Check 1–9 (family connector in Check 8, termination loops in Check 9)
 - [Health Scoring](references/health-scoring.md) -- Scoring formula including family penalty
 - [Responsibility Split](references/responsibility-split.md) -- Boundary vs skill-retrospective
 

--- a/dev-flow-doctor/references/diagnostic-checks.md
+++ b/dev-flow-doctor/references/diagnostic-checks.md
@@ -177,3 +177,54 @@ $SKILLS_DIR/dev-flow-doctor/scripts/run-diagnostics.sh --scope family --window 7
 Check 8 は **dev-flow 系 skill の連携健全性** に特化している。全 skill を対象にした
 汎用的な failure pattern detection や proposal 生成は `skill-retrospective` 側で
 行うこと。詳しくは [responsibility-split.md](responsibility-split.md) を参照。
+
+## Check 9: Termination Loop Health (kickoff.json-driven) — issue #53
+
+dev-kickoff の 2 つの evaluator-optimizer ループ（Phase 3 ⇄ 3b / Phase 4-5 ⇄ 6）が
+各 worktree の `kickoff.json` に書き出した `termination` block を横断分析する。
+verdict_history 履歴から「loop が健全に収束したか」「同一 feedback_target が繰り返されていないか」を検出する。
+
+```bash
+# kickoff.json 横断分析 (既定 worktree-base: $REPO_ROOT/../$(basename $REPO_ROOT)-worktrees)
+$SKILLS_DIR/dev-flow-doctor/scripts/analyze-termination-loops.sh
+
+# worktree-base を明示
+$SKILLS_DIR/dev-flow-doctor/scripts/analyze-termination-loops.sh --worktree-base /path/to/worktrees
+
+# run-diagnostics 経由 (scope full / family)
+$SKILLS_DIR/dev-flow-doctor/scripts/run-diagnostics.sh --scope family
+```
+
+### 検出パターン
+
+| pattern | 定義 | 推奨アクション |
+|---------|------|---------------|
+| **repeated_feedback_target** | Phase 6 `verdict_history` で同一 `feedback_target` が **2 iteration 連続** | 同じ層（design/implementation）の feedback が繰り返されている → もう一段上のレイヤー（例: design 連続なら issue 自体の要件）を疑う |
+| **max_iterations** | `termination.reason == "max_iterations"` | 最大 iteration で収束しなかった。issue のサイズ見直し・分解検討 |
+| **stuck** (3b のみ) | `termination.reason == "stuck"` | Plan-Review で同一 finding が 2 iteration 残った → 計画の根本見直し |
+| **fork_failure** | `termination.reason == "fork_failure"` | verifier (dev-plan-review / dev-evaluate) の fork 起動に失敗 → tooling issue 調査 |
+
+### 出力 JSON schema
+
+```jsonc
+{
+  "worktree_base": "/path/to/skills-worktrees",
+  "checked_worktrees": 3,
+  "findings": [
+    {
+      "worktree": "/path/to/skills-worktrees/feature-issue-53-m",
+      "issue": 53,
+      "phase": "6_evaluate",
+      "pattern": "repeated_feedback_target",
+      "feedback_target": "design",
+      "occurrences": 2,
+      "message": "同一 feedback_target (design) が 2 iteration 連続で発生 → 設計問題の可能性"
+    }
+  ]
+}
+```
+
+### スコアリングへの影響
+
+Check 9 の findings は現時点では **health score 計算に寄与しない**（informational のみ）。
+スコア組み込みは別 issue で扱う。

--- a/dev-flow-doctor/scripts/analyze-termination-loops.sh
+++ b/dev-flow-doctor/scripts/analyze-termination-loops.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# analyze-termination-loops.sh - Analyze verdict_history / termination block across kickoff worktrees
+#
+# Check 9 (issue #53): Detect unhealthy Generator-Verifier loop outcomes recorded
+# in `phases.3b_plan_review.termination` and `phases.6_evaluate.termination`.
+#
+# Findings:
+#   - pattern="repeated_feedback_target"  : same feedback_target in 2 consecutive Phase 6 iterations
+#                                             → likely a design vs. implementation mis-diagnosis
+#   - pattern="max_iterations"             : termination.reason == "max_iterations"
+#                                             → loop could not converge within iteration budget
+#   - pattern="stuck"                      : termination.reason == "stuck"
+#                                             → same finding persisted across Phase 3b iterations
+#   - pattern="fork_failure"               : termination.reason == "fork_failure"
+#                                             → verifier fork failed (possibly tooling issue)
+#
+# Usage:
+#   analyze-termination-loops.sh [--worktree-base <dir>] [--max-age-days N]
+#
+#   --worktree-base  Directory containing worktree subdirectories with .claude/kickoff.json.
+#                    Default: $REPO_ROOT/../$(basename $REPO_ROOT)-worktrees
+#   --max-age-days   Skip kickoff.json whose updated_at is older than N days (default: 30)
+#
+# Output: JSON on stdout.
+#
+# See: dev-kickoff/references/kickoff-schema.md `termination` block.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+WORKTREE_BASE=""
+MAX_AGE_DAYS=30
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --worktree-base) WORKTREE_BASE="$2"; shift 2 ;;
+        --max-age-days) MAX_AGE_DAYS="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,25p' "$0"
+            exit 0
+            ;;
+        *) die_json "Unknown argument: $1" 1 ;;
+    esac
+done
+
+# Default worktree base: $REPO_ROOT/../$(basename $REPO_ROOT)-worktrees
+if [[ -z "$WORKTREE_BASE" ]]; then
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [[ -n "$GIT_ROOT" ]]; then
+        REPO_NAME=$(basename "$GIT_ROOT")
+        WORKTREE_BASE="$GIT_ROOT/../${REPO_NAME}-worktrees"
+    else
+        die_json "Cannot auto-detect worktree-base; use --worktree-base" 1
+    fi
+fi
+
+if [[ ! -d "$WORKTREE_BASE" ]]; then
+    # Non-existent → return empty result (not an error; rotation of worktrees is expected)
+    jq -n --arg base "$WORKTREE_BASE" '{
+        worktree_base: $base,
+        checked_worktrees: 0,
+        findings: []
+    }'
+    exit 0
+fi
+
+# Collect kickoff.json paths
+KICKOFF_FILES=()
+while IFS= read -r -d '' f; do
+    KICKOFF_FILES+=("$f")
+done < <(find "$WORKTREE_BASE" -maxdepth 3 -type f -name 'kickoff.json' -path '*/.claude/kickoff.json' -print0 2>/dev/null)
+
+CHECKED=0
+FINDINGS_JSON='[]'
+
+for kf in "${KICKOFF_FILES[@]}"; do
+    # Skip unreadable / invalid JSON
+    if ! jq empty "$kf" >/dev/null 2>&1; then
+        continue
+    fi
+
+    CHECKED=$((CHECKED + 1))
+    WT_DIR=$(dirname "$(dirname "$kf")")
+    ISSUE=$(jq -r '.issue // null' "$kf")
+
+    # -----------------------------------------------------------
+    # Phase 6 (6_evaluate) — check verdict_history
+    # -----------------------------------------------------------
+    HAS_P6=$(jq 'has("phases") and (.phases | has("6_evaluate")) and (.phases["6_evaluate"] | has("termination"))' "$kf")
+    if [[ "$HAS_P6" == "true" ]]; then
+        P6_REASON=$(jq -r '.phases["6_evaluate"].termination.reason // "null"' "$kf")
+        P6_FINAL_ITER=$(jq -r '.phases["6_evaluate"].termination.final_iteration // 0' "$kf")
+
+        # Pattern: max_iterations
+        if [[ "$P6_REASON" == "max_iterations" ]]; then
+            FINDING=$(jq -n \
+                --arg wt "$WT_DIR" \
+                --argjson issue "$ISSUE" \
+                --arg phase "6_evaluate" \
+                --arg pattern "max_iterations" \
+                --argjson iter "$P6_FINAL_ITER" \
+                --arg msg "Phase 6 loop did not converge within max iterations ($P6_FINAL_ITER)" \
+                '{worktree: $wt, issue: $issue, phase: $phase, pattern: $pattern, final_iteration: $iter, message: $msg}')
+            FINDINGS_JSON=$(echo "$FINDINGS_JSON" | jq --argjson f "$FINDING" '. + [$f]')
+        fi
+
+        # Pattern: fork_failure
+        if [[ "$P6_REASON" == "fork_failure" ]]; then
+            FINDING=$(jq -n \
+                --arg wt "$WT_DIR" \
+                --argjson issue "$ISSUE" \
+                --arg phase "6_evaluate" \
+                --arg pattern "fork_failure" \
+                --arg msg "dev-evaluate fork failed — verifier could not run" \
+                '{worktree: $wt, issue: $issue, phase: $phase, pattern: $pattern, message: $msg}')
+            FINDINGS_JSON=$(echo "$FINDINGS_JSON" | jq --argjson f "$FINDING" '. + [$f]')
+        fi
+
+        # Pattern: repeated_feedback_target (same target in 2+ consecutive iterations)
+        REPEATED=$(jq -c '
+            .phases["6_evaluate"].termination.verdict_history // [] as $h
+            | [range(1; $h | length)
+                | . as $i
+                | if ($h[$i].feedback_target // null) != null
+                     and ($h[$i].feedback_target == ($h[$i - 1].feedback_target // null))
+                  then $h[$i].feedback_target
+                  else empty end]
+            | unique
+        ' "$kf" 2>/dev/null || echo '[]')
+
+        REPEATED_LEN=$(echo "$REPEATED" | jq 'length')
+        if [[ "$REPEATED_LEN" -gt 0 ]]; then
+            for target in $(echo "$REPEATED" | jq -r '.[]'); do
+                # Count occurrences across the history
+                OCCURRENCES=$(jq --arg t "$target" \
+                    '[.phases["6_evaluate"].termination.verdict_history[]? | select(.feedback_target == $t)] | length' "$kf")
+                FINDING=$(jq -n \
+                    --arg wt "$WT_DIR" \
+                    --argjson issue "$ISSUE" \
+                    --arg phase "6_evaluate" \
+                    --arg pattern "repeated_feedback_target" \
+                    --arg target "$target" \
+                    --argjson occ "$OCCURRENCES" \
+                    --arg msg "同一 feedback_target ($target) が 2 iteration 連続で発生 → 設計問題の可能性" \
+                    '{worktree: $wt, issue: $issue, phase: $phase, pattern: $pattern, feedback_target: $target, occurrences: $occ, message: $msg}')
+                FINDINGS_JSON=$(echo "$FINDINGS_JSON" | jq --argjson f "$FINDING" '. + [$f]')
+            done
+        fi
+    fi
+
+    # -----------------------------------------------------------
+    # Phase 3b (3b_plan_review) — check termination.reason
+    # -----------------------------------------------------------
+    HAS_P3B=$(jq 'has("phases") and (.phases | has("3b_plan_review")) and (.phases["3b_plan_review"] | has("termination"))' "$kf")
+    if [[ "$HAS_P3B" == "true" ]]; then
+        P3B_REASON=$(jq -r '.phases["3b_plan_review"].termination.reason // "null"' "$kf")
+        P3B_FINAL_ITER=$(jq -r '.phases["3b_plan_review"].termination.final_iteration // 0' "$kf")
+
+        if [[ "$P3B_REASON" == "stuck" ]]; then
+            FINDING=$(jq -n \
+                --arg wt "$WT_DIR" \
+                --argjson issue "$ISSUE" \
+                --arg phase "3b_plan_review" \
+                --arg pattern "stuck" \
+                --argjson iter "$P3B_FINAL_ITER" \
+                --arg msg "Plan-review loop が stuck (同一 finding が連続)" \
+                '{worktree: $wt, issue: $issue, phase: $phase, pattern: $pattern, final_iteration: $iter, message: $msg}')
+            FINDINGS_JSON=$(echo "$FINDINGS_JSON" | jq --argjson f "$FINDING" '. + [$f]')
+        fi
+
+        if [[ "$P3B_REASON" == "max_iterations" ]]; then
+            FINDING=$(jq -n \
+                --arg wt "$WT_DIR" \
+                --argjson issue "$ISSUE" \
+                --arg phase "3b_plan_review" \
+                --arg pattern "max_iterations" \
+                --argjson iter "$P3B_FINAL_ITER" \
+                --arg msg "Plan-review loop が max_iterations で escalate" \
+                '{worktree: $wt, issue: $issue, phase: $phase, pattern: $pattern, final_iteration: $iter, message: $msg}')
+            FINDINGS_JSON=$(echo "$FINDINGS_JSON" | jq --argjson f "$FINDING" '. + [$f]')
+        fi
+
+        if [[ "$P3B_REASON" == "fork_failure" ]]; then
+            FINDING=$(jq -n \
+                --arg wt "$WT_DIR" \
+                --argjson issue "$ISSUE" \
+                --arg phase "3b_plan_review" \
+                --arg pattern "fork_failure" \
+                --arg msg "dev-plan-review fork failed — verifier could not run" \
+                '{worktree: $wt, issue: $issue, phase: $phase, pattern: $pattern, message: $msg}')
+            FINDINGS_JSON=$(echo "$FINDINGS_JSON" | jq --argjson f "$FINDING" '. + [$f]')
+        fi
+    fi
+done
+
+jq -n \
+    --arg base "$WORKTREE_BASE" \
+    --argjson checked "$CHECKED" \
+    --argjson findings "$FINDINGS_JSON" \
+    '{
+        worktree_base: $base,
+        checked_worktrees: $checked,
+        findings: $findings
+    }'

--- a/dev-flow-doctor/scripts/run-diagnostics.sh
+++ b/dev-flow-doctor/scripts/run-diagnostics.sh
@@ -458,6 +458,44 @@ run_family_checks() {
 }
 
 # ============================================================================
+# Check 9: Termination Loop Health (kickoff.json driven) — issue #53
+# ============================================================================
+
+run_termination_loops_check() {
+  local analyze_sh="$SCRIPT_DIR_RD/analyze-termination-loops.sh"
+  if [[ ! -x "$analyze_sh" ]]; then
+    CHECKS=$(echo "$CHECKS" | jq '.termination_loops = {"status": "skipped", "reason": "analyze-termination-loops.sh not found"}')
+    return
+  fi
+
+  local term_data
+  if ! term_data=$("$analyze_sh" 2>/dev/null); then
+    CHECKS=$(echo "$CHECKS" | jq '.termination_loops = {"status": "error", "reason": "analyze-termination-loops.sh failed"}')
+    return
+  fi
+
+  if ! echo "$term_data" | jq 'type == "object"' 2>/dev/null | grep -q true; then
+    CHECKS=$(echo "$CHECKS" | jq '.termination_loops = {"status": "error", "reason": "invalid JSON from analyze-termination-loops.sh"}')
+    return
+  fi
+
+  local findings_count
+  findings_count=$(echo "$term_data" | jq '.findings | length')
+
+  if [[ "$findings_count" -gt 0 ]]; then
+    # Emit a single summary warn; detailed findings remain inside CHECKS.termination_loops
+    local repeated max_iter stuck_cnt fork_cnt
+    repeated=$(echo "$term_data" | jq '[.findings[] | select(.pattern == "repeated_feedback_target")] | length')
+    max_iter=$(echo "$term_data" | jq '[.findings[] | select(.pattern == "max_iterations")] | length')
+    stuck_cnt=$(echo "$term_data" | jq '[.findings[] | select(.pattern == "stuck")] | length')
+    fork_cnt=$(echo "$term_data" | jq '[.findings[] | select(.pattern == "fork_failure")] | length')
+    add_issue "warn" "Termination loop findings: repeated_feedback_target=${repeated}, max_iterations=${max_iter}, stuck=${stuck_cnt}, fork_failure=${fork_cnt}"
+  fi
+
+  CHECKS=$(echo "$CHECKS" | jq --argjson t "$term_data" '.termination_loops = $t')
+}
+
+# ============================================================================
 # Run checks based on scope
 # ============================================================================
 
@@ -467,6 +505,7 @@ case "$SCOPE" in
     run_worktree_checks
     run_config_checks
     run_family_checks
+    run_termination_loops_check
     ;;
   journal)
     run_journal_checks
@@ -479,6 +518,7 @@ case "$SCOPE" in
     ;;
   family)
     run_family_checks
+    run_termination_loops_check
     ;;
 esac
 

--- a/dev-flow-doctor/tests/test-analyze-termination-loops.sh
+++ b/dev-flow-doctor/tests/test-analyze-termination-loops.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# test-analyze-termination-loops.sh - Unit tests for analyze-termination-loops.sh (issue #53)
+#
+# Run: ./dev-flow-doctor/tests/test-analyze-termination-loops.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANALYZE_SH="$SCRIPT_DIR/../scripts/analyze-termination-loops.sh"
+
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "${2:-}"; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then pass "$label"; else fail "$label" "expected='$expected' actual='$actual'"; fi
+}
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Create a fake worktree-base directory
+BASE="$TMP_ROOT/worktrees"
+mkdir -p "$BASE"
+
+make_kickoff() {
+  local name="$1" phase="$2" content="$3"
+  local dir="$BASE/$name/.claude"
+  mkdir -p "$dir"
+  echo "$content" > "$dir/kickoff.json"
+}
+
+# ----------------------------------------------------------------------------
+# Test 1: script exists and is executable
+# ----------------------------------------------------------------------------
+printf 'Test 1: script exists\n'
+if [[ -x "$ANALYZE_SH" ]]; then
+  pass "analyze-termination-loops.sh exists and is executable"
+else
+  fail "analyze-termination-loops.sh exists" "missing: $ANALYZE_SH"
+  printf '\nSummary: %d passed, %d failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# Test 2: empty worktree-base → valid JSON with empty findings
+# ----------------------------------------------------------------------------
+printf '\nTest 2: empty worktree-base\n'
+EMPTY_BASE="$TMP_ROOT/empty"
+mkdir -p "$EMPTY_BASE"
+RESULT=$("$ANALYZE_SH" --worktree-base "$EMPTY_BASE" 2>&1)
+if echo "$RESULT" | jq empty 2>/dev/null; then
+  pass "empty base produces valid JSON"
+  FINDINGS_LEN=$(echo "$RESULT" | jq '.findings | length')
+  assert_eq "empty base findings length = 0" "0" "$FINDINGS_LEN"
+else
+  fail "empty base produces valid JSON" "$RESULT"
+fi
+
+# ----------------------------------------------------------------------------
+# Test 3: repeated feedback_target (design 2 iterations in a row) → finding
+# ----------------------------------------------------------------------------
+printf '\nTest 3: repeated feedback_target detected\n'
+make_kickoff "wt-repeat" "6_evaluate" '{
+  "issue": 100,
+  "updated_at": "2026-04-10T00:00:00Z",
+  "phases": {
+    "6_evaluate": {
+      "termination": {
+        "reason": "max_iterations",
+        "final_iteration": 3,
+        "final_verdict": "fail",
+        "verdict_history": [
+          {"iteration":1,"verdict":"fail","feedback_target":"design"},
+          {"iteration":2,"verdict":"fail","feedback_target":"design"},
+          {"iteration":3,"verdict":"fail","feedback_target":"implementation"}
+        ]
+      }
+    }
+  }
+}'
+RESULT=$("$ANALYZE_SH" --worktree-base "$BASE" 2>&1)
+REPEAT_COUNT=$(echo "$RESULT" | jq '[.findings[] | select(.pattern == "repeated_feedback_target")] | length')
+assert_eq "repeated_feedback_target finding count = 1" "1" "$REPEAT_COUNT"
+TARGET=$(echo "$RESULT" | jq -r '[.findings[] | select(.pattern == "repeated_feedback_target")][0].feedback_target')
+assert_eq "repeated target = design" "design" "$TARGET"
+
+# ----------------------------------------------------------------------------
+# Test 4: feedback_target alternates → no repeated finding
+# ----------------------------------------------------------------------------
+printf '\nTest 4: alternating feedback_target NOT flagged\n'
+rm -rf "$BASE"/*
+make_kickoff "wt-alt" "6_evaluate" '{
+  "issue": 101,
+  "updated_at": "2026-04-10T00:00:00Z",
+  "phases": {
+    "6_evaluate": {
+      "termination": {
+        "reason": "max_iterations",
+        "final_iteration": 3,
+        "final_verdict": "fail",
+        "verdict_history": [
+          {"iteration":1,"verdict":"fail","feedback_target":"design"},
+          {"iteration":2,"verdict":"fail","feedback_target":"implementation"},
+          {"iteration":3,"verdict":"fail","feedback_target":"design"}
+        ]
+      }
+    }
+  }
+}'
+RESULT=$("$ANALYZE_SH" --worktree-base "$BASE" 2>&1)
+REPEAT_COUNT=$(echo "$RESULT" | jq '[.findings[] | select(.pattern == "repeated_feedback_target")] | length')
+assert_eq "alternating → no repeated_feedback_target" "0" "$REPEAT_COUNT"
+
+# ----------------------------------------------------------------------------
+# Test 5: Phase 3b stuck termination → finding
+# ----------------------------------------------------------------------------
+printf '\nTest 5: phase 3b stuck termination\n'
+rm -rf "$BASE"/*
+make_kickoff "wt-stuck" "3b_plan_review" '{
+  "issue": 102,
+  "updated_at": "2026-04-10T00:00:00Z",
+  "phases": {
+    "3b_plan_review": {
+      "termination": {
+        "reason": "stuck",
+        "final_iteration": 2,
+        "final_verdict": "revise",
+        "verdict_history": [
+          {"iteration":1,"verdict":"revise","score":70},
+          {"iteration":2,"verdict":"revise","score":71}
+        ]
+      }
+    }
+  }
+}'
+RESULT=$("$ANALYZE_SH" --worktree-base "$BASE" 2>&1)
+STUCK_COUNT=$(echo "$RESULT" | jq '[.findings[] | select(.pattern == "stuck")] | length')
+assert_eq "stuck finding count = 1" "1" "$STUCK_COUNT"
+PHASE=$(echo "$RESULT" | jq -r '[.findings[] | select(.pattern == "stuck")][0].phase')
+assert_eq "stuck finding phase = 3b_plan_review" "3b_plan_review" "$PHASE"
+
+# ----------------------------------------------------------------------------
+# Test 6: max_iterations termination → finding
+# ----------------------------------------------------------------------------
+printf '\nTest 6: max_iterations termination\n'
+rm -rf "$BASE"/*
+make_kickoff "wt-maxiter" "6_evaluate" '{
+  "issue": 103,
+  "updated_at": "2026-04-10T00:00:00Z",
+  "phases": {
+    "6_evaluate": {
+      "termination": {
+        "reason": "max_iterations",
+        "final_iteration": 5,
+        "final_verdict": "fail",
+        "verdict_history": [
+          {"iteration":1,"verdict":"fail","feedback_target":"implementation"},
+          {"iteration":2,"verdict":"fail","feedback_target":"design"},
+          {"iteration":3,"verdict":"fail","feedback_target":"implementation"},
+          {"iteration":4,"verdict":"fail","feedback_target":"design"},
+          {"iteration":5,"verdict":"fail","feedback_target":"implementation"}
+        ]
+      }
+    }
+  }
+}'
+RESULT=$("$ANALYZE_SH" --worktree-base "$BASE" 2>&1)
+MAX_COUNT=$(echo "$RESULT" | jq '[.findings[] | select(.pattern == "max_iterations")] | length')
+assert_eq "max_iterations finding count = 1" "1" "$MAX_COUNT"
+
+# ----------------------------------------------------------------------------
+# Test 7: kickoff without termination block → skipped (no findings)
+# ----------------------------------------------------------------------------
+printf '\nTest 7: kickoff without termination skipped\n'
+rm -rf "$BASE"/*
+make_kickoff "wt-notermination" "6_evaluate" '{
+  "issue": 104,
+  "updated_at": "2026-04-10T00:00:00Z",
+  "phases": {
+    "6_evaluate": { "status": "done" }
+  }
+}'
+RESULT=$("$ANALYZE_SH" --worktree-base "$BASE" 2>&1)
+FINDINGS_LEN=$(echo "$RESULT" | jq '.findings | length')
+assert_eq "no termination → findings = 0" "0" "$FINDINGS_LEN"
+CHECKED=$(echo "$RESULT" | jq '.checked_worktrees')
+assert_eq "checked_worktrees = 1" "1" "$CHECKED"
+
+# ----------------------------------------------------------------------------
+# Test 8: converged termination → NOT flagged
+# ----------------------------------------------------------------------------
+printf '\nTest 8: converged termination NOT flagged\n'
+rm -rf "$BASE"/*
+make_kickoff "wt-conv" "6_evaluate" '{
+  "issue": 105,
+  "updated_at": "2026-04-10T00:00:00Z",
+  "phases": {
+    "6_evaluate": {
+      "termination": {
+        "reason": "converged",
+        "final_iteration": 1,
+        "final_verdict": "pass",
+        "verdict_history": [
+          {"iteration":1,"verdict":"pass"}
+        ]
+      }
+    }
+  }
+}'
+RESULT=$("$ANALYZE_SH" --worktree-base "$BASE" 2>&1)
+FINDINGS_LEN=$(echo "$RESULT" | jq '.findings | length')
+assert_eq "converged → findings = 0" "0" "$FINDINGS_LEN"
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+printf '\n----------------------------------------\n'
+printf 'Summary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/dev-kickoff/SKILL.md
+++ b/dev-kickoff/SKILL.md
@@ -116,9 +116,13 @@ Phase 3b（dev-plan-review）の Output JSON schema は `{score, verdict, findin
 
 - **`max_iterations = 3`**（既定、`config.plan_review.max_iterations` で override 可）
 - 3 iteration で pass に達しない場合、**user escalate**:
-  - `kickoff.json` に `phases.3b_plan_review.escalated = true` と `escalation_reason = "max_iterations"` を記録
+  - `kickoff.json` の `phases.3b_plan_review.termination.reason = "max_iterations"` を記録（issue #53 の統一 termination schema）
+  - 同時に legacy フィールド `escalated = true` / `escalation_reason = "max_iterations"` も書き込む（1 リリース backward-compat）
   - Skill 出力に `⚠️ Plan did not converge after 3 iterations. Proceeding with last plan; please review manually.` を明示
   - 既定は warning 付きで Phase 4 に進行（ユーザー中断を妨げない）
+
+> `termination` block の schema は [kickoff-schema.md `termination` block](references/kickoff-schema.md#termination-block-v320-%E3%80%9C-generator-verifier-loop-%E7%B5%82%E4%BA%86%E7%8A%B6%E6%85%8B) を参照。
+> Phase 3b と Phase 6 で共通の schema を持ち、`dev-flow-doctor` の Check 9 が verdict_history を横断分析する。
 
 ### Stuck Detection（同一 finding 連続）
 
@@ -133,11 +137,10 @@ ESCALATE=$(echo "$STUCK_RESULT" | jq -r '.escalate')
 STUCK_FINDINGS=$(echo "$STUCK_RESULT" | jq -c '.stuck_findings')
 
 if [[ "$ESCALATE" == "true" ]]; then
-  # iter 3 を待たず即 escalate
+  # iter 3 を待たず即 escalate — 統一 termination schema (issue #53) 経由で記録
   $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 3b_plan_review done \
     --worktree "$WORKTREE" \
-    --escalated true \
-    --escalation-reason stuck \
+    --termination-reason stuck \
     --stuck-findings "$STUCK_FINDINGS"
   echo "⚠️ Plan-review loop stuck. Same finding persisted across iterations. Escalating to user."
   echo "Stuck findings: $STUCK_FINDINGS"

--- a/dev-kickoff/references/evaluate-retry.md
+++ b/dev-kickoff/references/evaluate-retry.md
@@ -4,8 +4,21 @@ After Phase 6 (dev-evaluate) returns evaluation JSON:
 
 ## Flow
 
-1. **Record result**: `update-phase.sh 6_evaluate done --eval-result '$JSON' --worktree $PATH`
-2. **If `verdict == "pass"`**: Proceed to Phase 7 (git-commit)
+1. **Record iteration**: `update-phase.sh 6_evaluate in_progress --eval-result '$JSON' --worktree $PATH`
+
+   `--eval-result` は `phases.6_evaluate.iterations[]` に eval_result 全体を append すると同時に、
+   **`phases.6_evaluate.termination.verdict_history`** にも
+   `{iteration, verdict, feedback_target}` を同期的に append する（issue #53）。
+
+2. **If `verdict == "pass"`**: Record termination and proceed to Phase 7 (git-commit).
+
+   ```bash
+   $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 6_evaluate done \
+     --worktree $PATH \
+     --termination-reason converged \
+     --termination-final-verdict pass
+   ```
+
 3. **If `verdict == "fail"` AND iterations < max_iterations (default 5)**:
    - Read `feedback_level` from the evaluation result
    - If `"design"`: Reset to Phase 3
@@ -18,8 +31,26 @@ After Phase 6 (dev-evaluate) returns evaluation JSON:
      $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 6_evaluate done --reset-to 4_implement --worktree $PATH
      ```
      Pass feedback to dev-implement for code revision
-4. **If max_iterations reached**: Proceed to Phase 7 with warning log
-5. **If evaluate fork fails**: Retry once. If still fails, skip evaluation and proceed to Phase 7 with warning. Record error in kickoff.json.
+
+4. **If max_iterations reached**: Record termination with reason `max_iterations` and proceed to Phase 7 with warning log.
+
+   ```bash
+   $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 6_evaluate done \
+     --worktree $PATH \
+     --termination-reason max_iterations \
+     --termination-final-verdict fail
+   ```
+
+5. **If evaluate fork fails**: Retry once. If still fails, skip evaluation and proceed to Phase 7 with warning.
+
+   ```bash
+   $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 6_evaluate done \
+     --worktree $PATH \
+     --termination-reason fork_failure
+   ```
+
+> `termination` block の schema は [kickoff-schema.md](kickoff-schema.md#termination-block-v320-%E3%80%9C-generator-verifier-loop-%E7%B5%82%E4%BA%86%E7%8A%B6%E6%85%8B) を参照。
+> Phase 3b / Phase 6 で共通の schema を持ち、`dev-flow-doctor` が `verdict_history` を横断分析する。
 
 ## Plan-Review Loop (Phase 3b — Evaluator-Optimizer)
 
@@ -90,7 +121,14 @@ After Phase 6 (dev-evaluate) returns evaluation JSON:
 
 1. **Record result**: `update-phase.sh 3b_plan_review done --worktree $PATH`（記録時に Output JSON 全体を保存）
 2. **Parse verdict**（`config.plan_review.pass_threshold` 既定 80）:
-   - `verdict == "pass"` → **Phase 4 (dev-implement)** に進行
+   - `verdict == "pass"` → `--termination-reason converged` で termination 記録 → **Phase 4 (dev-implement)** に進行
+     ```bash
+     $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 3b_plan_review done \
+       --worktree $PATH \
+       --termination-reason converged \
+       --termination-final-verdict pass \
+       --append-verdict "$(jq -c '{iteration:'$ITER',verdict:.verdict,score:.score}' review.json)"
+     ```
    - `verdict == "revise" | "block"` → 次ステップへ
 3. **Append history**: `plan-review-history.json` に canonical schema `{"iteration": <int>, "score": <int>, "verdict": "pass"|"revise"|"block", "findings": [...]}` を追記（配列に push）。`findings` は dev-plan-review Output JSON の findings をそのまま保存
 4. **Stuck detection**: iteration N と N-1 の findings を比較し、同じ `{dimension, topic}` が両方に存在すれば **stuck escalate** して iter 3 を待たずに終了
@@ -141,10 +179,16 @@ STUCK_RESULT=$($SKILLS_DIR/_shared/scripts/detect-stuck-findings.py \
   --history "$WORKTREE/.claude/plan-review-history.json")
 if [[ "$(echo "$STUCK_RESULT" | jq -r .escalate)" == "true" ]]; then
   STUCK=$(echo "$STUCK_RESULT" | jq -c .stuck_findings)
+  # New unified termination schema (issue #53) — also mirrors legacy escalation fields
   $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 3b_plan_review done \
-    --worktree "$WORKTREE" --escalated true --escalation-reason stuck --stuck-findings "$STUCK"
+    --worktree "$WORKTREE" \
+    --termination-reason stuck \
+    --stuck-findings "$STUCK"
 fi
 ```
+
+> `--escalated` / `--escalation-reason` を直接指定する旧 API は後方互換のため残るが、
+> 新規利用は `--termination-reason` に移行する（v3.2.0 の deprecation、v3.3.0 で旧 API 削除予定）。
 
 > 参考: 以前は `references/evaluate-retry.md` に下記の擬似 Python コードを載せていた。現在は上記スクリプトが同等ロジックを実装している。
 >

--- a/dev-kickoff/references/kickoff-schema.md
+++ b/dev-kickoff/references/kickoff-schema.md
@@ -79,6 +79,108 @@
 
 **書き込みルール**: append-only。`decisions` フィールドは `init-kickoff.sh` で `[]` 初期化される。
 
+## `termination` block (v3.2.0〜) — Generator-Verifier loop 終了状態
+
+**目的**: dev-kickoff が内包する 2 つの evaluator-optimizer（Generator-Verifier）ループ
+（Phase 3 ⇄ 3b, Phase 4-5 ⇄ 6）の終了理由と verdict 履歴を **統一 schema** で記録する。
+これにより `dev-flow-doctor` が verdict_history を横断分析できる
+（e.g.「同一 feedback_target が 2 回以上繰り返された → 設計問題の可能性」）。
+
+### 位置
+
+- `phases.3b_plan_review.termination` — Plan-Review loop の終了状態
+- `phases.6_evaluate.termination` — Evaluate-Retry loop の終了状態
+
+### Schema
+
+```jsonc
+{
+  "termination": {
+    "reason": "converged",          // 必須 enum: 下記参照
+    "final_iteration": 2,            // 1-indexed、loop が実際に回った回数
+    "final_verdict": "pass",         // loop 終了時の最終 verdict (phase 依存 vocabulary)
+    "verdict_history": [             // append-only、iteration ごと
+      { "iteration": 1, "verdict": "revise", "score": 72 },
+      { "iteration": 2, "verdict": "pass",   "score": 85 }
+    ],
+    "recorded_at": "2026-04-11T11:45:00Z"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `reason` | string (enum) | yes | `converged` / `max_iterations` / `stuck` / `fork_failure` |
+| `final_iteration` | integer (≥ 0) | yes | 1-indexed。0 は loop 未実行（fork_failure 等） |
+| `final_verdict` | string | no | phase 固有 vocabulary（Phase 3b: `pass`/`revise`/`block`、Phase 6: `pass`/`fail`） |
+| `verdict_history` | array | yes | append-only。要素 schema は下記 |
+| `recorded_at` | string (ISO8601 UTC) | yes | 記録タイムスタンプ |
+
+### `reason` enum
+
+| reason | 意味 |
+|--------|------|
+| `converged` | verdict `pass` に到達 → 正常終了 |
+| `max_iterations` | 最大 iteration 回数に到達してもまだ pass していない |
+| `stuck` | 同一 finding が連続 iteration に残った（Phase 3b のみ） |
+| `fork_failure` | `context:fork` による generator / verifier 起動に失敗 |
+
+### `verdict_history[]` 要素 schema
+
+#### Phase 3b (`3b_plan_review`)
+
+```jsonc
+{
+  "iteration": 1,
+  "verdict": "revise",   // "pass" | "revise" | "block"
+  "score": 72
+}
+```
+
+#### Phase 6 (`6_evaluate`)
+
+```jsonc
+{
+  "iteration": 1,
+  "verdict": "fail",              // "pass" | "fail"
+  "feedback_target": "design"     // "design" | "implementation"、pass 時は省略可
+}
+```
+
+`feedback_target` は `dev-flow-doctor` の診断対象フィールド。同一 `feedback_target` が
+**2 iteration 連続**で発生すると "repeated_feedback_target" として flag される
+（[dev-flow-doctor diagnostic-checks.md Check 9](../../dev-flow-doctor/references/diagnostic-checks.md) 参照）。
+
+### 書き込みルール
+
+1. **共通呼び出し点**: `_shared/scripts/termination-record.sh` を使用する。
+   両ループ（dev-kickoff Phase 3b / Phase 6）から同じインターフェースで呼び出す。
+2. **dev-kickoff 互換**: `dev-kickoff/scripts/update-phase.sh` の
+   `--termination-reason` オプション経由でも書き込める。
+3. **verdict_history の append**: `--append-verdict '<JSON>'` で単一 verdict を追加する。
+   `final_iteration` は自動的に配列長に同期する。
+4. **原子性**: `mktemp + mv` による atomic write を必ず行う。
+5. **冪等性**: 同じ reason を複数回書き込んでも state は崩れない。
+   `verdict_history` は append-only なので、同じ iteration を再度 append しないよう
+   呼び出し側が重複排除する責任を持つ。
+
+### 後方互換（1 リリース間維持、v3.2.0 → v3.3.0 で削除予定）
+
+既存の Phase 3b escalation フィールドは **deprecated** だが termination block と並行して
+書き込まれる:
+
+| 旧フィールド | 新しい位置 | deprecation |
+|------------|-----------|-------------|
+| `phases.3b_plan_review.escalated` (bool) | `termination.reason != "converged"` で true | deprecated、v3.3.0 で削除予定 |
+| `phases.3b_plan_review.escalation_reason` | `termination.reason` | 同上 |
+| `phases.3b_plan_review.stuck_findings` | `termination.reason == "stuck"` の補足情報 | 同上、termination block の `verdict_history` では表現しない |
+| `phases.3b_plan_review.last_verdict` | `termination.final_verdict` | 同上 |
+| `phases.3b_plan_review.last_score` | 最後の `verdict_history[].score` | 同上 |
+| `phases.6_evaluate.iterations[]` | `termination.verdict_history` | `iterations[]` は eval_result 全文を残すため継続維持 |
+| `phases.6_evaluate.current_iteration` | `termination.final_iteration` | 継続維持（状態機械の読み取りに使用） |
+
+読み取り側は **termination block を優先** し、存在しなければ旧フィールドへフォールバックする。
+
 ## 後方互換
 
 - 既存の kickoff.json に `feature_list` / `progress_log` が無い場合は **空配列扱い**。
@@ -102,6 +204,9 @@
 - `dev-kickoff/scripts/init-kickoff.sh` — 初期化
 - `dev-kickoff/scripts/append-progress.sh` — `progress_log.append`
 - `dev-kickoff/scripts/update-feature.sh` — `feature_list[i].status` 更新
+- `dev-kickoff/scripts/update-phase.sh` — phase 状態 + termination block 書き込み
+- `_shared/scripts/termination-record.sh` — 両ループ共通の termination block 書き込み
+- `dev-flow-doctor/scripts/analyze-termination-loops.sh` — verdict_history 横断分析
 - `dev-validate/scripts/validate-kickoff.sh` — immutability warning
 
 ## 参考

--- a/dev-kickoff/scripts/update-phase.sh
+++ b/dev-kickoff/scripts/update-phase.sh
@@ -3,6 +3,8 @@
 # Usage: update-phase.sh <phase> <status> [--result "..."] [--error "..."] [--worktree PATH] [--reset-to PHASE] [--eval-result JSON]
 #        [--escalated true|false] [--escalation-reason max_iterations|stuck|fork_failure]
 #        [--stuck-findings JSON] [--review-iteration N] [--review-verdict pass|revise|block] [--review-score N]
+#        [--termination-reason converged|max_iterations|stuck|fork_failure]
+#        [--termination-final-verdict V] [--termination-verdict-history JSON] [--append-verdict JSON]
 
 set -euo pipefail
 
@@ -27,6 +29,10 @@ STUCK_FINDINGS=""
 REVIEW_ITERATION=""
 REVIEW_VERDICT=""
 REVIEW_SCORE=""
+TERMINATION_REASON=""
+TERMINATION_FINAL_VERDICT=""
+TERMINATION_VERDICT_HISTORY=""
+APPEND_VERDICT=""
 
 # Valid phases and statuses for validation
 VALID_PHASES="1_prepare 2_analyze 3_plan_impl 3b_plan_review 4_implement 5_validate 6_evaluate 7_commit 8_pr"
@@ -49,6 +55,10 @@ while [[ $# -gt 0 ]]; do
         --review-iteration) REVIEW_ITERATION="$2"; shift 2 ;;
         --review-verdict) REVIEW_VERDICT="$2"; shift 2 ;;
         --review-score) REVIEW_SCORE="$2"; shift 2 ;;
+        --termination-reason) TERMINATION_REASON="$2"; shift 2 ;;
+        --termination-final-verdict) TERMINATION_FINAL_VERDICT="$2"; shift 2 ;;
+        --termination-verdict-history) TERMINATION_VERDICT_HISTORY="$2"; shift 2 ;;
+        --append-verdict) APPEND_VERDICT="$2"; shift 2 ;;
         -*)
             die_json "Unknown option: $1" 1
             ;;
@@ -171,6 +181,15 @@ if [[ -n "$EVAL_RESULT" ]]; then
     JQ_ARGS+=(--argjson eval_result "$EVAL_RESULT")
     JQ_FILTER="$JQ_FILTER | .phases[\"6_evaluate\"].iterations += [\$eval_result]"
     JQ_FILTER="$JQ_FILTER | .phases[\"6_evaluate\"].current_iteration += 1"
+    # Also mirror into termination.verdict_history (issue #53)
+    # Construct a verdict entry from eval_result: {iteration, verdict, feedback_target?}
+    JQ_FILTER="$JQ_FILTER | .phases[\"6_evaluate\"].termination = (.phases[\"6_evaluate\"].termination // {\"verdict_history\": []})"
+    JQ_FILTER="$JQ_FILTER | .phases[\"6_evaluate\"].termination.verdict_history += [{"
+    JQ_FILTER="$JQ_FILTER \"iteration\": .phases[\"6_evaluate\"].current_iteration,"
+    JQ_FILTER="$JQ_FILTER \"verdict\": (\$eval_result.verdict // null),"
+    JQ_FILTER="$JQ_FILTER \"feedback_target\": (\$eval_result.feedback_level // \$eval_result.feedback_target // null)"
+    JQ_FILTER="$JQ_FILTER }]"
+    JQ_FILTER="$JQ_FILTER | .phases[\"6_evaluate\"].termination.final_iteration = .phases[\"6_evaluate\"].current_iteration"
 fi
 
 # Plan-Review Loop (Phase 3b) escalation / state fields
@@ -223,6 +242,63 @@ if [[ -n "$REVIEW_SCORE" ]]; then
     fi
     JQ_ARGS+=(--argjson review_score "$REVIEW_SCORE")
     JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].last_score = \$review_score"
+fi
+
+# ----------------------------------------------------------------------------
+# Termination block (issue #53) — unified Generator-Verifier loop state
+# Only applies to 3b_plan_review and 6_evaluate phases.
+# ----------------------------------------------------------------------------
+if [[ -n "$TERMINATION_REASON" ]]; then
+    case "$TERMINATION_REASON" in
+        converged|max_iterations|stuck|fork_failure) ;;
+        *) die_json "--termination-reason must be one of: converged, max_iterations, stuck, fork_failure" 1 ;;
+    esac
+    case "$PHASE" in
+        3b_plan_review|6_evaluate) ;;
+        *) die_json "--termination-reason only valid for 3b_plan_review or 6_evaluate (got: $PHASE)" 1 ;;
+    esac
+
+    if [[ -n "$TERMINATION_VERDICT_HISTORY" ]]; then
+        if ! echo "$TERMINATION_VERDICT_HISTORY" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            die_json "--termination-verdict-history must be a JSON array" 1
+        fi
+    fi
+    if [[ -n "$APPEND_VERDICT" ]]; then
+        if ! echo "$APPEND_VERDICT" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            die_json "--append-verdict must be a JSON object" 1
+        fi
+    fi
+
+    JQ_ARGS+=(--arg termination_reason "$TERMINATION_REASON")
+    JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination = (.phases[\$phase].termination // {\"verdict_history\": []})"
+    JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination.reason = \$termination_reason"
+    JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination.recorded_at = \$now"
+
+    if [[ -n "$TERMINATION_VERDICT_HISTORY" ]]; then
+        JQ_ARGS+=(--argjson termination_history "$TERMINATION_VERDICT_HISTORY")
+        JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination.verdict_history = \$termination_history"
+    elif [[ -n "$APPEND_VERDICT" ]]; then
+        JQ_ARGS+=(--argjson append_verdict "$APPEND_VERDICT")
+        JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination.verdict_history = ((.phases[\$phase].termination.verdict_history // []) + [\$append_verdict])"
+    fi
+
+    if [[ -n "$TERMINATION_FINAL_VERDICT" ]]; then
+        JQ_ARGS+=(--arg termination_final_verdict "$TERMINATION_FINAL_VERDICT")
+        JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination.final_verdict = \$termination_final_verdict"
+    fi
+
+    # Sync final_iteration from verdict_history length
+    JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination.final_iteration = (.phases[\$phase].termination.verdict_history | length)"
+
+    # Legacy mirror (deprecated, 1 release): escalated / escalation_reason on Phase 3b
+    if [[ "$PHASE" == "3b_plan_review" ]]; then
+        if [[ "$TERMINATION_REASON" == "converged" ]]; then
+            JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalated = false"
+        else
+            JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalated = true"
+            JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalation_reason = \$termination_reason"
+        fi
+    fi
 fi
 
 if [[ -n "$RESET_TO" ]]; then

--- a/tests/_shared/test-termination-record.sh
+++ b/tests/_shared/test-termination-record.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Unit tests for _shared/scripts/termination-record.sh (issue #53).
+#
+# Run: bash tests/_shared/test-termination-record.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/_shared/scripts/termination-record.sh"
+
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "${2:-}"; }
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+make_worktree() {
+  local name="$1"
+  local path="$TMP_ROOT/$name"
+  mkdir -p "$path/.claude"
+  cat > "$path/.claude/kickoff.json" <<'JSON'
+{
+  "version": "3.0.0",
+  "issue": 53,
+  "branch": "feature/issue-53-m",
+  "worktree": "/tmp/wt",
+  "base_branch": "dev",
+  "started_at": "2026-04-11T10:00:00Z",
+  "updated_at": "2026-04-11T10:00:00Z",
+  "current_phase": "3b_plan_review",
+  "phases": {
+    "3b_plan_review": { "status": "in_progress" },
+    "6_evaluate": { "status": "pending", "iterations": [], "current_iteration": 0, "max_iterations": 5 }
+  },
+  "feature_list": [],
+  "progress_log": [],
+  "decisions": [],
+  "config": {}
+}
+JSON
+  echo "$path"
+}
+
+# ----------------------------------------------------------------------------
+# Test 1: script file exists and is executable
+# ----------------------------------------------------------------------------
+printf 'Test 1: script exists and is executable\n'
+if [[ -x "$SCRIPT" ]]; then
+  pass "termination-record.sh exists and is executable"
+else
+  fail "termination-record.sh exists and is executable" "missing: $SCRIPT"
+  printf '\nSummary: %d passed, %d failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# Test 2: Phase 3b converged termination writes block + legacy flags
+# ----------------------------------------------------------------------------
+printf '\nTest 2: phase 3b converged termination\n'
+WT=$(make_worktree wt1)
+OUT=$("$SCRIPT" 3b_plan_review converged \
+  --worktree "$WT" \
+  --final-iteration 2 \
+  --final-verdict pass \
+  --verdict-history '[{"iteration":1,"verdict":"revise","score":72},{"iteration":2,"verdict":"pass","score":85}]' \
+  2>&1)
+if [[ $? -ne 0 ]]; then
+  fail "converged termination exits 0" "$OUT"
+else
+  pass "converged termination exits 0"
+fi
+
+STATE="$WT/.claude/kickoff.json"
+REASON=$(jq -r '.phases["3b_plan_review"].termination.reason' "$STATE")
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then pass "$label"; else fail "$label" "expected='$expected' actual='$actual'"; fi
+}
+assert_eq "termination.reason = converged" "converged" "$REASON"
+FINAL_ITER=$(jq -r '.phases["3b_plan_review"].termination.final_iteration' "$STATE")
+assert_eq "final_iteration = 2" "2" "$FINAL_ITER"
+FINAL_VERDICT=$(jq -r '.phases["3b_plan_review"].termination.final_verdict' "$STATE")
+assert_eq "final_verdict = pass" "pass" "$FINAL_VERDICT"
+HIST_LEN=$(jq -r '.phases["3b_plan_review"].termination.verdict_history | length' "$STATE")
+assert_eq "verdict_history length = 2" "2" "$HIST_LEN"
+RECORDED=$(jq -r '.phases["3b_plan_review"].termination.recorded_at' "$STATE")
+if [[ -n "$RECORDED" && "$RECORDED" != "null" ]]; then
+  pass "recorded_at is populated"
+else
+  fail "recorded_at is populated" "got: $RECORDED"
+fi
+
+# converged should NOT set escalated=true
+ESCALATED=$(jq -r '.phases["3b_plan_review"].escalated // false' "$STATE")
+assert_eq "converged: escalated = false" "false" "$ESCALATED"
+
+# ----------------------------------------------------------------------------
+# Test 3: append-verdict grows history and updates final_iteration
+# ----------------------------------------------------------------------------
+printf '\nTest 3: append-verdict grows history\n'
+WT=$(make_worktree wt2)
+# First verdict
+"$SCRIPT" 3b_plan_review converged \
+  --worktree "$WT" \
+  --append-verdict '{"iteration":1,"verdict":"revise","score":70}' >/dev/null 2>&1
+# Second verdict appended
+"$SCRIPT" 3b_plan_review converged \
+  --worktree "$WT" \
+  --append-verdict '{"iteration":2,"verdict":"pass","score":88}' \
+  --final-verdict pass >/dev/null 2>&1
+STATE="$WT/.claude/kickoff.json"
+LEN=$(jq -r '.phases["3b_plan_review"].termination.verdict_history | length' "$STATE")
+assert_eq "verdict_history length after 2 appends = 2" "2" "$LEN"
+FINAL_ITER=$(jq -r '.phases["3b_plan_review"].termination.final_iteration' "$STATE")
+assert_eq "final_iteration synced from history length = 2" "2" "$FINAL_ITER"
+LAST_VERDICT=$(jq -r '.phases["3b_plan_review"].termination.verdict_history[-1].verdict' "$STATE")
+assert_eq "last verdict = pass" "pass" "$LAST_VERDICT"
+
+# ----------------------------------------------------------------------------
+# Test 4: stuck reason writes legacy escalation fields
+# ----------------------------------------------------------------------------
+printf '\nTest 4: stuck termination writes legacy fields\n'
+WT=$(make_worktree wt3)
+"$SCRIPT" 3b_plan_review stuck \
+  --worktree "$WT" \
+  --final-iteration 2 \
+  --final-verdict revise \
+  --verdict-history '[{"iteration":1,"verdict":"revise","score":68},{"iteration":2,"verdict":"revise","score":69}]' >/dev/null 2>&1
+STATE="$WT/.claude/kickoff.json"
+REASON=$(jq -r '.phases["3b_plan_review"].termination.reason' "$STATE")
+assert_eq "termination.reason = stuck" "stuck" "$REASON"
+ESC=$(jq -r '.phases["3b_plan_review"].escalated' "$STATE")
+assert_eq "legacy escalated = true" "true" "$ESC"
+ESC_REASON=$(jq -r '.phases["3b_plan_review"].escalation_reason' "$STATE")
+assert_eq "legacy escalation_reason = stuck" "stuck" "$ESC_REASON"
+LAST_VERDICT_LEGACY=$(jq -r '.phases["3b_plan_review"].last_verdict' "$STATE")
+assert_eq "legacy last_verdict = revise" "revise" "$LAST_VERDICT_LEGACY"
+LAST_SCORE_LEGACY=$(jq -r '.phases["3b_plan_review"].last_score' "$STATE")
+assert_eq "legacy last_score = 69" "69" "$LAST_SCORE_LEGACY"
+
+# ----------------------------------------------------------------------------
+# Test 5: Phase 6 termination with feedback_target in verdict_history
+# ----------------------------------------------------------------------------
+printf '\nTest 5: phase 6 max_iterations termination\n'
+WT=$(make_worktree wt4)
+"$SCRIPT" 6_evaluate max_iterations \
+  --worktree "$WT" \
+  --final-iteration 5 \
+  --final-verdict fail \
+  --verdict-history '[
+    {"iteration":1,"verdict":"fail","feedback_target":"design"},
+    {"iteration":2,"verdict":"fail","feedback_target":"design"},
+    {"iteration":3,"verdict":"fail","feedback_target":"implementation"},
+    {"iteration":4,"verdict":"fail","feedback_target":"implementation"},
+    {"iteration":5,"verdict":"fail","feedback_target":"design"}
+  ]' >/dev/null 2>&1
+STATE="$WT/.claude/kickoff.json"
+REASON=$(jq -r '.phases["6_evaluate"].termination.reason' "$STATE")
+assert_eq "phase 6 reason = max_iterations" "max_iterations" "$REASON"
+HIST_LEN=$(jq -r '.phases["6_evaluate"].termination.verdict_history | length' "$STATE")
+assert_eq "phase 6 verdict_history length = 5" "5" "$HIST_LEN"
+FIRST_FT=$(jq -r '.phases["6_evaluate"].termination.verdict_history[0].feedback_target' "$STATE")
+assert_eq "first iteration feedback_target = design" "design" "$FIRST_FT"
+# current_iteration (legacy) should be synced as well
+CUR_ITER=$(jq -r '.phases["6_evaluate"].current_iteration' "$STATE")
+assert_eq "legacy current_iteration = 5" "5" "$CUR_ITER"
+
+# ----------------------------------------------------------------------------
+# Test 6: invalid reason → exit non-zero
+# ----------------------------------------------------------------------------
+printf '\nTest 6: invalid reason exits non-zero\n'
+WT=$(make_worktree wt5)
+if "$SCRIPT" 3b_plan_review bogus --worktree "$WT" --final-iteration 1 >/dev/null 2>&1; then
+  fail "invalid reason rejected" "script exited 0"
+else
+  pass "invalid reason rejected"
+fi
+
+# ----------------------------------------------------------------------------
+# Test 7: invalid phase → exit non-zero
+# ----------------------------------------------------------------------------
+printf '\nTest 7: invalid phase exits non-zero\n'
+WT=$(make_worktree wt6)
+if "$SCRIPT" 4_implement converged --worktree "$WT" --final-iteration 1 >/dev/null 2>&1; then
+  fail "invalid phase rejected" "script exited 0"
+else
+  pass "invalid phase rejected"
+fi
+
+# ----------------------------------------------------------------------------
+# Test 8: idempotence — re-recording converged keeps state consistent
+# ----------------------------------------------------------------------------
+printf '\nTest 8: idempotent record\n'
+WT=$(make_worktree wt7)
+"$SCRIPT" 3b_plan_review converged --worktree "$WT" --final-iteration 1 --final-verdict pass \
+  --verdict-history '[{"iteration":1,"verdict":"pass","score":90}]' >/dev/null 2>&1
+"$SCRIPT" 3b_plan_review converged --worktree "$WT" --final-iteration 1 --final-verdict pass \
+  --verdict-history '[{"iteration":1,"verdict":"pass","score":90}]' >/dev/null 2>&1
+STATE="$WT/.claude/kickoff.json"
+LEN=$(jq -r '.phases["3b_plan_review"].termination.verdict_history | length' "$STATE")
+assert_eq "idempotent verdict_history length = 1" "1" "$LEN"
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+printf '\n----------------------------------------\n'
+printf 'Summary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## 概要

fixes #53

Anthropic の [Multi-Agent Coordination Patterns (Generator-Verifier)](https://claude.com/blog/multi-agent-coordination-patterns) に沿って、dev-kickoff に内包する **2 つの evaluator-optimizer (Generator-Verifier) ループ**の終了状態を共通 schema で記録できるようにした。

- **Phase 3 ⇄ 3b**: dev-plan-impl ⇄ dev-plan-review（max_iterations=3, stuck detection）
- **Phase 4-5 ⇄ 6**: dev-implement/validate ⇄ dev-evaluate（max 5 iterations, retry）

これまで両者の termination 記録 schema がバラバラで、`dev-flow-doctor` が「どの iteration でどの verdict が出たか」を横断分析できなかった。

## 変更点

### 1. 統一 `termination` block schema

`phases.<phase>.termination` を新設：

\`\`\`jsonc
{
  "termination": {
    "reason": "converged" | "max_iterations" | "stuck" | "fork_failure",
    "final_iteration": 2,
    "final_verdict": "pass",
    "verdict_history": [
      { "iteration": 1, "verdict": "revise", "score": 72 },
      { "iteration": 2, "verdict": "pass",   "score": 85 }
    ],
    "recorded_at": "2026-04-11T..."
  }
}
\`\`\`

- Phase 6 の verdict 要素は \`{iteration, verdict, feedback_target}\` 形式
- `dev-flow-doctor` の Check 9 が \`feedback_target\` の繰り返しを検出

### 2. 共通書き込み点

**新規**: \`_shared/scripts/termination-record.sh\` — 両ループから同じ interface で呼べる共通 script。

\`\`\`bash
termination-record.sh <phase> <reason> \\
  --worktree PATH \\
  [--final-iteration N] [--final-verdict V] \\
  [--verdict-history JSON | --append-verdict JSON]
\`\`\`

**dev-kickoff 側**: \`dev-kickoff/scripts/update-phase.sh\` に \`--termination-reason\` / \`--termination-final-verdict\` / \`--termination-verdict-history\` / \`--append-verdict\` を追加。\`--eval-result\` 受領時には Phase 6 の \`termination.verdict_history\` も自動同期する。

### 3. `dev-flow-doctor` Check 9 — Termination Loop Health

**新規**: \`dev-flow-doctor/scripts/analyze-termination-loops.sh\`

worktree 群の \`kickoff.json\` を横断走査し、以下 4 パターンを検出：

| pattern | 意味 |
|---------|------|
| \`repeated_feedback_target\` | Phase 6 で同一 \`feedback_target\` が 2 iteration 連続 → 設計問題の可能性 |
| \`max_iterations\` | loop が iteration 上限で収束せず escalate |
| \`stuck\` | Phase 3b で同一 finding が連続 iteration に残った |
| \`fork_failure\` | verifier (dev-plan-review / dev-evaluate) の fork 失敗 |

\`run-diagnostics.sh --scope full|family\` に組み込み済み。

### 4. 後方互換（1 リリース間、v3.2.0 → v3.3.0 で削除予定）

旧 Phase 3b escalation フィールドは **deprecated** だが termination block と並行して書き込まれる：

| 旧フィールド | 新しい位置 |
|------------|-----------|
| \`escalated\` (bool) | \`termination.reason != "converged"\` で true |
| \`escalation_reason\` | \`termination.reason\` |
| \`last_verdict\` / \`last_score\` | 最後の \`verdict_history[]\` 要素 |
| Phase 6 \`iterations[]\` / \`current_iteration\` | \`termination.verdict_history\` / \`final_iteration\` |

読み取り側は **termination block を優先** し、存在しなければ旧フィールドへフォールバック。

## 受け入れ基準

- [x] \`dev-kickoff/references/kickoff-schema.md\` に \`termination\` block を仕様化
- [x] \`_shared/scripts/termination-record.sh\` で両ループから共通呼び出し
- [x] Phase 3b / Phase 6 の既存 escalation / retry ロジックを新 schema に移行
- [x] 既存 \`escalated\` / \`escalation_reason\` フィールドは deprecation warning 付きで読み取り互換維持（1 リリース）
- [x] \`dev-flow-doctor\` に「verdict_history 分析」診断ルール追加（同一 feedback_target が 2 回以上 → 設計問題の可能性）
- [x] 既存テスト（stuck detection, max iterations）が new schema 上でパスする

## テスト

| Suite | 件数 | 結果 |
|-------|------|------|
| \`tests/_shared/test-termination-record.sh\` (新規) | 23 | ✅ pass |
| \`dev-flow-doctor/tests/test-analyze-termination-loops.sh\` (新規) | 12 | ✅ pass |
| \`tests/_shared/test-detect-stuck-findings.py\` (regression) | 11 | ✅ pass |
| \`dev-flow-doctor/tests/test-analyze-dev-flow-family.sh\` (regression) | 18 | ✅ pass |
| **合計** | **64** | **✅ all pass** |

### Test plan

- [x] \`bash tests/_shared/test-termination-record.sh\`
- [x] \`bash dev-flow-doctor/tests/test-analyze-termination-loops.sh\`
- [x] \`python3 -m unittest tests/_shared/test-detect-stuck-findings.py\`
- [x] \`bash dev-flow-doctor/tests/test-analyze-dev-flow-family.sh\`
- [x] \`./dev-flow-doctor/scripts/run-diagnostics.sh --scope full\` (smoke)
- [x] \`./dev-flow-doctor/scripts/run-diagnostics.sh --scope family\` (smoke)

## 関連

- epic #38
- 前提 PR: #51, #52