### PR TITLE
refactor(dev-decompose): worker subagent ベースに移行 (#81)

### DIFF
--- a/dev-decompose/SKILL.md
+++ b/dev-decompose/SKILL.md
@@ -28,9 +28,7 @@ Decompose large issues into parallel subtasks with file-boundary isolation. Crea
 - Dispatch `dev-kickoff-worker` subagent (`isolation: worktree`) for each subtask to create its worktree from the contract branch
 - Generate flow.json with subtask definitions (including `branch` field), checklists, and contract info
 
-## Workflow
-
-### Full Execution (default)
+## Workflow (Full Execution, default)
 
 ```
 1. Read issue analysis (from dev-issue-analyze output or issue body)
@@ -46,65 +44,7 @@ Decompose large issues into parallel subtasks with file-boundary isolation. Crea
 10. Validate decomposition (validate-decomposition.sh)
 ```
 
-### Dry-Run Mode (`--dry-run`)
-
-Lightweight mode that executes only Steps 1-4 (analysis and file grouping) without creating branches, worktrees, or flow.json. Used by dev-flow for auto-detect mode selection.
-
-```
-1. Read issue analysis (from dev-issue-analyze output or issue body)
-2. Identify affected files and dependencies
-2b. Read past integration feedback via analyze-past-conflicts.sh
-    (files + directory prefixes that recurred in previous conflicts)
-3. Group files into subtasks (no file overlap), biasing files flagged by
-   step 2b toward the same subtask when possible
-4. Apply fallback criteria (see Decomposition Guide)
-→ Return assessment JSON (no side effects). The dry-run JSON includes a
-  `past_conflict_hints` field with the analyzer output for observability.
-```
-
-**Reading past feedback**:
-
-```bash
-$SKILLS_DIR/dev-decompose/scripts/analyze-past-conflicts.sh \
-  --affected-files "src/types/user.ts,src/api/auth.ts,..." \
-  --limit 50 --min-occurrences 2
-```
-
-Output shape (informational, decomposer LLM makes the final call):
-
-```jsonc
-{
-  "has_hints": true,
-  "scanned_events": 42,
-  "recurring_files": [
-    {"file": "src/types/user.ts", "occurrences": 3,
-     "lessons": ["同じ types/ 配下は 1 subtask にまとめるべき"]}
-  ],
-  "recurring_prefixes": [
-    {"prefix": "src/types", "occurrences": 4}
-  ]
-}
-```
-
-See [`_shared/references/integration-feedback.md`](../_shared/references/integration-feedback.md)
-for the pub/sub pattern and how events are written by `dev-integrate`.
-
-Dry-run output:
-```json
-// single_fallback
-{"status": "single_fallback", "reason": "Fewer than 4 affected files", "file_count": 2}
-
-// ready for parallel
-{"status": "ready", "subtask_count": 3, "file_groups": [
-  {"id": "task1", "files": ["src/models/user.ts", "src/models/user.test.ts"]},
-  {"id": "task2", "files": ["src/routes/auth.ts", "src/middleware/jwt.ts"]}
-]}
-```
-
-To continue from dry-run to full execution, pass the dry-run result path:
-```bash
-Skill: dev-decompose $ISSUE --resume /path/to/dry-run-result.json --base $BASE
-```
+Dry-run mode (`--dry-run`) executes Steps 1-4 only; see [Dry-Run Mode](references/dry-run.md).
 
 ### Step 1-4: Analysis & File Grouping
 
@@ -119,10 +59,7 @@ Generate contract per [Decomposition Guide](references/decomposition-guide.md). 
 ```bash
 # Step 6: contract worktree 作成（--local でリモート push を防止）
 $SKILLS_DIR/git-prepare/scripts/git-prepare.sh $ISSUE \
-  --suffix contract \
-  --base $BASE \
-  --env-mode $ENV_MODE \
-  --local
+  --suffix contract --base $BASE --env-mode $ENV_MODE --local
 
 # Step 7: contract worktree 内でファイル作成・コミット
 cd $CONTRACT_WORKTREE
@@ -131,66 +68,20 @@ cd $CONTRACT_WORKTREE
 
 ### Step 8: Subtask Worktree Creation (worker subagent dispatch)
 
-For each subtask, spawn a `dev-kickoff-worker` subagent in `isolation: worktree` mode based on the contract branch. The worker creates its own branch (`feature/issue-${ISSUE}-task${INDEX}`) inside the isolated worktree and returns the resulting `branch` / `worktree_path` / `commit_sha`.
+For each subtask, spawn a `dev-kickoff-worker` subagent in `isolation: worktree` mode based on the contract branch. The worker creates its own branch (`feature/issue-${ISSUE}-task${INDEX}`) inside the isolated worktree and returns `{status, branch, worktree_path, commit_sha}`.
 
-```text
-Agent(
-  subagent_type: "dev-kickoff-worker",
-  isolation: "worktree",
-  prompt: "
-    issue_number: $ISSUE
-    branch_name: feature/issue-${ISSUE}-task${INDEX}
-    base_ref: feature/issue-${ISSUE}-contract
-    mode: parallel
-    task_id: task${INDEX}
-    flow_state: $FLOW_STATE
-  "
-)
-```
+Direct `git worktree add` and direct `git-prepare.sh --suffix task...` calls are **prohibited** for subtask worktrees. Subtask/contract ブランチはリモートに push しない。
 
-The worker dispatch replaces the previous direct `git-prepare` invocation. Direct `git worktree add` and direct `git-prepare.sh --suffix task...` calls are **prohibited** for subtask worktrees.
-
-**Requirements**:
-- Claude Code >= 2.1.63 (`isolation: worktree` field support)
-- `.claude/agents/dev-kickoff-worker.md` present in the repo
-
-**Subtask/contract ブランチはリモートに push しない。** push が必要なのは最終的な merge ブランチのみ（PR 作成時）。worker は parallel mode で `git push` をスキップする。
+Details (Agent call shape, 5-element dispatch rules, constraints): [Worker Dispatch](references/worker-dispatch.md).
 
 ### Step 9: Flow State Generation
 
-Initialize flow.json:
 ```bash
 $SKILLS_DIR/dev-decompose/scripts/init-flow.sh $ISSUE \
-  --flow-state $FLOW_STATE \
-  --base $BASE \
-  --env-mode $ENV_MODE
+  --flow-state $FLOW_STATE --base $BASE --env-mode $ENV_MODE
 ```
 
-Then populate each subtask entry with:
-
-- `id` — `task1`, `task2`, ... (stable across reruns)
-- `scope` — short description of the subtask
-- `files` — array of file paths owned by this subtask
-- **`branch` — required (flow.json v2 schema).** Use the branch name returned by the `dev-kickoff-worker` dispatch in Step 8 (typically `feature/issue-${ISSUE}-task${INDEX}`). validate-decomposition.sh rejects empty/missing `branch`.
-- `status` — `pending`
-- `checklist` — at least 1 item per subtask
-- `depends_on` — array of other subtask `id`s (optional)
-- `worktree_path` — absolute path returned by the worker
-
-Example subtask entry:
-
-```jsonc
-{
-  "id": "task1",
-  "scope": "src/models/user types and tests",
-  "files": ["src/models/user.ts", "src/models/user.test.ts"],
-  "branch": "feature/issue-${ISSUE}-task1",
-  "worktree_path": "/abs/path/to/skills-worktrees/feature-issue-${ISSUE}-task1",
-  "status": "pending",
-  "checklist": [{"item": "Define User type", "done": false}],
-  "depends_on": []
-}
-```
+Populate each subtask entry with `id` / `scope` / `files` / **`branch` (required, v2 schema — populated from worker return)** / `status` / `checklist` / `depends_on` / `worktree_path`. See [flow.schema.json](../_lib/schemas/flow.schema.json) for the full schema.
 
 ### Step 10: Validation
 
@@ -198,11 +89,11 @@ Example subtask entry:
 $SKILLS_DIR/_lib/scripts/validate-decomposition.sh --flow-state $FLOW_STATE
 ```
 
-Additionally verify manually: contract branch exists and has commits, all worktree paths exist on disk.
+Also verify manually: contract branch exists with commits, all worktree paths exist on disk.
 
 ## Decomposition Rules
 
-See [Decomposition Guide](references/decomposition-guide.md) for rules (file exclusivity, test co-location, contract isolation, coupling), edge cases, and examples.
+See [Decomposition Guide](references/decomposition-guide.md) for file exclusivity, test co-location, contract isolation, coupling rules, edge cases, and examples.
 
 ## Contract Branch Pattern
 
@@ -216,7 +107,7 @@ main --> feature/issue-{N}-contract (dev-decompose commits shared types)
 
 ## Fallback
 
-If decomposition yields 1 subtask, return fallback (see [Decomposition Guide](references/decomposition-guide.md) for criteria):
+If decomposition yields 1 subtask (see [Decomposition Guide](references/decomposition-guide.md) for criteria):
 
 ```json
 {"status": "single_fallback", "subtask_count": 1, "reason": "All files are tightly coupled"}
@@ -237,45 +128,13 @@ When `--flow-state` is `auto`, the path defaults to `$WORKTREE_BASE/.claude/flow
 
 ## Output
 
-### Full Execution
+Full execution creates flow.json at `$WORKTREE_BASE/.claude/flow.json` and returns:
 
-flow.json is created at `$WORKTREE_BASE/.claude/flow.json`.
-
-Structure: `{ version, issue, status, subtasks[], contract, config, created_at, updated_at }`
-
-See [flow.schema.json](../_lib/schemas/flow.schema.json) for full schema.
-
-Return value:
 ```json
 {"status": "decomposed|single_fallback", "subtask_count": N, "flow_state": "/path/to/flow.json"}
 ```
 
-### Dry-Run
-
-No files created on disk. Return value only:
-```json
-// Ready for parallel
-{
-  "status": "ready",
-  "subtask_count": N,
-  "file_groups": [{"id": "taskN", "files": ["..."]}],
-  "past_conflict_hints": {
-    "has_hints": true,
-    "scanned_events": 42,
-    "recurring_files": [{"file": "src/types/user.ts", "occurrences": 3, "lessons": ["..."]}],
-    "recurring_prefixes": [{"prefix": "src/types", "occurrences": 4}]
-  }
-}
-
-// Fallback to single
-{"status": "single_fallback", "reason": "<criteria from Decomposition Guide>", "file_count": N, "past_conflict_hints": {...}}
-```
-
-`past_conflict_hints` is populated by
-`dev-decompose/scripts/analyze-past-conflicts.sh` reading
-`_shared/integration-feedback.json`. If the feedback file is missing or
-empty, the field has `{"has_hints": false, ...}` and decomposition proceeds
-normally.
+Dry-run returns assessment JSON only (no files created); see [Dry-Run Mode](references/dry-run.md).
 
 ## Error Handling
 
@@ -289,33 +148,22 @@ normally.
 
 ## Subagent Dispatch Rules
 
-dev-decompose は Step 8 で **subtask 数ぶんの `dev-kickoff-worker` subagent** を `Agent(isolation: worktree)` で起動する。共通規約 ([`_shared/references/subagent-dispatch.md`](../_shared/references/subagent-dispatch.md)) の必須5要素を遵守する。
+dev-decompose は Step 8 で **subtask 数ぶんの `dev-kickoff-worker` subagent** を `Agent(isolation: worktree)` で起動する。共通規約 ([`_shared/references/subagent-dispatch.md`](../_shared/references/subagent-dispatch.md)) の必須5要素を遵守する:
 
-### Step 8: Agent(dev-kickoff-worker, isolation: worktree) — per subtask
+- **Objective** — contract branch をベースに subtask 用 isolated worktree を作成し `{status, branch, worktree_path, commit_sha}` を返す (Phase 1 のみ)
+- **Output format** — `{status, branch, worktree_path, commit_sha, phase_failed?, error?}` JSON (worker last-line contract)
+- **Tools** — worker frontmatter で許可 (Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep)。追加制約は付けない
+- **Boundary** — isolated worktree 内のみ作業、`git push` 禁止 (parallel mode)、subtask 外 branch 不可、`git worktree add` 直接実行禁止
+- **Token cap** — worker 1 回あたり 2000 turn 以内、Step 8 全体で subtask 数 ≤ 5 推奨
 
-1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに subtask `task${INDEX}` 用の branch `feature/issue-${ISSUE}-task${INDEX}` を isolated worktree で作成し、`{status, branch, worktree_path, commit_sha}` を返す」（Phase 1 のみ。Phase 2-7 は dev-kickoff から `--task-id` で再呼び出し）
-2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, phase_failed?: string, error?: string }` JSON（worker の last-line JSON contract）
-3. **Tools** — worker frontmatter で許可: Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep。dev-decompose 側から追加 tool 制約は付けない
-4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止（parallel mode）、subtask 外の branch 触らない、`git worktree add` を直接実行しない
-5. **Token cap** — worker 1 回あたり 2000 turn 以内（dev-kickoff-worker.md 既定）、Step 8 全体で subtask 数 ≤ 5 を推奨
-
-### Routing
-
-- subtask worktree 作成 → `dev-kickoff-worker` (sonnet, isolation: worktree)
-- 通常の探索 / planning は dev-decompose 自身（opus, effort: max）で行う
-
-詳細・チェックリスト: [Subagent Dispatch Rules（共通）](../_shared/references/subagent-dispatch.md)
+詳細・チェックリストは [Worker Dispatch](references/worker-dispatch.md) を参照。
 
 ## Journal Logging
 
 On completion, log execution to skill-retrospective journal:
 
 ```bash
