### PR TITLE
fix(blog-mv-date): seed/articles.json 更新漏れ防止の検証ステップを追加

### DIFF
--- a/blog-mv-date/SKILL.md
+++ b/blog-mv-date/SKILL.md
@@ -27,6 +27,18 @@ model: haiku
 | dest-date  | 移動先の日付 (`YYYY-MM-DD`)             |
 | --dry-run  | 変更内容を表示するのみ                  |
 
+## Files to Update（必ず全て対象）
+
+| File                                  | 内容                          |
+| ------------------------------------- | ----------------------------- |
+| `content/blog/<date>-<slug>.mdx`      | リネーム + frontmatter        |
+| `public/blog/<date>-<slug>.webp`      | リネーム                      |
+| `post/blog/<date>-<slug>.json`        | リネーム + schedule 日付更新  |
+| `seed/*/articles.json`                | path 更新（★忘れがち）        |
+
+**重要**: 必ず `move-date.sh` を実行する。手動 mv / sed で個別に処理しない。
+過去に articles.json の更新漏れが発生したため、Step 6 で残存検証を行う。
+
 ## Workflow
 
 ### Step 1: 記事の特定
@@ -54,13 +66,18 @@ bash $SKILLS_DIR/blog-mv-date/scripts/move-date.sh <path> <dest-date> --dry-run
 bash $SKILLS_DIR/blog-mv-date/scripts/move-date.sh <path> <dest-date>
 ```
 
-### Step 5: ビルド検証
+### Step 5: 残存検証
+
+`move-date.sh` の Step 6 が seed/ に旧 `<old-date>-<slug>` 文字列が残っていないかを自動検証する。
+失敗した場合は exit 1 で止まるので、表示されるパスを手動で修正してから次のステップに進む。
+
+### Step 6: ビルド検証
 
 ```bash
 npm run build
 ```
 
-### Step 6: Zernio API（旧Late）手順表示
+### Step 7: Zernio API（旧Late）手順表示
 
 Zernio API（旧Late）に既存スケジュールがある場合、手動変更手順を提示：
 

--- a/blog-mv-date/scripts/move-date.sh
+++ b/blog-mv-date/scripts/move-date.sh
@@ -113,6 +113,11 @@ update_seed() {
     # Find seed files containing this article
     local seed_files=$(grep -rl "$old_relative" "$seed_abs" 2>/dev/null || true)
 
+    if [[ -z "$seed_files" ]]; then
+        log "Warning: no seed files reference $old_relative (skipping seed update)"
+        return
+    fi
+
     for seed_file in $seed_files; do
         if [[ -z "$seed_file" ]]; then continue; fi
 
@@ -260,6 +265,19 @@ fi
 # Step 5: Update seed files
 log "Step 5: Updating seed files..."
 update_seed "$ARTICLE" "$NEW_MDX" "$OLD_DATE" "$DEST_DATE"
+
+# Step 6: Verify no stale references remain in seed/
+if [[ "$DRY_RUN" != "true" ]]; then
+    log "Step 6: Verifying no stale references..."
+    SEED_ABS="$PROJECT_ROOT/$SEED_DIR"
+    STALE=$(grep -rl "${OLD_DATE}-${SLUG}" "$SEED_ABS" 2>/dev/null || true)
+    if [[ -n "$STALE" ]]; then
+        echo "Error: stale references to ${OLD_DATE}-${SLUG} still remain in:" >&2
+        echo "$STALE" >&2
+        echo "Manual fix required before commit." >&2
+        exit 1
+    fi
+fi
 
 # Output summary
 cat << EOF


### PR DESCRIPTION
## Summary

- `move-date.sh` に Step 6（残存検証）を追加: 旧 `<old-date>-<slug>` 文字列が `seed/` に残っていれば exit 1 で停止
- `update_seed` の grep が空ヒット時に warning ログを出力（従来は silent）
- `SKILL.md` に対象ファイル一覧（articles.json含む）と「`move-date.sh` 必須」を明記

## Why

playpark/corporate-site の記事 `2026-05-14` → `2026-05-05` 移動時、`context: fork + haiku` のサブエージェントがスクリプトを使わず手動で MDX / SNS post JSON / 画像のみ更新し、`seed/it-all-playpark-skills/articles.json` の path 更新を漏らした事例があった。スクリプト自体は articles.json を更新できるが、サブエージェントが script 経由でなく手動オペした場合に検出機能が無かった。

## Test plan

- [x] `move-date.sh --dry-run` が articles.json の更新を正しく検出することを確認
- [x] Step 6 の検証ロジックが `OLD_DATE-SLUG` 文字列の残存を grep する動作を確認
- [ ] 実際の `/blog-mv-date` 経由で articles.json まで更新されることを次回利用時に確認