### PR TITLE
feat(seo-strategy): content_overlap_analysis でカニバリ提案を機械的に防止 (#69)

### DIFF
--- a/seo-strategy/references/analysis_guide.md
+++ b/seo-strategy/references/analysis_guide.md
@@ -33,11 +33,18 @@ strategy_analyzer.py が使用する分析手法・閾値・判断基準。
 
 ### new_article_directions の priority
 
+`content_overlap_analysis.clusters[].coverage_count` を**必ず参照**して priority を決定する。
+
 | Priority | 条件 |
 | -------- | ---- |
-| high | クラスタ imp ≥ 500 AND 既存記事なし/不足 |
-| medium | クラスタ imp 100-500 OR トレンド上昇中 |
-| low | imp < 100 AND トレンド横ばい |
+| high | クラスタ imp ≥ 500 AND `coverage_count == 0` |
+| medium | クラスタ imp 100-500 AND `coverage_count ≤ 1` |
+| low | `coverage_count ≤ 2` AND トレンド上昇中 |
+| skip | `coverage_count ≥ 3`（既存記事の最適化を優先） |
+
+**注意**: `existing_articles` だけでは GSC 未反映の新着記事を見落とすため、必ず
+`content_overlap_analysis.coverage_articles` を参照すること。`content_overlap_analysis`
+は frontmatter ベースの機械的判定であり、LLM の主観判定より優先する（Issue #69）。
 
 ## Query Clustering ロジック
 
@@ -244,3 +251,34 @@ GA4 で `landingPage` が `(not set)` または空文字のセッションは以
 | CVR > 1% かつ sessions < 100 | **CVポテンシャル高**: このテーマの記事を増産すべき |
 | エンゲージメント率 < 40% かつ CVR < 0.5% | **コンテンツ品質問題**: リライト or 削除検討 |
 | ブログ全体CVR と 非ブログCVR の差が 10倍以上 | **構造的ミスマッチ**: ブログ→CVの導線設計を根本的に見直す |
+
+## Validation: content_overlap_analysis
+
+corporate-site (issue#419) など既知のカニバリ事例で再生成検証する場合の手順:
+
+1. 解析を実行して JSON を生成:
+
+   ```bash
+   python3 seo-strategy/scripts/strategy_analyzer.py \
+     --config seo-config.json \
+     --blog-dir content/blog \
+     --gsc-report claudedocs/gsc-report.json \
+     --output claudedocs/seo-strategy-analysis.json
+   ```
+
+2. high saturation クラスタを抽出:
+
+   ```bash
+   jq '.content_overlap_analysis.clusters[] | select(.saturation == "high")' \
+     claudedocs/seo-strategy-analysis.json
+   ```
+
+3. 上記クラスタに対して `seo-strategy.md` の `new_article_directions` で
+   `priority: high` 提案が含まれていないことを確認する。
+
+4. 含まれていれば content-strategist agent への入力ガード違反であり、
+   `references/devils-advocate.md` チェック項目 6 で **Blocking** として処理する。
+
+5. 設定の調整: false negative（実際にカニバリしているのに検出されない）が多い場合は
+   `seo-config.json` の `overlap_match_threshold` を下げる（例: 0.4 → 0.3）。
+   false positive が多い場合は上げる（例: 0.4 → 0.5）。

--- a/seo-strategy/references/devils-advocate.md
+++ b/seo-strategy/references/devils-advocate.md
@@ -61,11 +61,15 @@
 ### 6. 内部整合性
 
 - [ ] existing_article_optimizations と new_article_directions で同じ KW 領域を重複カバーしていないか
+- [ ] **new_article_directions の各提案が `content_overlap_analysis.coverage_articles` と重複していないか（GSC 未反映の新着記事を含む全件チェック）**
 - [ ] site_structure の内部リンク提案と existing_article_optimizations の対象記事が整合しているか
 - [ ] technical_seo の修正提案が channel_strategy の改善と矛盾していないか
 - [ ] cluster_suggestions が既存 cluster_keywords と重複していないか
 
-**Blocking**: 明確な矛盾が存在
+**Blocking**:
+- 明確な矛盾が存在
+- `content_overlap_analysis.clusters[].coverage_count >= 2` の領域に新規記事が
+  `priority: high` で提案されている（既存記事の最適化を優先すべき）
 
 ### 7. 見落としチェック
 

--- a/seo-strategy/references/schema.md
+++ b/seo-strategy/references/schema.md
@@ -16,6 +16,7 @@
 | `channel_strategy` | array | チャネル別改善 |
 | `new_article_directions` | array | 新規記事の方向性 |
 | `cluster_suggestions` | array | 未分類クエリからの新クラスタ提案 |
+| `content_overlap_analysis` | object | KW × 既存記事の重複マップ（カニバリ防止） |
 | `kpi_targets` | object | 目標 KPI |
 | `roadmap` | object | フェーズ別計画 |
 
@@ -185,6 +186,47 @@
 ```
 
 LLM はこの提案を確認し、有用なものを `seo-config.json` の `cluster_keywords` に追加する判断を行う。
+
+## content_overlap_analysis
+
+`strategy_analyzer.py` が frontmatter ベースで機械的に算出する KW × 既存記事の重複マップ。
+`new_article_directions` が GSC 未反映の新着記事と重複するテーマを提案する事故 (Issue #69) を防ぐ。
+
+```jsonc
+{
+  "content_overlap_analysis": {
+    "match_threshold": 0.4,                  // number, 0.0-1.0 (config: overlap_match_threshold)
+    "thresholds": {                          // saturation 判定用 (config: saturation_thresholds の snapshot)
+      "none": 0,                             // count <= "none" → "none"
+      "low": 1,                              // count <= "low"  → "low"
+      "medium": 3                            // count <= "medium" → "medium" / それ以上 → "high"
+    },
+    "clusters": [
+      {
+        "name": "Claude Code",               // string, cluster_keywords のキー
+        "keywords": ["claude code", "..."],  // string[], cluster_keywords[name]
+        "coverage_articles": [               // match_score >= match_threshold の記事 (slug 順)
+          {
+            "slug": "claude-code-vs-codex-comparison",
+            "title": "Claude Code vs Codex 比較",
+            "match_score": 0.92,             // number, 0.0-1.0 (overlap coefficient)
+            "matched_on": ["title", "tags"]  // ("title"|"tags"|"description"|"keywords")[]
+          }
+        ],
+        "coverage_count": 3,                 // int, len(coverage_articles)
+        "saturation": "high"                 // "none" | "low" | "medium" | "high"
+      }
+    ]
+  }
+}
+```
+
+各 field は required。`cluster_keywords` が空の場合 `clusters: []`。
+スコアリングは KW トークン集合 × 記事結合トークン集合の overlap coefficient
+`|A∩B| / min(|A|,|B|)`。日本語は CJK bigram で対応。
+
+LLM はこのセクションを参照して `new_article_directions` の `priority` を決定する
+（references/analysis_guide.md の priority 表を参照）。
 
 ## category_performance
 

--- a/seo-strategy/references/team-lifecycle.md
+++ b/seo-strategy/references/team-lifecycle.md
@@ -65,6 +65,7 @@ Phase 6: Shutdown     → チーム解散
 - query_clusters: クエリクラスタ
 - cluster_suggestions: 新クラスタ提案
 - trends_summary: トレンドデータ
+- content_overlap_analysis: KW × 既存記事の重複マップ（**新規提案前に必ず参照**）
 
 出力セクション:
 1. existing_article_optimizations（references/schema.md 準拠）
@@ -75,6 +76,13 @@ measure-evaluator の結果を必ず参照し:
 - 既に実装済みの施策は提案から除外する
 - data_validity.assertions で confidence: low の指標に基づく提案には注意書きを付ける
 - theme_cv_analysis の diagnosis を new_article_directions の funnel 判定に活用する
+
+🔴 CRITICAL (新規記事提案ガード - Issue #69):
+- new_article_directions に書く前に必ず `content_overlap_analysis.clusters[].coverage_count` を確認する
+- `coverage_count >= 3` のクラスタには新規提案禁止（existing_article_optimizations を優先）
+- `coverage_count >= 2` でも `priority: high` は付けない
+- `existing_articles` だけでは GSC 未反映の新着記事を見落とすため、
+  必ず `content_overlap_analysis.coverage_articles` (frontmatter ベース機械判定) を参照する
 
 判断基準は references/analysis_guide.md に従う。
 tech-seo-specialist や channel-kpi-analyst に質問がある場合は SendMessage で問い合わせること。

--- a/seo-strategy/scripts/strategy_analyzer.py
+++ b/seo-strategy/scripts/strategy_analyzer.py
@@ -38,6 +38,17 @@ DEFAULT_CONFIG = {
     "unclustered_min_impressions": 20,
     "cluster_suggestion_min_impressions": 50,
     "cluster_suggestion_top_n": 5,
+    # content_overlap_analysis: KW × 既存記事の重複検出 (Issue #69)
+    "saturation_thresholds": {
+        # coverage_count <= "none" → "none" (新規提案OK)
+        # coverage_count <= "low"  → "low"
+        # coverage_count <= "medium" → "medium"
+        # それ以上 → "high" (新規提案禁止)
+        "none": 0,
+        "low": 1,
+        "medium": 3,
+    },
+    "overlap_match_threshold": 0.4,
 }
 
 # --- Stop words for cluster suggestions ---
@@ -172,8 +183,33 @@ def load_config(path: str | None) -> dict:
     return config
 
 
+def _split_csv_or_array(value) -> list[str]:
+    """Normalize CSV / array literal / list / single string into a list[str].
+
+    Accepts:
+      - list (returned as-is, items stripped)
+      - "[a, b, c]" → ["a", "b", "c"]
+      - "a, b, c" → ["a", "b", "c"]
+      - "single" → ["single"]
+      - "" / None → []
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return [str(v).strip().strip('"').strip("'") for v in value if str(v).strip()]
+    s = str(value).strip()
+    if s.startswith("[") and s.endswith("]"):
+        s = s[1:-1]
+    return [t.strip().strip('"').strip("'") for t in s.split(",") if t.strip()]
+
+
 def parse_frontmatter(mdx_path: str) -> dict | None:
-    """Extract frontmatter from MDX file."""
+    """Extract frontmatter from MDX file.
+
+    Supports:
+      - inline `key: value`
+      - YAML block list (continuation lines starting with `- `)
+    """
     try:
         with open(mdx_path) as f:
             content = f.read()
@@ -184,14 +220,37 @@ def parse_frontmatter(mdx_path: str) -> dict | None:
     if not match:
         return None
 
-    fm = {}
-    for line in match.group(1).split("\n"):
-        if ":" in line:
+    fm: dict = {}
+    lines = match.group(1).split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if ":" in line and not line.lstrip().startswith("-"):
             key, _, value = line.partition(":")
             key = key.strip()
             value = value.strip().strip('"').strip("'")
             if value:
                 fm[key] = value
+            else:
+                # Empty value — check for following YAML block list (- item).
+                items: list[str] = []
+                j = i + 1
+                while j < len(lines):
+                    nxt = lines[j]
+                    stripped = nxt.lstrip()
+                    if stripped.startswith("- "):
+                        items.append(stripped[2:].strip().strip('"').strip("'"))
+                        j += 1
+                        continue
+                    if stripped == "" and not items:
+                        # blank line before any item — end of block
+                        break
+                    break
+                if items:
+                    fm[key] = items
+                    i = j
+                    continue
+        i += 1
     return fm
 
 
@@ -213,7 +272,8 @@ def scan_blog_articles(blog_dir: str) -> list[dict]:
             "description": fm.get("description", ""),
             "date": fm.get("date", ""),
             "category": fm.get("category", ""),
-            "tags": [t.strip() for t in fm.get("tags", "").split(",") if t.strip()],
+            "tags": _split_csv_or_array(fm.get("tags", "")),
+            "keywords": _split_csv_or_array(fm.get("keywords", "")),
         })
     return articles
 
@@ -479,6 +539,164 @@ def build_query_clusters(
 def _tokenize(text: str) -> list[str]:
     """Split text into tokens by whitespace, hyphens, underscores."""
     return [t for t in re.split(r"[\s\-_]+", text.lower()) if t and t not in STOP_WORDS and len(t) > 1]
+
+
+# CJK 連続部分を検出する正規表現 (Hiragana / Katakana / CJK Unified Ideographs)
+_CJK_RUN_RE = re.compile(r"[぀-ゟ゠-ヿ㐀-鿿]+")
+
+
+def _tokenize_for_overlap(text: str) -> set[str]:
+    """Tokenize text for overlap matching (CJK-aware, no MeCab dependency).
+
+    Returns a lowercase token set built from:
+    - whitespace/hyphen/underscore split tokens (length >= 2, stop-words removed)
+    - 2-gram of every contiguous CJK character run (covers Japanese/Chinese)
+
+    The bigram fallback lets us match terms like "シフト管理" against article
+    titles like "シフト管理アプリの選び方" without a morphological analyzer.
+    """
+    if not text:
+        return set()
+    tokens: set[str] = set()
+    # ASCII / latin tokens via the existing tokenizer.
+    tokens.update(_tokenize(text))
+    # CJK bigrams.
+    for run in _CJK_RUN_RE.findall(text):
+        if len(run) < 2:
+            continue
+        for i in range(len(run) - 1):
+            tokens.add(run[i:i + 2])
+    return tokens
+
+
+def _saturation_label(count: int, thresholds: dict) -> str:
+    """Map coverage_count to saturation label using config thresholds."""
+    none_max = int(thresholds.get("none", 0))
+    low_max = int(thresholds.get("low", 1))
+    medium_max = int(thresholds.get("medium", 3))
+    if count <= none_max:
+        return "none"
+    if count <= low_max:
+        return "low"
+    if count <= medium_max:
+        return "medium"
+    return "high"
+
+
+def build_content_overlap_analysis(
+    blog_articles: list[dict],
+    config: dict,
+) -> dict:
+    """Build content overlap analysis: cluster KW × existing articles coverage.
+
+    Mechanically detects which existing published articles already cover each
+    cluster keyword so that LLM-driven `new_article_directions` proposals can
+    avoid cannibalizing newly-published (GSC-not-yet-indexed) articles.
+
+    Output structure (see seo-strategy/references/schema.md):
+
+        {
+          "match_threshold": 0.4,
+          "thresholds": {"none": 0, "low": 1, "medium": 3},
+          "clusters": [
+            {
+              "name": "Claude Code",
+              "keywords": ["claude code", ...],
+              "coverage_articles": [
+                {"slug": "...", "title": "...", "match_score": 0.92,
+                 "matched_on": ["title", "tags"]}
+              ],
+              "coverage_count": 3,
+              "saturation": "high"
+            }
+          ]
+        }
+    """
+    cluster_keywords = config.get("cluster_keywords", {}) or {}
+    match_threshold = float(config.get("overlap_match_threshold", 0.4))
+    thresholds = dict(
+        config.get("saturation_thresholds")
+        or DEFAULT_CONFIG["saturation_thresholds"]
+    )
+
+    if not cluster_keywords:
+        return {
+            "match_threshold": match_threshold,
+            "thresholds": thresholds,
+            "clusters": [],
+        }
+
+    # Pre-tokenize each article: per-field token set + combined token set.
+    article_index = []
+    for article in blog_articles:
+        field_tokens = {
+            "title": _tokenize_for_overlap(article.get("title", "")),
+            "tags": _tokenize_for_overlap(" ".join(article.get("tags", []) or [])),
+            "description": _tokenize_for_overlap(article.get("description", "")),
+            "keywords": _tokenize_for_overlap(" ".join(article.get("keywords", []) or [])),
+        }
+        combined: set[str] = set()
+        for s in field_tokens.values():
+            combined |= s
+        if not combined:
+            continue
+        article_index.append({
+            "slug": article.get("slug", ""),
+            "title": article.get("title", ""),
+            "field_tokens": field_tokens,
+            "combined": combined,
+        })
+
+    clusters_out: list[dict] = []
+    # Iterate over cluster_keywords in declaration order.
+    for cluster_name, raw_keywords in cluster_keywords.items():
+        if isinstance(raw_keywords, str):
+            keywords = [raw_keywords]
+        else:
+            keywords = [str(k) for k in (raw_keywords or [])]
+
+        # Pre-tokenize each KW.
+        kw_token_sets = [(kw, _tokenize_for_overlap(kw)) for kw in keywords]
+        kw_token_sets = [(kw, ts) for kw, ts in kw_token_sets if ts]
+
+        coverage: list[dict] = []
+        for art in article_index:
+            best_score = 0.0
+            matched_fields: set[str] = set()
+            for _kw, kw_tokens in kw_token_sets:
+                inter_combined = kw_tokens & art["combined"]
+                if not inter_combined:
+                    continue
+                denom = min(len(kw_tokens), len(art["combined"]))
+                score = len(inter_combined) / denom if denom else 0.0
+                if score > best_score:
+                    best_score = score
+                # matched_on は KW トークンが intersect する field 名のみ採用
+                for field, ftokens in art["field_tokens"].items():
+                    if kw_tokens & ftokens:
+                        matched_fields.add(field)
+            if best_score >= match_threshold:
+                coverage.append({
+                    "slug": art["slug"],
+                    "title": art["title"],
+                    "match_score": round(best_score, 3),
+                    "matched_on": sorted(matched_fields),
+                })
+
+        coverage.sort(key=lambda c: c["slug"])
+        clusters_out.append({
+            "name": cluster_name,
+            "keywords": keywords,
+            "coverage_articles": coverage,
+            "coverage_count": len(coverage),
+            "saturation": _saturation_label(len(coverage), thresholds),
+        })
+
+    return {
+        "match_threshold": match_threshold,
+        "thresholds": thresholds,
+        "clusters": clusters_out,
+    }
 
 
 def build_cluster_suggestions(
@@ -1231,6 +1449,13 @@ def build_output(
         for a in blog_articles
     ]
 
+    # Content overlap analysis (Issue #69): mechanical KW × article coverage
+    # Prevents new_article_directions from cannibalizing GSC-not-yet-indexed
+    # newly-published articles. Always emitted (clusters: [] when no KW config).
+    output["content_overlap_analysis"] = build_content_overlap_analysis(
+        blog_articles, config,
+    )
+
     # Codebase audit (technical SEO from source code)
     project_dir = getattr(args, "project_dir", None) or "."
     output["codebase_audit"] = build_codebase_audit(project_dir, blog_dir)
@@ -1280,7 +1505,16 @@ def main():
     n_suggestions = len(output.get("cluster_suggestions", []))
     audit_summary = output.get("codebase_audit", {}).get("summary", {})
     n_audit_issues = audit_summary.get("total_issues", 0)
-    print(f"Analysis complete: {n_articles} articles, {n_issues} issues detected, {n_clusters} query clusters, {n_suggestions} cluster suggestions, {n_audit_issues} codebase audit issues")
+    overlap = output.get("content_overlap_analysis", {}) or {}
+    overlap_clusters = overlap.get("clusters", []) or []
+    n_overlap = len(overlap_clusters)
+    n_high_sat = sum(1 for c in overlap_clusters if c.get("saturation") == "high")
+    print(
+        f"Analysis complete: {n_articles} articles, {n_issues} issues detected, "
+        f"{n_clusters} query clusters, {n_suggestions} cluster suggestions, "
+        f"{n_audit_issues} codebase audit issues, "
+        f"{n_overlap} overlap clusters analyzed ({n_high_sat} high saturation)"
+    )
     print(f"Output: {args.output}")
 
 

--- a/seo-strategy/scripts/test_strategy_analyzer.py
+++ b/seo-strategy/scripts/test_strategy_analyzer.py
@@ -152,5 +152,195 @@ class BrokenLinksTest(unittest.TestCase):
         self.assertIn("/blog/this-does-not-exist", broken_targets)
 
 
+class ContentOverlapAnalysisTest(unittest.TestCase):
+    """`build_content_overlap_analysis` should map cluster KWs to existing articles
+    so that new_article_directions can avoid cannibalizing recently-published
+    (GSC-not-yet-indexed) articles. Issue #69."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.blog_dir = self.root / "content" / "blog"
+        self.blog_dir.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write(self, name: str, frontmatter: str, body: str = "body\n") -> None:
+        (self.blog_dir / name).write_text(
+            "---\n" + frontmatter.strip() + "\n---\n\n" + body,
+            encoding="utf-8",
+        )
+
+    def _scan(self) -> list[dict]:
+        cwd = os.getcwd()
+        os.chdir(self.root)
+        try:
+            return strategy_analyzer.scan_blog_articles("content/blog")
+        finally:
+            os.chdir(cwd)
+
+    def test_returns_clusters_with_zero_coverage_when_no_articles_match(self) -> None:
+        self._write(
+            "2026-01-01-something-else.mdx",
+            "title: 'Unrelated topic'\ndate: 2026-01-01\ntags: cooking, recipes",
+        )
+        articles = self._scan()
+        config = {
+            "cluster_keywords": {"Claude Code": ["claude code", "claude-code"]},
+            "saturation_thresholds": {"none": 0, "low": 1, "medium": 3},
+            "overlap_match_threshold": 0.4,
+        }
+        out = strategy_analyzer.build_content_overlap_analysis(articles, config)
+        self.assertEqual(len(out["clusters"]), 1)
+        self.assertEqual(out["clusters"][0]["coverage_count"], 0)
+        self.assertEqual(out["clusters"][0]["saturation"], "none")
+        self.assertEqual(out["clusters"][0]["coverage_articles"], [])
+
+    def test_marks_high_saturation_when_four_or_more_articles_cover_keyword(self) -> None:
+        for i in range(4):
+            self._write(
+                f"2026-01-0{i+1}-claude-code-{i}.mdx",
+                f"title: 'Claude Code 入門 {i}'\ndate: 2026-01-0{i+1}",
+            )
+        articles = self._scan()
+        config = {
+            "cluster_keywords": {"Claude Code": ["claude code"]},
+            "saturation_thresholds": {"none": 0, "low": 1, "medium": 3},
+            "overlap_match_threshold": 0.4,
+        }
+        out = strategy_analyzer.build_content_overlap_analysis(articles, config)
+        cluster = out["clusters"][0]
+        self.assertGreaterEqual(cluster["coverage_count"], 4)
+        self.assertEqual(cluster["saturation"], "high")
+
+    def test_match_score_is_in_zero_to_one_range_and_perfect_match_is_one(self) -> None:
+        self._write(
+            "2026-01-01-exact.mdx",
+            "title: 'claude code'\ndate: 2026-01-01",
+        )
+        articles = self._scan()
+        config = {
+            "cluster_keywords": {"Claude Code": ["claude code"]},
+            "overlap_match_threshold": 0.4,
+        }
+        out = strategy_analyzer.build_content_overlap_analysis(articles, config)
+        scores = [a["match_score"] for a in out["clusters"][0]["coverage_articles"]]
+        self.assertTrue(scores, "expected at least one matched article")
+        for s in scores:
+            self.assertGreaterEqual(s, 0.0)
+            self.assertLessEqual(s, 1.0)
+        self.assertAlmostEqual(max(scores), 1.0, places=2)
+
+    def test_matched_on_lists_only_fields_with_token_intersection(self) -> None:
+        self._write(
+            "2026-01-01-title-only.mdx",
+            "title: 'claude code 速習'\ndate: 2026-01-01\ntags: foo, bar",
+        )
+        self._write(
+            "2026-01-02-tags-only.mdx",
+            "title: 'AI ツール比較'\ndate: 2026-01-02\ntags: claude code, comparison",
+        )
+        articles = self._scan()
+        config = {
+            "cluster_keywords": {"Claude Code": ["claude code"]},
+            "overlap_match_threshold": 0.4,
+        }
+        out = strategy_analyzer.build_content_overlap_analysis(articles, config)
+        cov = {a["slug"]: a["matched_on"] for a in out["clusters"][0]["coverage_articles"]}
+        self.assertIn("title-only", cov)
+        self.assertIn("title", cov["title-only"])
+        self.assertNotIn("tags", cov["title-only"])
+        self.assertIn("tags-only", cov)
+        self.assertIn("tags", cov["tags-only"])
+
+    def test_threshold_overrides_from_config_change_saturation(self) -> None:
+        for i in range(2):
+            self._write(
+                f"2026-01-0{i+1}-claude-code-{i}.mdx",
+                f"title: 'Claude Code 入門 {i}'\ndate: 2026-01-0{i+1}",
+            )
+        articles = self._scan()
+        # default thresholds {none:0, low:1, medium:3} → 2 articles → "medium"
+        out_default = strategy_analyzer.build_content_overlap_analysis(
+            articles,
+            {
+                "cluster_keywords": {"Claude Code": ["claude code"]},
+                "saturation_thresholds": {"none": 0, "low": 1, "medium": 3},
+                "overlap_match_threshold": 0.4,
+            },
+        )
+        self.assertEqual(out_default["clusters"][0]["saturation"], "medium")
+        # tighter thresholds {none:0, low:0, medium:1} → 2 articles → "high"
+        out_strict = strategy_analyzer.build_content_overlap_analysis(
+            articles,
+            {
+                "cluster_keywords": {"Claude Code": ["claude code"]},
+                "saturation_thresholds": {"none": 0, "low": 0, "medium": 1},
+                "overlap_match_threshold": 0.4,
+            },
+        )
+        self.assertEqual(out_strict["clusters"][0]["saturation"], "high")
+
+    def test_match_threshold_filters_low_score_articles(self) -> None:
+        # KW = 3 tokens、article は KW のうち 1 トークンのみ含む → score = 1/3 ≈ 0.33
+        self._write(
+            "2026-01-01-partial.mdx",
+            "title: 'cli ツール紹介'\ndate: 2026-01-01",
+        )
+        articles = self._scan()
+        config_low = {
+            "cluster_keywords": {"Claude Code CLI": ["claude code cli"]},
+            "overlap_match_threshold": 0.3,
+        }
+        config_high = {
+            "cluster_keywords": {"Claude Code CLI": ["claude code cli"]},
+            "overlap_match_threshold": 0.5,
+        }
+        out_low = strategy_analyzer.build_content_overlap_analysis(articles, config_low)
+        out_high = strategy_analyzer.build_content_overlap_analysis(articles, config_high)
+        self.assertEqual(out_low["clusters"][0]["coverage_count"], 1)
+        self.assertEqual(out_high["clusters"][0]["coverage_count"], 0)
+
+    def test_japanese_keywords_match_via_bigram(self) -> None:
+        self._write(
+            "2026-01-01-shift.mdx",
+            "title: 'シフト管理アプリの選び方'\ndate: 2026-01-01",
+        )
+        articles = self._scan()
+        config = {
+            "cluster_keywords": {"シフト管理": ["シフト管理"]},
+            "overlap_match_threshold": 0.4,
+        }
+        out = strategy_analyzer.build_content_overlap_analysis(articles, config)
+        self.assertEqual(out["clusters"][0]["coverage_count"], 1)
+        self.assertEqual(
+            out["clusters"][0]["coverage_articles"][0]["slug"], "shift",
+        )
+
+    def test_keywords_field_in_frontmatter_is_used(self) -> None:
+        self._write(
+            "2026-01-01-via-keywords.mdx",
+            textwrap.dedent(
+                """\
+                title: 'Unrelated headline'
+                date: 2026-01-01
+                keywords:
+                  - claude code
+                  - cli
+                """
+            ).strip(),
+        )
+        articles = self._scan()
+        config = {
+            "cluster_keywords": {"Claude Code": ["claude code"]},
+            "overlap_match_threshold": 0.4,
+        }
+        out = strategy_analyzer.build_content_overlap_analysis(articles, config)
+        self.assertEqual(out["clusters"][0]["coverage_count"], 1)
+        matched_on = out["clusters"][0]["coverage_articles"][0]["matched_on"]
+        self.assertIn("keywords", matched_on)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skill-config.json
+++ b/skill-config.json
@@ -17,7 +17,13 @@
     "cluster_keywords": {},
     "unclustered_min_impressions": 20,
     "cluster_suggestion_min_impressions": 50,
-    "cluster_suggestion_top_n": 5
+    "cluster_suggestion_top_n": 5,
+    "saturation_thresholds": {
+      "none": 0,
+      "low": 1,
+      "medium": 3
+    },
+    "overlap_match_threshold": 0.4
   },
   "trends-analyzer": {
     "geo": "JP",


### PR DESCRIPTION
## 概要

`seo-strategy` skill の `new_article_directions` が**既に公開済みの記事と重複するテーマを新規記事として提案する**事故（[corporate-site#419](https://github.com/playpark-llc/corporate-site/issues/419) で 9 本中 5 本がカニバリ）を機械的に防ぐため、frontmatter ベースで KW × 全公開記事の重複を算出する `content_overlap_analysis` セクションを `strategy_analyzer.py` の出力に追加する。

Closes #69

## 構造的な原因への対応

3 層すべての弱点を以下のように補強:

| 層 | 既存の弱点 | 本 PR の補強 |
|---|---|---|
| データ収集 (`strategy_analyzer.py`) | `existing_articles` の生リストを LLM に渡すだけで、KW × 既存記事のマッピングがなかった | `build_content_overlap_analysis()` で各クラスタ KW に対する coverage 記事と saturation を機械的に算出 |
| 判定基準 (`analysis_guide.md`) | priority 表の「既存記事なし/不足」が LLM の主観判定。GSC 未反映の新着記事を見落とす | priority 表を `coverage_count` 駆動に変更（`>= 3` で skip） |
| レビュー (`devils-advocate.md`) | 項目6が optimization 候補に挙がった既存記事しか見ていなかった | 全件 `coverage_articles` チェックに拡張、`coverage_count >= 2` で `priority: high` を Blocking 化 |

加えて content-strategist agent の入力リストに `content_overlap_analysis` を追加し、CRITICAL ガードを `team-lifecycle.md` に明示。

## アルゴリズム

- **マッチング**: 各 KW × 各 article の `title` / `tags` / `description` / `keywords` 結合トークン集合に対して overlap coefficient `|A∩B| / min(|A|,|B|)` を算出
- **トークン化**: ASCII は既存 `_tokenize` を再利用、日本語は CJK 連続部分の文字 bigram で対応（MeCab 等の追加依存なし）
- **`matched_on`**: KW トークンが intersect する field 名のみ採用
- **saturation**: `coverage_count` を `none` / `low` / `medium` / `high` に分類。閾値は `seo-config.json` で外部化

## 受け入れ条件

- [x] `strategy_analyzer.py` が `content_overlap_analysis` を出力する
- [x] `seo-config.json` (`skill-config.json` 内) で saturation 閾値を外部化できる
- [x] `analysis_guide.md` の priority 表が coverage 駆動に更新される
- [x] `devils-advocate.md` の項目 6 が全件チェックに拡張される
- [x] content-strategist の入力ドキュメントに `content_overlap_analysis` が追加される
- [ ] corporate-site で再生成して issue#419 と同様のカニバリ提案が出ないことを検証
  - 別リポジトリでの実行のため、検証手順を `references/analysis_guide.md` の `Validation: content_overlap_analysis` セクションに記載済み

## テスト

`ContentOverlapAnalysisTest` を新規追加（8 ケース、全 13 tests pass）:

- `test_returns_clusters_with_zero_coverage_when_no_articles_match`
- `test_marks_high_saturation_when_four_or_more_articles_cover_keyword`
- `test_match_score_is_in_zero_to_one_range_and_perfect_match_is_one`
- `test_matched_on_lists_only_fields_with_token_intersection`
- `test_threshold_overrides_from_config_change_saturation`
- `test_match_threshold_filters_low_score_articles`
- `test_japanese_keywords_match_via_bigram`
- `test_keywords_field_in_frontmatter_is_used`

```
$ python3 -m unittest seo-strategy.scripts.test_strategy_analyzer
Ran 13 tests in 0.024s
OK
```

## Test plan

- [x] `python3 -m unittest seo-strategy.scripts.test_strategy_analyzer -v` が全 pass
- [x] `python3 -c "import json; json.load(open('skill-config.json'))['seo-strategy']['saturation_thresholds']"` で config が valid
- [x] smoke test で `build_content_overlap_analysis` が期待通りの構造を返すことを確認
- [ ] (フォローアップ) corporate-site で `python3 seo-strategy/scripts/strategy_analyzer.py --config seo-config.json --gsc-report ... --output ...` を実行し、`high` saturation クラスタに対して `priority: high` の new_article_directions が生成されないことを目視確認

## 関連

- corporate-site issue: playpark-llc/corporate-site#419
- 親 issue: playpark-llc/corporate-site#416