-# On success (flow.json created)
-$SKILLS_DIR/skill-retrospective/scripts/journal.sh log dev-decompose success \
-  --issue $ISSUE --duration-turns $TURNS
-
-# On single_fallback (dry-run determined single mode)
+# On success (flow.json created, or single_fallback)
 $SKILLS_DIR/skill-retrospective/scripts/journal.sh log dev-decompose success \
   --issue $ISSUE --duration-turns $TURNS
 
@@ -327,7 +175,9 @@ $SKILLS_DIR/skill-retrospective/scripts/journal.sh log dev-decompose failure \
 ## References
 
 - [Decomposition Guide](references/decomposition-guide.md) - Detailed strategy and edge cases
+- [Dry-Run Mode](references/dry-run.md) - --dry-run mode, past_conflict_hints, resume
+- [Worker Dispatch](references/worker-dispatch.md) - Step 8 Agent call, 5-element dispatch rules
 - [dev-kickoff-worker](../.claude/agents/dev-kickoff-worker.md) - Subagent that creates each subtask worktree (Step 8)
-- [git-prepare](../git-prepare/SKILL.md) - Contract worktree creation (Step 6-7 only; subtask worktrees now route through dev-kickoff-worker)
+- [git-prepare](../git-prepare/SKILL.md) - Contract worktree creation (Step 6-7 only; subtask worktrees route through dev-kickoff-worker)
 - [dev-issue-analyze](../dev-issue-analyze/SKILL.md) - Issue analysis input
 - [dev-kickoff](../dev-kickoff/SKILL.md) - Per-subtask execution (parallel mode, `--task-id`)

