### PR TITLE
feat(dev-flow): Phase 0 に read-only preflight を追加

### DIFF
--- a/dev-flow/SKILL.md
+++ b/dev-flow/SKILL.md
@@ -59,7 +59,7 @@ dev-flow <issue>
 ## Phase 0: Preflight (Always, Read-Only)
 
 ```bash
-$SKILLS_DIR/dev-flow/scripts/preflight.sh $ISSUE [--strict|--warn-only]
+$SKILLS_DIR/dev-flow/scripts/preflight.sh $ISSUE [--strict|--warn-only] [--repo OWNER/REPO]
 ```
 
 Read-only verification before mode decision. Runs **once** at the top of dev-flow (single / parallel どちらでも 1 回のみ)。
@@ -68,7 +68,11 @@ Checks:
 - `gh auth` valid
 - Issue `$ISSUE` exists and is `OPEN` (closed/merged は warning)
 
-Defaults to `--warn-only` — emit warnings to JSON, exit 0, dev-flow continues. Use `--strict` only when the user explicitly requests halt-on-failure semantics.
+Options:
+- `--warn-only` (default) / `--strict` — failure handling mode
+- `--repo OWNER/REPO` — query a different repo (default: current repo from `gh repo view`)
+
+`--preflight-mode` の値はそのまま script フラグに対応する（`warn-only` → `--warn-only`、`strict` → `--strict`）。
 
 | Outcome | Behavior |
 |---------|----------|

--- a/dev-flow/SKILL.md
+++ b/dev-flow/SKILL.md
@@ -41,6 +41,8 @@ End-to-end development automation from issue to LGTM (merge manually).
 ```
 dev-flow <issue>
 │
+├─→ Phase 0: preflight (issue exists & open, gh auth)
+│
 ├─→ Step 0: dev-issue-analyze --depth standard
 │
 ├─→ Step 1: Mode Decision
@@ -53,6 +55,31 @@ dev-flow <issue>
 ├─→ [Single]   Steps 2a-4a → details: references/single-mode.md
 └─→ [Parallel] Steps 2b-8b → details: references/parallel-mode.md
 ```
+
+## Phase 0: Preflight (Always, Read-Only)
+
+```bash
+$SKILLS_DIR/dev-flow/scripts/preflight.sh $ISSUE [--strict|--warn-only]
+```
+
+Read-only verification before mode decision. Runs **once** at the top of dev-flow (single / parallel どちらでも 1 回のみ)。
+
+Checks:
+- `gh auth` valid
+- Issue `$ISSUE` exists and is `OPEN` (closed/merged は warning)
+
+Defaults to `--warn-only` — emit warnings to JSON, exit 0, dev-flow continues. Use `--strict` only when the user explicitly requests halt-on-failure semantics.
+
+| Outcome | Behavior |
+|---------|----------|
+| All checks pass | Continue to Step 0 |
+| Warnings only (e.g., closed issue) | Show warnings, continue |
+| Errors + `--warn-only` (default) | Show errors, continue (let downstream surface real failure) |
+| Errors + `--strict` | Halt with exit 10 (issue) or 11 (gh auth) |
+
+**git-prepare は呼ばない**: worktree 作成は `dev-kickoff` Phase 1 / `dev-decompose` の責務。Phase 0 は read-only に徹する。
+
+**`--task-id` 経由で起動された dev-kickoff には preflight は走らない**（dev-flow を経由しないため）。これは意図的な設計で、parallel subtask は flow.json で前提が既に確定しているため重複検証不要。
 
 ## Step 0: Issue Analysis (Always)
 
@@ -104,7 +131,7 @@ Details: [Parallel Mode](references/parallel-mode.md) -- decomposition, batch sc
 ## Usage
 
 ```
-/dev-flow <issue> [--testing tdd] [--design ddd] [--depth comprehensive] [--base dev] [--max-iterations 10] [--force-single] [--force-parallel]
+/dev-flow <issue> [--testing tdd] [--design ddd] [--depth comprehensive] [--base dev] [--max-iterations 10] [--force-single] [--force-parallel] [--preflight-mode warn-only|strict]
 ```
 
 ## Args
@@ -121,6 +148,7 @@ Details: [Parallel Mode](references/parallel-mode.md) -- decomposition, batch sc
 | `--force-single` | - | Skip auto-detect, force single mode |
 | `--force-parallel` | - | Skip auto-detect, force parallel mode |
 | `--parallel` | - | **Deprecated**: alias for `--force-parallel` |