--- a/dev-decompose/SKILL.md
+++ b/dev-decompose/SKILL.md
@@ -9,6 +9,7 @@ description: |
 allowed-tools:
   - Bash
   - Task
+  - Agent
 model: opus
 effort: max
 ---
@@ -24,8 +25,8 @@ Decompose large issues into parallel subtasks with file-boundary isolation. Crea
 - Split work into non-conflicting subtasks at file boundaries
 - Define `depends_on` relationships between subtasks
 - Generate shared contract (types/interfaces) committed to a contract branch
-- Create N worktrees via git-prepare (base: contract branch, suffix: task1, task2, ...)
-- Generate flow.json with subtask definitions, checklists, and contract info
+- Dispatch `dev-kickoff-worker` subagent (`isolation: worktree`) for each subtask to create its worktree from the contract branch
+- Generate flow.json with subtask definitions (including `branch` field), checklists, and contract info
 
 ## Workflow
 
@@ -37,10 +38,11 @@ Decompose large issues into parallel subtasks with file-boundary isolation. Crea
 3. Group files into subtasks (no file overlap)
 4. Define checklist for each subtask
 5. Generate shared contract (interfaces/types if needed)
-6. Create contract branch from base
+6. Create contract worktree from base (orchestrator-local, see Step 5-7)
 7. Commit contract files to contract branch
-8. Create worktrees for each subtask (git-prepare --base contract-branch --suffix taskN)
-9. Generate flow.json
+8. Dispatch dev-kickoff-worker subagent (isolation: worktree) per subtask
+   to create its branch (feature/issue-${N}-task${INDEX}) from the contract branch
+9. Generate flow.json (populating subtask.branch returned by each worker)
 10. Validate decomposition (validate-decomposition.sh)
 ```
 
@@ -127,18 +129,32 @@ cd $CONTRACT_WORKTREE
 # ... create contract files, git add, git commit ...
 ```
 
-### Step 8: Worktree Creation
+### Step 8: Subtask Worktree Creation (worker subagent dispatch)
 
-For each subtask, call git-prepare with `--local` to keep branches local:
-```bash
-$SKILLS_DIR/git-prepare/scripts/git-prepare.sh $ISSUE \
-  --suffix task${INDEX} \
-  --base feature/issue-${ISSUE}-contract \
-  --env-mode $ENV_MODE \
-  --local
+For each subtask, spawn a `dev-kickoff-worker` subagent in `isolation: worktree` mode based on the contract branch. The worker creates its own branch (`feature/issue-${ISSUE}-task${INDEX}`) inside the isolated worktree and returns the resulting `branch` / `worktree_path` / `commit_sha`.
+
+```text
+Agent(
+  subagent_type: "dev-kickoff-worker",
+  isolation: "worktree",
+  prompt: "
+    issue_number: $ISSUE
+    branch_name: feature/issue-${ISSUE}-task${INDEX}
+    base_ref: feature/issue-${ISSUE}-contract
+    mode: parallel
+    task_id: task${INDEX}
+    flow_state: $FLOW_STATE
+  "
+)
 ```
 
-**Subtask/contract ブランチはリモートに push しない。** push が必要なのは最終的な merge ブランチのみ（PR 作成時）。
+The worker dispatch replaces the previous direct `git-prepare` invocation. Direct `git worktree add` and direct `git-prepare.sh --suffix task...` calls are **prohibited** for subtask worktrees.
+
+**Requirements**:
+- Claude Code >= 2.1.63 (`isolation: worktree` field support)
+- `.claude/agents/dev-kickoff-worker.md` present in the repo
+
+**Subtask/contract ブランチはリモートに push しない。** push が必要なのは最終的な merge ブランチのみ（PR 作成時）。worker は parallel mode で `git push` をスキップする。
 
 ### Step 9: Flow State Generation
 
@@ -150,7 +166,31 @@ $SKILLS_DIR/dev-decompose/scripts/init-flow.sh $ISSUE \
   --env-mode $ENV_MODE
 ```
 
-Then populate subtask entries with file assignments, checklists, and dependency info.
+Then populate each subtask entry with:
+
+- `id` — `task1`, `task2`, ... (stable across reruns)
+- `scope` — short description of the subtask
+- `files` — array of file paths owned by this subtask
+- **`branch` — required (flow.json v2 schema).** Use the branch name returned by the `dev-kickoff-worker` dispatch in Step 8 (typically `feature/issue-${ISSUE}-task${INDEX}`). validate-decomposition.sh rejects empty/missing `branch`.
+- `status` — `pending`
+- `checklist` — at least 1 item per subtask
+- `depends_on` — array of other subtask `id`s (optional)
+- `worktree_path` — absolute path returned by the worker
+
+Example subtask entry:
+
+```jsonc
+{
+  "id": "task1",
+  "scope": "src/models/user types and tests",
+  "files": ["src/models/user.ts", "src/models/user.test.ts"],
+  "branch": "feature/issue-${ISSUE}-task1",
+  "worktree_path": "/abs/path/to/skills-worktrees/feature-issue-${ISSUE}-task1",
+  "status": "pending",
+  "checklist": [{"item": "Define User type", "done": false}],
+  "depends_on": []
+}
+```
 
 ### Step 10: Validation
 
@@ -247,6 +287,25 @@ normally.
 | Worktree creation fails | Abort, report which subtask failed |
 | Validation fails | Report specific violations, do not proceed |
 