+| `--preflight-mode` | `warn-only` | Phase 0 mode: `warn-only` (continue on errors) or `strict` (halt on errors) |
 
 ## Completion Conditions
 

--- a/dev-flow/scripts/preflight.sh
+++ b/dev-flow/scripts/preflight.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# preflight.sh - Verify dev-flow prerequisites before mode decision
+# Read-only checks: issue exists & open, gh auth valid
+# Does NOT call git-prepare or modify any state
+#
+# Usage: preflight.sh <issue-number> [--strict|--warn-only] [--repo OWNER/REPO]
+#
+# Exit codes:
+#   0  = all checks passed (or --warn-only with warnings)
+#   1  = generic failure
+#   10 = issue check failed (--strict only)
+#   11 = gh auth check failed (--strict only)
+#
+# Output: single-line JSON to stdout
+#   {"status":"ok|warn|error","mode":"strict|warn-only","checks":{...},"warnings":[...],"errors":[...]}
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+ISSUE_NUMBER=""
+MODE="warn-only"
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --strict) MODE="strict"; shift ;;
+        --warn-only) MODE="warn-only"; shift ;;
+        --repo) REPO="$2"; shift 2 ;;
+        -h|--help)
+            cat <<EOF
+Usage: preflight.sh <issue-number> [--strict|--warn-only] [--repo OWNER/REPO]
+
+Read-only verification of dev-flow prerequisites.
+
+Options:
+  --warn-only  (default) emit warnings but exit 0
+  --strict     exit non-zero on any failure
+  --repo       override repository (default: current repo)
+EOF
+            exit 0
+            ;;
+        -*) die_json "Unknown option: $1" 1 ;;
+        *)
+            [[ -z "$ISSUE_NUMBER" ]] && ISSUE_NUMBER="$1"
+            shift
+            ;;
+    esac
+done
+
+[[ -z "$ISSUE_NUMBER" ]] && die_json "Issue number required" 1
+[[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]] || die_json "Issue number must be numeric: $ISSUE_NUMBER" 1
+
+WARNINGS=()
+ERRORS=()
+GH_AUTH_OK=false
+ISSUE_EXISTS=false
+ISSUE_OPEN=false
+ISSUE_TITLE=""
+ISSUE_STATE=""
+
+# ----------------------------------------------------------------------------
+# Check 1: gh auth
+# ----------------------------------------------------------------------------
+if ! command -v gh &>/dev/null; then
+    ERRORS+=("gh CLI not installed (brew install gh)")
+elif gh auth token &>/dev/null; then
+    GH_AUTH_OK=true
+else
+    ERRORS+=("gh CLI not authenticated (run: gh auth login)")
+fi
+
+# ----------------------------------------------------------------------------
+# Check 2: issue exists & open
+# Skipped if gh auth failed (cannot query without auth)
+# ----------------------------------------------------------------------------
+if [[ "$GH_AUTH_OK" == true ]]; then
+    GH_ARGS=(issue view "$ISSUE_NUMBER" --json state,title)
+    [[ -n "$REPO" ]] && GH_ARGS+=(--repo "$REPO")
+
+    if ISSUE_JSON=$(gh "${GH_ARGS[@]}" 2>/dev/null); then
+        ISSUE_EXISTS=true
+        ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state // ""')
+        ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // ""')
+        if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+            ISSUE_OPEN=true
+        else
+            WARNINGS+=("Issue #$ISSUE_NUMBER is $ISSUE_STATE (not OPEN)")
+        fi
+    else
+        ERRORS+=("Issue #$ISSUE_NUMBER not found or inaccessible")
+    fi
+else
+    WARNINGS+=("Issue check skipped due to gh auth failure")
+fi
+
+# ----------------------------------------------------------------------------
+# Compose result
+# ----------------------------------------------------------------------------
+HAS_ERRORS=$([ ${#ERRORS[@]} -gt 0 ] && echo true || echo false)
+HAS_WARNINGS=$([ ${#WARNINGS[@]} -gt 0 ] && echo true || echo false)
+
+if [[ "$HAS_ERRORS" == true ]]; then
+    STATUS="error"
+elif [[ "$HAS_WARNINGS" == true ]]; then
+    STATUS="warn"
+else
+    STATUS="ok"
+fi
+
+# Build JSON output
+warnings_json=$(printf '%s\n' "${WARNINGS[@]:-}" | jq -R . | jq -s 'map(select(. != ""))')
+errors_json=$(printf '%s\n' "${ERRORS[@]:-}" | jq -R . | jq -s 'map(select(. != ""))')
+
+jq -n \
+    --arg status "$STATUS" \
+    --arg mode "$MODE" \
+    --arg issue "$ISSUE_NUMBER" \
+    --arg issue_title "$ISSUE_TITLE" \
+    --arg issue_state "$ISSUE_STATE" \
+    --argjson gh_auth_ok "$GH_AUTH_OK" \
+    --argjson issue_exists "$ISSUE_EXISTS" \
+    --argjson issue_open "$ISSUE_OPEN" \
+    --argjson warnings "$warnings_json" \
+    --argjson errors "$errors_json" \
+    '{
+        status: $status,
+        mode: $mode,
+        checks: {
+            gh_auth: $gh_auth_ok,
+            issue_exists: $issue_exists,
+            issue_open: $issue_open,
+            issue_state: $issue_state,
+            issue_title: $issue_title,
+            issue: ($issue | tonumber)
+        },
+        warnings: $warnings,
+        errors: $errors
+    }'
+
+# ----------------------------------------------------------------------------
+# Exit code
+# ----------------------------------------------------------------------------
+if [[ "$MODE" == "strict" && "$HAS_ERRORS" == true ]]; then
+    if [[ "$GH_AUTH_OK" != true ]]; then
+        exit 11
+    else
+        exit 10
+    fi
+fi
+
+exit 0

--- a/dev-flow/scripts/preflight.sh
+++ b/dev-flow/scripts/preflight.sh
@@ -7,12 +7,14 @@
 #
 # Exit codes:
 #   0  = all checks passed (or --warn-only with warnings)
-#   1  = generic failure
+#   1  = CLI-level failure (missing/invalid arg, unknown option) — JSON to stderr
 #   10 = issue check failed (--strict only)
 #   11 = gh auth check failed (--strict only)
 #
-# Output: single-line JSON to stdout
-#   {"status":"ok|warn|error","mode":"strict|warn-only","checks":{...},"warnings":[...],"errors":[...]}
+# Output:
+#   - Success / warn / strict-failure: structured JSON to stdout
+#       {"status":"ok|warn|error","mode":"strict|warn-only","checks":{...},"warnings":[...],"errors":[...]}
+#   - CLI-level failure (exit 1): error JSON to stderr via die_json (common.sh)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

dev-flow の最上段に **read-only な preflight Phase 0** を追加し、issue 不在 / gh 認証切れによる中盤での停止を未然に回避する。

### 背景
直近 18 日間の usage-data report で、dev-flow 起動後に「対象 issue が存在しない」「gh auth が切れていた」等の理由でパイプライン中盤が停止する事例が複数記録されていた。後段で同じ理由により失敗するなら、最上段で事前検出し fail-fast したほうがコストが低い。

### 設計方針
- **read-only に徹する**: git-prepare は呼ばない。worktree 作成は dev-kickoff Phase 1 / dev-decompose の責務のまま
- **デフォルト --warn-only で既存フロー破壊ゼロ**: errors があっても dev-flow は継続し、後段で同じ理由で失敗する従来挙動を保持
- **--strict はオプトイン**: 明示指定時のみ halt（exit 10: issue, exit 11: gh auth）
- **closed/merged issue は warning 扱い**: halt しない（reopen 等の意図的シナリオを尊重）
- **`--task-id` 経由の dev-kickoff には走らない**: parallel subtask は flow.json で前提が確定済みのため重複検証不要

### 変更点
- 新規: `dev-flow/scripts/preflight.sh` (5 KB, executable, read-only)
- 修正: `dev-flow/SKILL.md` に Phase 0 セクション追加 / Args テーブルに `--preflight-mode` 追加 / Usage 例更新

## Test plan

- [x] real OPEN issue → status:ok / exit 0
- [x] real CLOSED issue → status:warn / exit 0（--strict でも warn 扱い）
- [x] non-existent issue (--warn-only) → status:error / exit 0
- [x] non-existent issue (--strict) → status:error / exit 10
- [x] non-numeric issue → exit 1
- [x] missing arg → exit 1
- [x] --repo flag でクロスリポジトリ issue 参照可能
- [ ] 実際の dev-flow 経由起動で既存挙動が変わらないこと（マージ後に手元で確認）

Refs: usage-data report 2026-04-18~05-08