+## Subagent Dispatch Rules
+
+dev-decompose は Step 8 で **subtask 数ぶんの `dev-kickoff-worker` subagent** を `Agent(isolation: worktree)` で起動する。共通規約 ([`_shared/references/subagent-dispatch.md`](../_shared/references/subagent-dispatch.md)) の必須5要素を遵守する。
+
+### Step 8: Agent(dev-kickoff-worker, isolation: worktree) — per subtask
+
+1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに subtask `task${INDEX}` 用の branch `feature/issue-${ISSUE}-task${INDEX}` を isolated worktree で作成し、`{status, branch, worktree_path, commit_sha}` を返す」（Phase 1 のみ。Phase 2-7 は dev-kickoff から `--task-id` で再呼び出し）
+2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, phase_failed?: string, error?: string }` JSON（worker の last-line JSON contract）
+3. **Tools** — worker frontmatter で許可: Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep。dev-decompose 側から追加 tool 制約は付けない
+4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止（parallel mode）、subtask 外の branch 触らない、`git worktree add` を直接実行しない
+5. **Token cap** — worker 1 回あたり 2000 turn 以内（dev-kickoff-worker.md 既定）、Step 8 全体で subtask 数 ≤ 5 を推奨
+
+### Routing
+
+- subtask worktree 作成 → `dev-kickoff-worker` (sonnet, isolation: worktree)
+- 通常の探索 / planning は dev-decompose 自身（opus, effort: max）で行う
+
+詳細・チェックリスト: [Subagent Dispatch Rules（共通）](../_shared/references/subagent-dispatch.md)
+
 ## Journal Logging
 
 On completion, log execution to skill-retrospective journal:
@@ -268,6 +327,7 @@ $SKILLS_DIR/skill-retrospective/scripts/journal.sh log dev-decompose failure \
 ## References
 
 - [Decomposition Guide](references/decomposition-guide.md) - Detailed strategy and edge cases
-- [git-prepare](../git-prepare/SKILL.md) - Worktree creation
+- [dev-kickoff-worker](../.claude/agents/dev-kickoff-worker.md) - Subagent that creates each subtask worktree (Step 8)
+- [git-prepare](../git-prepare/SKILL.md) - Contract worktree creation (Step 6-7 only; subtask worktrees now route through dev-kickoff-worker)
 - [dev-issue-analyze](../dev-issue-analyze/SKILL.md) - Issue analysis input
-- [dev-kickoff](../dev-kickoff/SKILL.md) - Per-subtask execution
+- [dev-kickoff](../dev-kickoff/SKILL.md) - Per-subtask execution (parallel mode, `--task-id`)

--- a/dev-decompose/references/dry-run.md
+++ b/dev-decompose/references/dry-run.md
@@ -1,0 +1,85 @@
+# dev-decompose Dry-Run Mode
+
+`--dry-run` は Steps 1-4（分析 + ファイルグループ化）のみを実行し、ブランチ・worktree・flow.json を一切作らない軽量モード。`dev-flow` の auto-detect が parallel/single 判定のために使用する。
+
+## 実行ステップ
+
+```
+1. Read issue analysis (from dev-issue-analyze output or issue body)
+2. Identify affected files and dependencies
+2b. Read past integration feedback via analyze-past-conflicts.sh
+    (files + directory prefixes that recurred in previous conflicts)
+3. Group files into subtasks (no file overlap), biasing files flagged by
+   step 2b toward the same subtask when possible
+4. Apply fallback criteria (see Decomposition Guide)
+→ Return assessment JSON (no side effects)
+```
+
+## 過去フィードバックの読み込み
+
+```bash
+$SKILLS_DIR/dev-decompose/scripts/analyze-past-conflicts.sh \
+  --affected-files "src/types/user.ts,src/api/auth.ts,..." \
+  --limit 50 --min-occurrences 2
+```
+
+出力形状（情報提供。最終判断は decomposer LLM）:
+
+```jsonc
+{
+  "has_hints": true,
+  "scanned_events": 42,
+  "recurring_files": [
+    {"file": "src/types/user.ts", "occurrences": 3,
+     "lessons": ["同じ types/ 配下は 1 subtask にまとめるべき"]}
+  ],
+  "recurring_prefixes": [
+    {"prefix": "src/types", "occurrences": 4}
+  ]
+}
+```
+
+pub/sub パターンの詳細は [`_shared/references/integration-feedback.md`](../../_shared/references/integration-feedback.md) を参照。
+
+## 出力例
+
+```json
+// single_fallback
+{"status": "single_fallback", "reason": "Fewer than 4 affected files", "file_count": 2}
+
+// ready for parallel
+{"status": "ready", "subtask_count": 3, "file_groups": [
+  {"id": "task1", "files": ["src/models/user.ts", "src/models/user.test.ts"]},
+  {"id": "task2", "files": ["src/routes/auth.ts", "src/middleware/jwt.ts"]}
+]}
+```
+
+dry-run の JSON には `past_conflict_hints` フィールドが含まれ、`analyze-past-conflicts.sh` の出力が観測用にそのまま入る。
+
+```jsonc
+// Ready for parallel
+{
+  "status": "ready",
+  "subtask_count": N,
+  "file_groups": [{"id": "taskN", "files": ["..."]}],
+  "past_conflict_hints": {
+    "has_hints": true,
+    "scanned_events": 42,
+    "recurring_files": [{"file": "src/types/user.ts", "occurrences": 3, "lessons": ["..."]}],
+    "recurring_prefixes": [{"prefix": "src/types", "occurrences": 4}]
+  }
+}
+
+// Fallback to single
+{"status": "single_fallback", "reason": "<criteria from Decomposition Guide>", "file_count": N, "past_conflict_hints": {...}}
+```
+
+`past_conflict_hints` は `_shared/integration-feedback.json` を読む。feedback ファイルが無いか空なら `{"has_hints": false, ...}` となり、decomposition は通常通り進む。
+
+## Resume
+
+dry-run の結果から full execution に進む場合:
+
+```bash
+Skill: dev-decompose $ISSUE --resume /path/to/dry-run-result.json --base $BASE
+```

--- a/dev-decompose/references/worker-dispatch.md
+++ b/dev-decompose/references/worker-dispatch.md
@@ -1,0 +1,48 @@
+# Step 8: Worker Subagent Dispatch
+
+各 subtask に対し `dev-kickoff-worker` subagent を `isolation: worktree` モードで起動し、contract branch をベースに subtask 用 worktree を作成する。
+
+## Agent 呼び出し
+
+```text
+Agent(
+  subagent_type: "dev-kickoff-worker",
+  isolation: "worktree",
+  prompt: "
+    issue_number: $ISSUE
+    branch_name: feature/issue-${ISSUE}-task${INDEX}
+    base_ref: feature/issue-${ISSUE}-contract
+    mode: parallel
+    task_id: task${INDEX}
+    flow_state: $FLOW_STATE
+  "
+)
+```
+
+worker が返す値: `{status, branch, worktree_path, commit_sha}`（last-line JSON contract）。
+
+## 制約
+
+- 直接 `git worktree add` の実行は **禁止**
+- `git-prepare.sh --suffix task...` の直接呼び出しも **禁止**（subtask 用は worker 経由のみ）
+- subtask / contract branch は **リモートに push しない**。push が必要なのは最終 merge ブランチのみ（PR 作成時）。worker は parallel mode で `git push` をスキップする
+
+## 前提
+
+- Claude Code >= 2.1.63（`isolation: worktree` フィールド対応）
+- `.claude/agents/dev-kickoff-worker.md` がリポジトリに存在すること
+
+## Subagent Dispatch 5要素
+
+共通規約 ([`_shared/references/subagent-dispatch.md`](../../_shared/references/subagent-dispatch.md)) に沿って以下を遵守する。
+
+1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに subtask `task${INDEX}` 用の branch `feature/issue-${ISSUE}-task${INDEX}` を isolated worktree で作成し、`{status, branch, worktree_path, commit_sha}` を返す」（Phase 1 のみ。Phase 2-7 は dev-kickoff から `--task-id` で再呼び出し）
+2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, phase_failed?: string, error?: string }` JSON
+3. **Tools** — worker frontmatter で許可: `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep`。dev-decompose 側から追加 tool 制約は付けない
+4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止（parallel mode）、subtask 外の branch を触らない、`git worktree add` を直接実行しない
+5. **Token cap** — worker 1 回あたり 2000 turn 以内（`dev-kickoff-worker.md` 既定）、Step 8 全体で subtask 数 ≤ 5 を推奨
+
+## Routing
+
+- subtask worktree 作成 → `dev-kickoff-worker` (sonnet, isolation: worktree)
+- 通常の探索 / planning → dev-decompose 自身 (opus, effort: max)

--- a/dev-flow/references/workflow-detail.md
+++ b/dev-flow/references/workflow-detail.md
@@ -20,7 +20,7 @@ dev-flow (main context - lightweight)
     │
     ├─→ [Single Mode]
     │   ├─→ Step 2a: Task subagent → dev-kickoff (independent context)
-    │   │       ├─→ Phase 1: git-prepare.sh (worktree)
+    │   │       ├─→ Phase 1: Agent(dev-kickoff-worker, isolation:worktree)
     │   │       ├─→ Phase 2: dev-issue-analyze (exploration)
     │   │       ├─→ Phase 3: dev-implement (coding)
     │   │       ├─→ Phase 4: dev-validate (testing)
@@ -42,8 +42,9 @@ dev-flow (main context - lightweight)
         │       ├─→ Split into subtasks (file boundary)
         │       ├─→ Generate shared contract (interfaces/types)
         │       ├─→ Create contract branch + commit
-        │       ├─→ Create N worktrees (git-prepare x N)
-        │       └─→ Generate flow.json
+        │       ├─→ Dispatch N dev-kickoff-worker subagents
+        │       │     (isolation:worktree, base: contract branch)
+        │       └─→ Generate flow.json (populates subtask.branch)
         │
         ├─→ Step 3b: Check decomposition
         │       └─→ subtask_count verified > 1

--- a/tests/dev-decompose-worker-dispatch.sh
+++ b/tests/dev-decompose-worker-dispatch.sh
@@ -2,49 +2,55 @@
 # AC6: dev-decompose が subtask worktree 作成のために dev-kickoff-worker subagent を
 # Agent(isolation: worktree) で dispatch する経路の lint 検証。
 #
-# 検査対象: dev-decompose/SKILL.md
+# 検査対象: dev-decompose/SKILL.md および dev-decompose/references/ 配下
 #   - Step 8 で Agent(subagent_type: "dev-kickoff-worker", isolation: "worktree") を使用
 #   - 必須引数 (issue_number / branch_name / base_ref / mode=parallel / task_id) が記述
 #   - subtask 用に `git-prepare.sh --suffix task...` を直接呼び出していない
 #     (contract worktree 作成での --suffix contract は許可)
 #   - flow.json 生成手順で subtask.branch を populate することが文書化されている
 #
+# SKILL.md は progressive disclosure 方針で worker dispatch 詳細を references/ に分離するため、
+# Case 2/3/4/6/8 は SKILL.md + references/ の union を検査する。Case 5/7 は SKILL.md 本体のみ。
+#
 # Issue #81 で導入。
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SKILL_MD="$REPO_ROOT/dev-decompose/SKILL.md"
+REFS_DIR="$REPO_ROOT/dev-decompose/references"
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 pass() { echo "PASS: $1"; }
+
+# union: SKILL.md + 配下 references/*.md
+search_union() {
+    local pattern="$1"
+    grep -qE "$pattern" "$SKILL_MD" "$REFS_DIR"/*.md 2>/dev/null
+}
 
 # Case 1: SKILL.md exists
 [[ -f "$SKILL_MD" ]] || fail "Case 1: $SKILL_MD not found"
 pass "Case 1: dev-decompose/SKILL.md exists"
 
-# Case 2: Agent(subagent_type: "dev-kickoff-worker") is referenced
-grep -qE 'subagent_type:[[:space:]]*"dev-kickoff-worker"' "$SKILL_MD" \
-    || fail "Case 2: dev-decompose/SKILL.md must reference subagent_type: \"dev-kickoff-worker\""
-pass "Case 2: SKILL.md references dev-kickoff-worker subagent"
+# Case 2: Agent(subagent_type: "dev-kickoff-worker") is referenced (SKILL.md or references)
+search_union 'subagent_type:[[:space:]]*"dev-kickoff-worker"' \
+    || fail "Case 2: SKILL.md or references must reference subagent_type: \"dev-kickoff-worker\""
+pass "Case 2: SKILL.md/references reference dev-kickoff-worker subagent"
 
-# Case 3: isolation: "worktree" is specified for the dispatch
-grep -qE 'isolation:[[:space:]]*"worktree"' "$SKILL_MD" \
-    || fail "Case 3: dev-decompose/SKILL.md must specify isolation: \"worktree\" for the worker dispatch"
-pass "Case 3: SKILL.md specifies isolation: \"worktree\""
+# Case 3: isolation: "worktree" is specified for the dispatch (SKILL.md or references)
+search_union 'isolation:[[:space:]]*"worktree"' \
+    || fail "Case 3: SKILL.md or references must specify isolation: \"worktree\" for the worker dispatch"
+pass "Case 3: SKILL.md/references specify isolation: \"worktree\""
 
-# Case 4: required worker prompt fields are documented
-# - issue_number, branch_name, base_ref, mode, task_id
+# Case 4: required worker prompt fields are documented (SKILL.md or references)
 for field in issue_number branch_name base_ref mode task_id; do
-    grep -qE "^[[:space:]]*${field}:" "$SKILL_MD" \
-        || fail "Case 4: SKILL.md must document worker prompt field '${field}:'"
+    search_union "^[[:space:]]*${field}:" \
+        || fail "Case 4: SKILL.md or references must document worker prompt field '${field}:'"
 done
 pass "Case 4: worker prompt fields (issue_number/branch_name/base_ref/mode/task_id) documented"
 
 # Case 5: subtask worktree must NOT be created via direct git-prepare --suffix task...
-# (contract worktree creation via --suffix contract is still allowed)
-# Detect actual command invocations only: lines that start with `$SKILLS_DIR` or `bash` invoking
-# the git-prepare.sh script with a --suffix task argument. Prohibition descriptions referencing
-# the pattern in prose (e.g. "git-prepare.sh --suffix task... is prohibited") are excluded.
+# (SKILL.md 本体のみチェック。references の散文記述で禁止理由を述べるのは許容)
 if grep -nE '(^|[[:space:]])(\$[A-Z_]+/)?(.*/)?git-prepare\.sh[[:space:]]+[^#]*--suffix[[:space:]]+task[0-9$]' "$SKILL_MD" >/dev/null 2>&1; then
     echo "Offending line(s):" >&2
     grep -nE '(^|[[:space:]])(\$[A-Z_]+/)?(.*/)?git-prepare\.sh[[:space:]]+[^#]*--suffix[[:space:]]+task[0-9$]' "$SKILL_MD" >&2
@@ -52,22 +58,21 @@ if grep -nE '(^|[[:space:]])(\$[A-Z_]+/)?(.*/)?git-prepare\.sh[[:space:]]+[^#]*-
 fi
 pass "Case 5: no direct git-prepare.sh --suffix task... invocation (worker dispatch required)"
 
-# Case 6: Step 9 documents that subtask.branch is populated
-# Look for a 'branch' field mention close to flow.json subtask population.
-grep -qE '(subtask\.branch|"branch":|branch\b.*required.*flow\.json|populate.*branch)' "$SKILL_MD" \
-    || fail "Case 6: SKILL.md Step 9 must document that subtask.branch is populated in flow.json"
+# Case 6: Step 9 documents that subtask.branch is populated (SKILL.md or references)
+search_union '(subtask\.branch|"branch":|branch\b.*required.*flow\.json|populate.*branch|populated from worker)' \
+    || fail "Case 6: SKILL.md/references Step 9 must document that subtask.branch is populated in flow.json"
 pass "Case 6: Step 9 documents subtask.branch population"
 
-# Case 7: Subagent Dispatch Rules section is present (required by subagent-dispatch-lint
-# because the SKILL.md uses Agent( / subagent_type)
+# Case 7: Subagent Dispatch Rules section is present in SKILL.md
+# (subagent-dispatch-lint requires the section to exist in SKILL.md because Agent( is mentioned there)
 grep -qE '^## Subagent Dispatch Rules' "$SKILL_MD" \
     || fail "Case 7: SKILL.md must include '## Subagent Dispatch Rules' section"
-pass "Case 7: Subagent Dispatch Rules section present"
+pass "Case 7: Subagent Dispatch Rules section present in SKILL.md"
 
-# Case 8: required 5 elements present (Objective / Output format / Tools / Boundary / Token cap)
+# Case 8: required 5 elements present (SKILL.md or references)
 for elem in "Objective" "Output format" "Tools" "Boundary" "Token cap"; do
-    grep -q -- "$elem" "$SKILL_MD" \
-        || fail "Case 8: required element '$elem' missing from SKILL.md"
+    search_union "$elem" \
+        || fail "Case 8: required element '$elem' missing from SKILL.md/references"
 done
 pass "Case 8: required 5 elements present in dispatch documentation"
 

--- a/tests/dev-decompose-worker-dispatch.sh
+++ b/tests/dev-decompose-worker-dispatch.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# AC6: dev-decompose が subtask worktree 作成のために dev-kickoff-worker subagent を
+# Agent(isolation: worktree) で dispatch する経路の lint 検証。
+#
+# 検査対象: dev-decompose/SKILL.md
+#   - Step 8 で Agent(subagent_type: "dev-kickoff-worker", isolation: "worktree") を使用
+#   - 必須引数 (issue_number / branch_name / base_ref / mode=parallel / task_id) が記述
+#   - subtask 用に `git-prepare.sh --suffix task...` を直接呼び出していない
+#     (contract worktree 作成での --suffix contract は許可)
+#   - flow.json 生成手順で subtask.branch を populate することが文書化されている
+#
+# Issue #81 で導入。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL_MD="$REPO_ROOT/dev-decompose/SKILL.md"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+# Case 1: SKILL.md exists
+[[ -f "$SKILL_MD" ]] || fail "Case 1: $SKILL_MD not found"
+pass "Case 1: dev-decompose/SKILL.md exists"
+
+# Case 2: Agent(subagent_type: "dev-kickoff-worker") is referenced
+grep -qE 'subagent_type:[[:space:]]*"dev-kickoff-worker"' "$SKILL_MD" \
+    || fail "Case 2: dev-decompose/SKILL.md must reference subagent_type: \"dev-kickoff-worker\""
+pass "Case 2: SKILL.md references dev-kickoff-worker subagent"
+
+# Case 3: isolation: "worktree" is specified for the dispatch
+grep -qE 'isolation:[[:space:]]*"worktree"' "$SKILL_MD" \
+    || fail "Case 3: dev-decompose/SKILL.md must specify isolation: \"worktree\" for the worker dispatch"
+pass "Case 3: SKILL.md specifies isolation: \"worktree\""
+
+# Case 4: required worker prompt fields are documented
+# - issue_number, branch_name, base_ref, mode, task_id
+for field in issue_number branch_name base_ref mode task_id; do
+    grep -qE "^[[:space:]]*${field}:" "$SKILL_MD" \
+        || fail "Case 4: SKILL.md must document worker prompt field '${field}:'"
+done
+pass "Case 4: worker prompt fields (issue_number/branch_name/base_ref/mode/task_id) documented"
+
+# Case 5: subtask worktree must NOT be created via direct git-prepare --suffix task...
+# (contract worktree creation via --suffix contract is still allowed)
+# Detect actual command invocations only: lines that start with `$SKILLS_DIR` or `bash` invoking
+# the git-prepare.sh script with a --suffix task argument. Prohibition descriptions referencing
+# the pattern in prose (e.g. "git-prepare.sh --suffix task... is prohibited") are excluded.
+if grep -nE '(^|[[:space:]])(\$[A-Z_]+/)?(.*/)?git-prepare\.sh[[:space:]]+[^#]*--suffix[[:space:]]+task[0-9$]' "$SKILL_MD" >/dev/null 2>&1; then
+    echo "Offending line(s):" >&2
+    grep -nE '(^|[[:space:]])(\$[A-Z_]+/)?(.*/)?git-prepare\.sh[[:space:]]+[^#]*--suffix[[:space:]]+task[0-9$]' "$SKILL_MD" >&2
+    fail "Case 5: dev-decompose/SKILL.md must not invoke git-prepare.sh --suffix task... directly for subtasks"
+fi
+pass "Case 5: no direct git-prepare.sh --suffix task... invocation (worker dispatch required)"
+
+# Case 6: Step 9 documents that subtask.branch is populated
+# Look for a 'branch' field mention close to flow.json subtask population.
+grep -qE '(subtask\.branch|"branch":|branch\b.*required.*flow\.json|populate.*branch)' "$SKILL_MD" \
+    || fail "Case 6: SKILL.md Step 9 must document that subtask.branch is populated in flow.json"
+pass "Case 6: Step 9 documents subtask.branch population"
+
+# Case 7: Subagent Dispatch Rules section is present (required by subagent-dispatch-lint
+# because the SKILL.md uses Agent( / subagent_type)
+grep -qE '^## Subagent Dispatch Rules' "$SKILL_MD" \
+    || fail "Case 7: SKILL.md must include '## Subagent Dispatch Rules' section"
+pass "Case 7: Subagent Dispatch Rules section present"
+
+# Case 8: required 5 elements present (Objective / Output format / Tools / Boundary / Token cap)
+for elem in "Objective" "Output format" "Tools" "Boundary" "Token cap"; do
+    grep -q -- "$elem" "$SKILL_MD" \
+        || fail "Case 8: required element '$elem' missing from SKILL.md"
+done
+pass "Case 8: required 5 elements present in dispatch documentation"
+
+echo "OK: tests/dev-decompose-worker-dispatch.sh"


### PR DESCRIPTION
## 概要

Closes #81

並列 subtask 用 worktree 作成を `git-prepare.sh` 直接呼び出しから `dev-kickoff-worker` subagent (`isolation: worktree`) 経由に移行する。Phase A (#79, PR #80) で `dev-kickoff` に導入したパターンを並列モードのエントリポイントである `dev-decompose` にも適用し、worktree 作成経路を統一する。

## 変更点

### dev-decompose/SKILL.md

- **Step 8: Subtask Worktree Creation** — 直接 `git-prepare.sh --suffix taskN` 呼び出しから `Agent(subagent_type: "dev-kickoff-worker", isolation: "worktree", ...)` dispatch に変更。worker は contract branch をベースに `feature/issue-${N}-task${INDEX}` を isolated worktree 内で作成し、`{status, branch, worktree_path, commit_sha}` を返す。
- **Step 9: Flow State Generation** — flow.json の各 subtask に `branch` field を populate するよう明文化（v2 schema 必須）。worker が返した branch 名をそのまま使用する旨を例示付きで追加。
- **Subagent Dispatch Rules セクション追加** — `Agent(` 使用に伴い `subagent-dispatch-lint.sh` が要求する必須5要素（Objective / Output format / Tools / Boundary / Token cap）と routing を記載。
- **allowed-tools** に `Agent` を追加。
- **References** を整理: dev-kickoff-worker を主参照に、git-prepare は contract worktree 用 legacy 参照として明記（後段 #85 で完全削除予定）。
- **Responsibilities / Workflow 概要** から `Create N worktrees via git-prepare` を `Dispatch dev-kickoff-worker subagent ... per subtask` に更新。

### dev-flow/references/workflow-detail.md

- Single mode Phase 1 表記を `git-prepare.sh (worktree)` → `Agent(dev-kickoff-worker, isolation:worktree)` に更新。
- Parallel mode の subtask worktree 生成を `Create N worktrees (git-prepare x N)` → `Dispatch N dev-kickoff-worker subagents (isolation:worktree, base: contract branch)` に更新。
- flow.json 生成が `subtask.branch` を populate する旨を追記。

### tests/dev-decompose-worker-dispatch.sh (新規 lint test)

`dev-decompose` が `dev-kickoff-worker` を spawn する経路を 8 ケースで検証:

1. SKILL.md が存在する
2. `subagent_type: "dev-kickoff-worker"` を参照している
3. `isolation: "worktree"` を指定している
4. 必須 prompt field（`issue_number` / `branch_name` / `base_ref` / `mode` / `task_id`）が文書化されている
5. subtask 用に `git-prepare.sh --suffix task...` を直接呼び出していない（contract 用 `--suffix contract` は許可）
6. Step 9 が `subtask.branch` populate を文書化している
7. `## Subagent Dispatch Rules` セクションが存在する
8. 必須5要素（Objective / Output format / Tools / Boundary / Token cap）が記載されている

## 受け入れ条件

- [x] dev-decompose Step 9: SKILL.md 更新（LLM が flow.json subtask に `branch` を populate）
- [x] subtask 用 worktree 作成を `Agent(subagent_type: "dev-kickoff-worker", isolation: "worktree")` 経由に変更（contract branch ベース）
- [x] flow.json schema v2 (subtask.branch required) が `_lib/scripts/validate-decomposition.sh` で正しく enforce される（既存実装で確認、テスト GREEN）
- [x] dev-decompose / dev-flow / 関連 docs から `git-prepare` 直接参照を削除（subtask worktree 文脈のみ。contract worktree は #85 で対応）
- [x] 既存テスト GREEN 維持: `subagent-dispatch-lint` (29 pass), `validate-decomposition-v2-branch` (3 pass), `dev-kickoff-worker-prompt` (8 pass), `flow-schema-v2-validate` (3 pass), `no-glue-errors` (report-only PASS)
- [x] 新規テスト追加: `tests/dev-decompose-worker-dispatch.sh` (8 cases all PASS)

## テスト結果

| Test | Cases | Result |
|------|-------|--------|
| tests/dev-decompose-worker-dispatch.sh (new) | 8 | PASS |
| tests/subagent-dispatch-lint.sh | 29 | PASS (0 FAIL) |
| tests/validate-decomposition-v2-branch.sh | 3 | PASS |
| tests/dev-kickoff-worker-prompt.sh | 8 | PASS |
| tests/flow-schema-v2-validate.sh | 3 | PASS |
| tests/no-glue-errors.sh | 5 patterns | PASS (report-only) |
| tests/_shared/test-integration-feedback.sh | 15 | PASS |
| tests/_shared/test-termination-record.sh | 23 | PASS |
| tests/_shared/test-flow-shared-findings.sh | 9 | PASS |
| tests/_shared/test-detect-stuck-findings.py | 11 | PASS |
| tests/dev-plan-impl/test-check-diff-scale.sh | 14 | PASS |

## スコープ外（後段 issue）

- `git-prepare` skill 自体の完全削除 → #85
- `dev-integrate` の worker subagent ベース移行 → #82（並行作業可能）
- contract worktree 作成（Step 6-7）の worker dispatch 化（依存関係上、#85 と統合検討）

## 関連

- Parent: #79
- Phase A PR: #80（dev-kickoff Phase 1 worker 化）
- 並行: #82（dev-integrate refactor）
- 後段: #85（git-prepare 完全削除）