### PR TITLE
refactor(dev-integrate): merge worktree を worker subagent 化 (#82)

### DIFF
--- a/.claude/agents/dev-kickoff-worker.md
+++ b/.claude/agents/dev-kickoff-worker.md
@@ -1,10 +1,10 @@
 ---
 name: dev-kickoff-worker
 description: |
-  Execute one dev-kickoff phase cycle (1b-7, optionally 8) in an isolated git worktree.
-  Use when: dev-kickoff Phase 1 detects worker availability via detect-worker.sh.
-  Inputs: issue_number, branch_name, base_ref (single mode: origin/main; parallel mode: contract branch).
-  Returns: {status, branch, worktree_path, commit_sha, pr_url?, phase_failed?, error?}
+  Execute one dev-kickoff phase cycle (1b-7, optionally 8) or a merge cycle in an isolated git worktree.
+  Use when: dev-kickoff Phase 1 (single/parallel) or dev-integrate Step 4 (merge) need an isolated worktree subagent.
+  Inputs: issue_number, branch_name, base_ref. Mode-specific: task_id (parallel), flow_state (parallel/merge).
+  Returns: {status, branch, worktree_path, commit_sha, pr_url?, merge_results?, conflicts?, phase_failed?, error?}
 isolation: worktree
 permissionMode: auto
 model: sonnet
@@ -21,18 +21,24 @@ tools:
 
 # dev-kickoff-worker
 
-A dev-kickoff worker that runs phases 1b-7 (optionally 8 in single mode) inside a Claude Code `isolation: worktree` subagent. The parent orchestrator (dev-kickoff main session) invokes this subagent through the Agent tool to delegate worktree-bound work in a clean context.
+A dev-kickoff worker that runs phases 1b-7 (optionally 8 in single mode) inside a Claude Code `isolation: worktree` subagent. The parent orchestrator (dev-kickoff main session, or dev-integrate for the merge variant) invokes this subagent through the Agent tool to delegate worktree-bound work in a clean context.
+
+The worker supports **three modes**:
+
+- `single` — full dev-kickoff cycle for an entire issue (Phase 1b-8)
+- `parallel` — one-subtask cycle inside a parallel decomposition (Phase 3-7, no Phase 8)
+- `merge` — dev-integrate's merge worktree variant (branch checkout + `merge-subtasks.sh` + type check + dev-validate)
 
 ## Inputs (provided in the spawn prompt)
 
 The caller MUST pass the following in your invocation prompt:
 
 - `issue_number`: integer, e.g. `79`
-- `branch_name`: e.g. `feature/issue-79-m` (single mode) or `feature/issue-79-task1` (parallel mode)
-- `base_ref`: e.g. `origin/main` (single mode) or `feature/issue-79-contract` (parallel mode)
-- `mode`: `single` or `parallel`
+- `branch_name`: e.g. `feature/issue-79-m` (single), `feature/issue-79-task1` (parallel), or `feature/issue-79-merge` / `feature/issue-79-merge-retry` (merge)
+- `base_ref`: e.g. `origin/main` (single mode) or `feature/issue-79-contract` (parallel and merge modes — the contract branch)
+- `mode`: `single`, `parallel`, or `merge`
 - `task_id` (parallel only): subtask ID from flow.json, e.g. `task1`
-- `flow_state` (parallel only): absolute path to flow.json
+- `flow_state` (parallel and merge): absolute path to flow.json
 
 ## Steps — execute IN ORDER, do NOT skip
 
@@ -80,6 +86,51 @@ Parallel mode (Phase 3-7, no Phase 8):
 - Run Phase 3-7 the same way as single mode
 - Do NOT run `git push` for the subtask branch — parent dev-integrate handles merge
 
+Merge mode (`mode: merge`, issue #82) — NOT phase 2-8. Instead, run the merge cycle below.
+
+After branch checkout (Step 1) succeeds, the worker is sitting on the new merge branch (e.g. `feature/issue-${issue_number}-merge`, or `feature/issue-${issue_number}-merge-retry` on retry) created from the contract branch. Execute:
+
+1. **Merge subtask branches** in topological order via the existing decomposition script (it owns conflict detection / auto-resolution / integration-feedback recording):
+
+   ```bash
+   "$SKILLS_DIR/dev-integrate/scripts/merge-subtasks.sh" \
+     --flow-state "$flow_state" \
+     --worktree "$(pwd)" > merge-subtasks.out.json
+   ```
+
+   Capture the JSON output. The script returns `{status, total_subtasks, merged, conflicts, results}` — store this as the `merge_results` field of the worker return JSON. The flat `conflicts` field (number) is mirrored at the top level too.
+
+2. **Type check** (best-effort; detect project type by manifest files):
+
+   ```bash
+   if [ -f tsconfig.json ]; then npx tsc --noEmit
+   elif [ -f setup.py ] || [ -f pyproject.toml ]; then mypy . || true
+   elif [ -f go.mod ]; then go vet ./...
+   fi
+   ```
+
+3. **Integration validation** via dev-validate:
+
+   ```bash
+   Skill: dev-validate --worktree $(pwd)
+   ```
+
+4. **Do NOT push** the merge branch. Parent `dev-integrate` writes worker results back to `flow.json.integration` (status / merge_worktree / merge_order / merge_results) via `flow-update.sh`.
+
+5. Return JSON of the shape:
+
+   ```json
+   {"status":"completed","branch":"feature/issue-79-merge","worktree_path":"/abs/path","commit_sha":"<HEAD sha>","merge_results":{"status":"success","total_subtasks":N,"merged":N,"conflicts":0,"results":[...]},"conflicts":0}
+   ```
+
+   On failure (e.g. unresolvable conflict, type check fail, validation fail):
+
+   ```json
+   {"status":"failed","phase_failed":"merge","branch":"feature/issue-79-merge","worktree_path":"/abs/path","commit_sha":"<sha or empty>","merge_results":{...partial...},"conflicts":N,"error":"<message>"}
+   ```
+
+   `status` is `failed` only when `merge-subtasks.sh` exits non-zero, type check fails, or validation fails. Auto-resolved conflicts (lock files) keep `status: completed` and surface in `merge_results.results[*].status == "merged_auto_resolved"` plus the top-level `conflicts` count.
+
 ### Step 4: Empty diff handling (EC1 from issue #79)
 
 Before Phase 7 (commit), check whether there are staged or unstaged changes:
@@ -96,7 +147,7 @@ This rule exists because Claude Code automatically removes a temp worktree when 
 
 ### Step 5: Return JSON (last line of your response)
 
-On success, your final response MUST end with a single-line JSON object:
+On success (single / parallel), your final response MUST end with a single-line JSON object:
 
 ```json
 {"status":"completed","branch":"feature/issue-79-m","worktree_path":"/abs/path","commit_sha":"<HEAD sha>","pr_url":"https://github.com/...optional in parallel mode"}
@@ -109,17 +160,18 @@ On failure at any phase:
 ```
 
 Required fields: `status`, `branch`, `worktree_path`, `commit_sha` (may be empty on early failure).
-Optional fields: `pr_url` (single mode Phase 8 only), `phase_failed`, `error`.
+Optional fields: `pr_url` (single mode Phase 8 only), `merge_results` / `conflicts` (merge mode only), `phase_failed`, `error`.
 
 ## Boundaries
 
-- DO NOT run `git push` for subtask branches in parallel mode. Only Phase 8 (single mode) pushes via `git-pr`.
+- DO NOT run `git push` for subtask branches in parallel mode, nor for the merge branch in merge mode. Only Phase 8 (single mode) pushes via `git-pr`. The merge branch is pushed later by parent dev-integrate's downstream PR step (#82 keeps that responsibility on the parent).
 - DO NOT modify files outside your worktree (`pwd` boundary).
 - DO NOT spawn other subagents (Claude Code subagents cannot nest — public docs L737).
-- DO NOT auto-reset / force-delete existing branches. Abort with `phase_failed:1` instead and let the parent / human decide cleanup.
+- DO NOT auto-reset / force-delete existing branches. Abort with `phase_failed:1` (or `phase_failed:"merge"` for merge mode) instead and let the parent / human decide cleanup.
 
 ## References
 
-- Issue: github.com/it-all-playpark/skills/issues/79
+- Issue: github.com/it-all-playpark/skills/issues/79 (single / parallel), github.com/it-all-playpark/skills/issues/82 (merge)
 - Claude Code subagent docs: https://code.claude.com/docs/en/sub-agents
 - spike Layer 1+2 (parent session) for `isolation: worktree` behavior validation
+- dev-integrate dispatch detail: [`dev-integrate/references/worker-dispatch.md`](../../dev-integrate/references/worker-dispatch.md)

--- a/dev-flow/references/workflow-detail.md
+++ b/dev-flow/references/workflow-detail.md
@@ -61,9 +61,10 @@ dev-flow (main context - lightweight)
         │
         ├─→ Step 6b: dev-integrate
         │       ├─→ Check drift (planned vs actual files)
-        │       ├─→ Merge subtask branches (topological order)
-        │       ├─→ Type check (tsc/mypy/go vet)
-        │       └─→ dev-validate (integration tests)
+        │       ├─→ Spawn Agent(dev-kickoff-worker, isolation:worktree, mode:merge)
+        │       │     (worker runs merge-subtasks.sh + type check + dev-validate
+        │       │      inside its isolated worktree and returns merge_results)
+        │       └─→ Transcribe worker JSON into flow.json.integration
         │
         ├─→ Step 7b: git-pr (from merge worktree)
         │

--- a/dev-integrate/SKILL.md
+++ b/dev-integrate/SKILL.md
@@ -33,59 +33,40 @@ Merge parallel subtask branches, resolve conflicts, run type checks and integrat
 ## Workflow
 
 ```
-1. Read flow.json, verify all subtasks status == "completed"
-1b. Check shared_findings for unacked entries (warning only, non-blocking)
-2. Warn if actual_files_changed differs from planned files
-3. Determine merge order from depends_on (topological sort, leaves first)
-4. Spawn worker: Agent(subagent_type: "dev-kickoff-worker", isolation: "worktree", mode: "merge")
-   prompt:
-     issue_number: $ISSUE
-     branch_name: feature/issue-${ISSUE}-merge   (or ...-merge-retry on retry)
-     base_ref: $CONTRACT_BRANCH
-     mode: merge
-     flow_state: $FLOW_STATE
-   worker internally runs:
-     a. git checkout -b $branch_name $base_ref
-     b. merge-subtasks.sh --flow-state $FLOW_STATE --worktree $(pwd)
-        (auto-resolves lock/config conflicts, appends integration-feedback events)
-     c. type check (tsc/mypy/go vet)
-     d. Skill: dev-validate --worktree $(pwd)
-   worker returns:
-     {status, branch, worktree_path, commit_sha, merge_results, conflicts, phase_failed?, error?}
-5. Parent writes worker result back to flow.json.integration via flow-update.sh
-   (status / merge_worktree / merge_order / type_check / validation / merge_results / conflicts)
-6. On merge failure: re-spawn worker with branch_name=feature/issue-${ISSUE}-merge-retry
+1.  Read flow.json, verify all subtasks status == "completed"
+1b. Check shared_findings (non-blocking warning)
+2.  Warn if actual_files_changed differs from planned files
+3.  Determine merge order from depends_on (topological)
+4.  Spawn dev-kickoff-worker (isolation: worktree, mode: merge)
+5.  Transcribe worker JSON to flow.json.integration via flow-update.sh
+6.  On merge failure: re-spawn worker with -merge-retry suffix (max 1)
 ```
 
 ### Step 1b: Unacked Shared Findings Check
 
 ```bash
-UNACKED=$($SKILLS_DIR/dev-integrate/scripts/check-unacked-findings.sh \
-  --flow-state "$FLOW_STATE")
-COUNT=$(echo "$UNACKED" | jq -r '.unacked_count')
-if [[ "$COUNT" -gt 0 ]]; then
-  echo "$COUNT shared finding(s) not acknowledged by all subtasks:"
-  echo "$UNACKED" | jq -r '.unacked[] | "  - \(.id) [\(.category)] \(.title) (missing: \(.missing_ack | join(",")))"'
-fi
+$SKILLS_DIR/dev-integrate/scripts/check-unacked-findings.sh --flow-state "$FLOW_STATE"
 ```
 
-The check is **non-blocking**: integration continues even with unacked findings. It only surfaces potential cross-worker coordination gaps for human awareness. See [`_shared/references/shared-findings.md`](../_shared/references/shared-findings.md) for the pattern.
+Non-blocking. Surfaces cross-worker coordination gaps. See [`_shared/references/shared-findings.md`](../_shared/references/shared-findings.md).
 
-## Execution
+### Step 4: Worker Dispatch
 
-See [Integration Guide](references/integration-guide.md#execution-steps) for detailed step-by-step commands, and [Worker Dispatch](references/worker-dispatch.md) for the `dev-kickoff-worker` (`mode: merge`) contract.
+Spawn `dev-kickoff-worker` (`isolation: worktree`, `mode: merge`) with prompt fields `issue_number` / `branch_name` (`feature/issue-${ISSUE}-merge`) / `base_ref` (contract branch) / `mode: merge` / `flow_state`. Worker internally runs `merge-subtasks.sh` → type check → `dev-validate` and returns `{status, branch, worktree_path, commit_sha, merge_results, conflicts}`.
+
+Agent call shape, retry pattern (`-merge-retry`), and full return JSON: [Worker Dispatch](references/worker-dispatch.md).
 
 ## Subagent Dispatch Rules
 
-dev-integrate spawns `dev-kickoff-worker` with `isolation: worktree` for the merge worktree (Step 4). Per `docs/skill-creation-guide.md`, the dispatch must satisfy the required 5 elements. Full prompt template and routing live in [`references/worker-dispatch.md`](references/worker-dispatch.md) (progressive disclosure); the binding values are summarised here.
+dev-integrate spawns `dev-kickoff-worker` (`Agent(isolation: worktree, mode: merge)`) at Step 4. Common rules ([`_shared/references/subagent-dispatch.md`](../_shared/references/subagent-dispatch.md)) require the 5 elements:
 
-1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに merge 用 branch `feature/issue-${ISSUE}-merge` (or `-merge-retry`) を isolated worktree で作成し、`merge-subtasks.sh` → 型チェック → `dev-validate` を実行して `{status, branch, worktree_path, commit_sha, merge_results, conflicts}` を返す」
-2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, merge_results: object, conflicts: number, phase_failed?: string, error?: string }` (last-line JSON contract)
-3. **Tools** — worker frontmatter 既定: `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep`。dev-integrate 側から追加制約は付けない
-4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止 (merge branch も含む)、subtask / contract branch を rewrite しない、`git worktree add` を直接実行しない、`git-prepare.sh --suffix merge` も呼ばない
-5. **Token cap** — worker 1 回あたり 2000 turn 以内 (`dev-kickoff-worker.md` 既定)、merge mode は通常 1 spawn で完結 (失敗時のみ `-merge-retry` で 1 回 re-spawn)
+- **Objective** — contract branch ベースに merge 用 isolated worktree を作成し `merge-subtasks.sh` → 型チェック → `dev-validate` を実行
+- **Output format** — `{status, branch, worktree_path, commit_sha, merge_results, conflicts, phase_failed?, error?}` JSON (worker last-line contract)
+- **Tools** — worker frontmatter で許可 (Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep)。追加制約は付けない
+- **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止 (merge branch も含む)、subtask / contract branch を rewrite しない、`git worktree add` / `git-prepare.sh --suffix merge` 直接実行禁止
+- **Token cap** — worker 1 回あたり 2000 turn 以内、merge mode は通常 1 spawn (失敗時のみ `-merge-retry` で 1 回 re-spawn)
 
-Routing: merge worktree 作成 + merge 実行 → `dev-kickoff-worker` (sonnet, `isolation: worktree`, `mode: merge`)。dev-integrate 自身は探索 / 集約 / `flow.json` 書き込みのみを担う。
+詳細・Routing: [Worker Dispatch](references/worker-dispatch.md)。
 
 ## Error Handling
 

--- a/dev-integrate/SKILL.md
+++ b/dev-integrate/SKILL.md
@@ -8,6 +8,7 @@ description: |
 allowed-tools:
   - Bash
   - Task
+  - Agent
   - Skill
 ---
 
@@ -19,16 +20,15 @@ Merge parallel subtask branches, resolve conflicts, run type checks and integrat
 
 - Read flow.json and verify all subtasks completed
 - Detect planned vs actual file changes (actual_files_changed vs files)
-- Create merge worktree (git-prepare --suffix merge)
-- Merge each subtask branch in dependency order (leaves first)
-- Detect and attempt auto-resolution of conflicts
+- Spawn `dev-kickoff-worker` subagent (`isolation: worktree`, `mode: merge`) for the merge worktree
+- The worker merges each subtask branch in dependency order (leaves first) via `merge-subtasks.sh`
+- Detect and attempt auto-resolution of conflicts (delegated to the worker / `merge-subtasks.sh`)
 - **Record conflicts / integration failures to `_shared/integration-feedback.json`**
   so that future `dev-decompose --dry-run` runs can learn from recurring patterns
   (pub/sub event store — see
   [`_shared/references/integration-feedback.md`](../_shared/references/integration-feedback.md))
-- Run type checking (tsc --noEmit, mypy, etc.)
-- Run integration tests via dev-validate
-- Update flow.json integration section
+- The worker also runs type checking (tsc --noEmit, mypy, etc.) and integration tests via dev-validate
+- Receive worker JSON `{status, branch, worktree_path, commit_sha, merge_results, conflicts}` and write the result back to `flow.json.integration` via `flow-update.sh`
 
 ## Workflow
 
@@ -37,17 +37,24 @@ Merge parallel subtask branches, resolve conflicts, run type checks and integrat
 1b. Check shared_findings for unacked entries (warning only, non-blocking)
 2. Warn if actual_files_changed differs from planned files
 3. Determine merge order from depends_on (topological sort, leaves first)
-4. Create merge worktree via git-prepare --suffix merge --base $CONTRACT_BRANCH
-4b. Sync .env files to merge worktree via sync-env
-5. For each subtask in order:
-   a. git merge --no-ff $TASK_BRANCH
-   b. If conflict: attempt auto-resolution, record in flow.json
-   c. Append event to `_shared/integration-feedback.json` (best-effort,
-      via `integration-event-append.sh` — never aborts the merge loop)
-   d. If unresolvable: stop and request user intervention
-6. Run type check (detect project type: tsc for TS, mypy for Python, etc.)
-7. Run Skill: dev-validate --worktree $MERGE_WORKTREE
-8. Update flow.json integration section with results
+4. Spawn worker: Agent(subagent_type: "dev-kickoff-worker", isolation: "worktree", mode: "merge")
+   prompt:
+     issue_number: $ISSUE
+     branch_name: feature/issue-${ISSUE}-merge   (or ...-merge-retry on retry)
+     base_ref: $CONTRACT_BRANCH
+     mode: merge
+     flow_state: $FLOW_STATE
+   worker internally runs:
+     a. git checkout -b $branch_name $base_ref
+     b. merge-subtasks.sh --flow-state $FLOW_STATE --worktree $(pwd)
+        (auto-resolves lock/config conflicts, appends integration-feedback events)
+     c. type check (tsc/mypy/go vet)
+     d. Skill: dev-validate --worktree $(pwd)
+   worker returns:
+     {status, branch, worktree_path, commit_sha, merge_results, conflicts, phase_failed?, error?}
+5. Parent writes worker result back to flow.json.integration via flow-update.sh
+   (status / merge_worktree / merge_order / type_check / validation / merge_results / conflicts)
+6. On merge failure: re-spawn worker with branch_name=feature/issue-${ISSUE}-merge-retry
 ```
 
 ### Step 1b: Unacked Shared Findings Check
@@ -57,7 +64,7 @@ UNACKED=$($SKILLS_DIR/dev-integrate/scripts/check-unacked-findings.sh \
   --flow-state "$FLOW_STATE")
 COUNT=$(echo "$UNACKED" | jq -r '.unacked_count')
 if [[ "$COUNT" -gt 0 ]]; then
-  echo "⚠️  $COUNT shared finding(s) not acknowledged by all subtasks:"
+  echo "$COUNT shared finding(s) not acknowledged by all subtasks:"
   echo "$UNACKED" | jq -r '.unacked[] | "  - \(.id) [\(.category)] \(.title) (missing: \(.missing_ack | join(",")))"'
 fi
 ```
@@ -66,32 +73,44 @@ The check is **non-blocking**: integration continues even with unacked findings.
 
 ## Execution
 
-See [Integration Guide](references/integration-guide.md#execution-steps) for detailed step-by-step commands.
+See [Integration Guide](references/integration-guide.md#execution-steps) for detailed step-by-step commands, and [Worker Dispatch](references/worker-dispatch.md) for the `dev-kickoff-worker` (`mode: merge`) contract.
+
+## Subagent Dispatch Rules
+
+dev-integrate spawns `dev-kickoff-worker` with `isolation: worktree` for the merge worktree (Step 4). Per `docs/skill-creation-guide.md`, the dispatch must satisfy the required 5 elements. Full prompt template and routing live in [`references/worker-dispatch.md`](references/worker-dispatch.md) (progressive disclosure); the binding values are summarised here.
+
+1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに merge 用 branch `feature/issue-${ISSUE}-merge` (or `-merge-retry`) を isolated worktree で作成し、`merge-subtasks.sh` → 型チェック → `dev-validate` を実行して `{status, branch, worktree_path, commit_sha, merge_results, conflicts}` を返す」
+2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, merge_results: object, conflicts: number, phase_failed?: string, error?: string }` (last-line JSON contract)
+3. **Tools** — worker frontmatter 既定: `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep`。dev-integrate 側から追加制約は付けない
+4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止 (merge branch も含む)、subtask / contract branch を rewrite しない、`git worktree add` を直接実行しない、`git-prepare.sh --suffix merge` も呼ばない
+5. **Token cap** — worker 1 回あたり 2000 turn 以内 (`dev-kickoff-worker.md` 既定)、merge mode は通常 1 spawn で完結 (失敗時のみ `-merge-retry` で 1 回 re-spawn)
+
+Routing: merge worktree 作成 + merge 実行 → `dev-kickoff-worker` (sonnet, `isolation: worktree`, `mode: merge`)。dev-integrate 自身は探索 / 集約 / `flow.json` 書き込みのみを担う。
 
 ## Error Handling
 
 | Scenario | Action |
 |----------|--------|
 | Subtask not completed | Abort, report |
-| Merge conflict | Auto-resolve → manual attempt → abort |
-| Type check / test fails | Fix attempt (max 2x) → report |
+| Worker returns `status: failed` with `phase_failed: "merge"` | Re-spawn worker with `branch_name: feature/issue-${ISSUE}-merge-retry` (max 1 retry), then escalate |
+| Worker returns conflicts > 0 but `status: completed` | Auto-resolved (lock/config). Pass-through, record in flow.json |
+| Type check / test fails (worker reports inside merge_results) | Worker returns `phase_failed: "merge"`. Fix attempt (max 2x) via retry → report |
 
-Details: [Integration Guide](references/integration-guide.md#conflict-auto-resolution)
+Details: [Integration Guide](references/integration-guide.md#conflict-auto-resolution), [Worker Dispatch](references/worker-dispatch.md)
 
 ## Args
 
 | Arg | Default | Description |
 |-----|---------|-------------|
 | `--flow-state` | auto | Path to flow.json |
-| `--base` | from flow.json | Base branch for merge worktree |
+| `--base` | from flow.json | Contract branch (passed to worker as `base_ref`) |
 
 ## Output
 
-Updates flow.json integration section.
+Updates flow.json integration section using the worker's return JSON.
 
-Returns:
 ```json
-{"status": "integrated|failed", "merge_worktree": "/path", "type_check": "passed|failed", "validation": "passed|failed"}
+{"status": "integrated|failed", "merge_worktree": "/path", "type_check": "passed|failed", "validation": "passed|failed", "merge_results": {...}, "conflicts": <n>}
 ```
 
 ## Journal Logging

--- a/dev-integrate/references/integration-guide.md
+++ b/dev-integrate/references/integration-guide.md
@@ -232,21 +232,34 @@ grep -rn '<<<<<<< \|======= \|>>>>>>> ' --include='*.ts' --include='*.py' --incl
 # 1. Check which subtask caused the conflict
 cat merge-results.json | jq '.results[] | select(.status == "conflict")'
 
-# 2. Create a fresh merge worktree
-git-prepare.sh $ISSUE --suffix merge-retry --base $BASE
+# 2. Re-spawn the worker with a merge-retry branch name
+#    (worker creates the fresh isolated worktree itself; no manual git-prepare invocation)
+Agent(
+  subagent_type: "dev-kickoff-worker",
+  isolation: "worktree",
+  prompt: "
+    issue_number: $ISSUE
+    branch_name: feature/issue-${ISSUE}-merge-retry
+    base_ref: $CONTRACT_BRANCH
+    mode: merge
+    flow_state: $FLOW_STATE
+  "
+)
 
-# 3. Manually merge the conflicting branch
-cd $NEW_WORKTREE
+# 3. If the retry worker also reports phase_failed=merge with conflicts,
+#    enter the returned worktree_path and resolve manually:
+cd $WORKER_RETURNED_WORKTREE_PATH
 git merge --no-ff $CONFLICTING_BRANCH
-
-# 4. Resolve conflicts
 # Edit conflicting files
 git add .
 git commit
 
-# 5. Continue with remaining branches
-# Re-run merge-subtasks.sh
+# 4. Re-run merge-subtasks.sh inside that worktree to continue with remaining branches:
+$SKILLS_DIR/dev-integrate/scripts/merge-subtasks.sh \
+    --flow-state $FLOW_STATE --worktree $WORKER_RETURNED_WORKTREE_PATH
 ```
+
+See [worker-dispatch.md](worker-dispatch.md) for the full re-spawn contract.
 
 ### Scenario 2: Type Check Failure
 
@@ -337,53 +350,64 @@ it is informational only.
 Use topological sort based on `depends_on` fields. Independent subtasks (no dependencies)
 are merged first, followed by subtasks that depend on them.
 
-### Step 4: Create Merge Worktree
+### Step 4: Spawn Worker for Merge Worktree
 
-```bash
-$SKILLS_DIR/git-prepare/scripts/git-prepare.sh $ISSUE --suffix merge --base $BASE
+Spawn `dev-kickoff-worker` with `isolation: worktree` + `mode: merge`. The worker creates its own isolated worktree internally — do NOT call `git worktree add` or `git-prepare.sh` directly.
+
+```text
+Agent(
+  subagent_type: "dev-kickoff-worker",
+  isolation: "worktree",
+  prompt: "
+    issue_number: $ISSUE
+    branch_name: feature/issue-${ISSUE}-merge
+    base_ref: $CONTRACT_BRANCH
+    mode: merge
+    flow_state: $FLOW_STATE
+  "
+)
 ```
 
-### Step 4b: Sync .env Files (git-prepareが自動実行しない場合のみ)
+Full dispatch contract: [worker-dispatch.md](worker-dispatch.md).
 
-> **Note**: git-prepare.sh は内部で sync-env を自動呼び出しする。
-> `--env-mode none` で Step 4 を実行した場合や、手動で再同期が必要な場合のみ以下を実行する。
+Inside the worker (Steps 5-7 below are now executed by the worker, not the parent):
 
-```bash
-$SKILLS_DIR/sync-env/scripts/sync-env.sh --worktree $MERGE_WORKTREE --mode $ENV_MODE --force
-```
+- Step 5 — merge subtask branches via `merge-subtasks.sh`
+- Step 6 — type check (tsc/mypy/go vet)
+- Step 7 — `Skill: dev-validate --worktree $(pwd)`
 
-### Step 5: Merge Subtask Branches
+### Step 4b: .env Sync (handled automatically by isolation: worktree)
 
-```bash
-$SKILLS_DIR/dev-integrate/scripts/merge-subtasks.sh \
-  --flow-state $FLOW_STATE --worktree $MERGE_WORKTREE
-```
+Claude Code's `isolation: worktree` mode owns the worktree creation lifecycle, including `.env` propagation. Manual `sync-env.sh` calls from dev-integrate are not required.
 
-### Step 6: Type Check
+### Step 5-7 (delegated to worker)
 
-Detect project type and run appropriate type checker:
+The merge / type check / validate sequence runs inside the worker. The parent only inspects the worker's return JSON:
 
-```bash
-# Detect project type:
-if [ -f "tsconfig.json" ]; then npx tsc --noEmit
-elif [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then mypy .
-elif [ -f "go.mod" ]; then go vet ./...
-fi
-```
-
-### Step 7: Integration Validation
-
-```
-Skill: dev-validate --worktree $MERGE_WORKTREE
+```json
+{
+  "status": "completed",
+  "branch": "feature/issue-${ISSUE}-merge",
+  "worktree_path": "/abs/path",
+  "commit_sha": "<sha>",
+  "merge_results": {"status": "success", "total_subtasks": N, "merged": N, "conflicts": 0, "results": [...]},
+  "conflicts": 0
+}
 ```
 
 ### Step 8: Update Flow State
+
+Transcribe the worker JSON into `flow.json.integration` using `flow-update.sh`:
 
 ```bash
 $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
   integration --field status --value "integrated"
 $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
-  integration --field merge_worktree --value "$MERGE_WORKTREE"
+  integration --field merge_worktree --value "$WORKER_WORKTREE_PATH"
+$SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
+  integration --field merge_results --value "$WORKER_MERGE_RESULTS_JSON"
+$SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
+  integration --field conflicts --value "$WORKER_CONFLICTS"
 $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \
   integration --field type_check --value "passed"
 $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state $FLOW_STATE \

--- a/dev-integrate/references/worker-dispatch.md
+++ b/dev-integrate/references/worker-dispatch.md
@@ -1,0 +1,114 @@
+# Step 4: Worker Subagent Dispatch (merge mode)
+
+dev-integrate の merge worktree 作成は、`dev-kickoff-worker` を `isolation: worktree` + `mode: merge` で spawn することで行う。`git-prepare.sh --suffix merge` は呼ばない (issue #82)。
+
+## Agent 呼び出し
+
+```text
+Agent(
+  subagent_type: "dev-kickoff-worker",
+  isolation: "worktree",
+  prompt: "
+    issue_number: $ISSUE
+    branch_name: feature/issue-${ISSUE}-merge
+    base_ref: feature/issue-${ISSUE}-contract
+    mode: merge
+    flow_state: $FLOW_STATE
+  "
+)
+```
+
+retry 時は `branch_name` に `-merge-retry` suffix を付ける:
+
+```text
+Agent(
+  subagent_type: "dev-kickoff-worker",
+  isolation: "worktree",
+  prompt: "
+    issue_number: $ISSUE
+    branch_name: feature/issue-${ISSUE}-merge-retry
+    base_ref: feature/issue-${ISSUE}-contract
+    mode: merge
+    flow_state: $FLOW_STATE
+  "
+)
+```
+
+worker が返す値 (last-line JSON):
+
+```json
+{
+  "status": "completed",
+  "branch": "feature/issue-${ISSUE}-merge",
+  "worktree_path": "/abs/path/to/isolated/worktree",
+  "commit_sha": "<HEAD sha>",
+  "merge_results": {
+    "status": "success",
+    "total_subtasks": 3,
+    "merged": 3,
+    "conflicts": 0,
+    "results": [
+      {"task_id": "task1", "branch": "feature/issue-79-task1", "status": "merged"}
+    ]
+  },
+  "conflicts": 0
+}
+```
+
+失敗時 (unresolvable conflict / type check fail / validation fail):
+
+```json
+{
+  "status": "failed",
+  "phase_failed": "merge",
+  "branch": "feature/issue-${ISSUE}-merge",
+  "worktree_path": "/abs/path",
+  "commit_sha": "<best-effort sha>",
+  "merge_results": {"status": "failed", "results": [...]},
+  "conflicts": 1,
+  "error": "unresolvable conflict in src/foo.ts"
+}
+```
+
+## Parent (dev-integrate) の責務
+
+worker から返った JSON をそのまま `flow.json.integration` に転記する。dev-integrate 親は worktree を直接操作せず、状態管理に専念する:
+
+```bash
+$SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state "$FLOW_STATE" \
+    integration --field status --value "integrated"
+$SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state "$FLOW_STATE" \
+    integration --field merge_worktree --value "$WORKTREE_PATH"
+$SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state "$FLOW_STATE" \
+    integration --field merge_results --value "$MERGE_RESULTS_JSON"
+$SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state "$FLOW_STATE" \
+    integration --field conflicts --value "$CONFLICTS_COUNT"
+```
+
+## 制約
+
+- 直接 `git worktree add` の実行は **禁止**
+- `git-prepare.sh --suffix merge` / `--suffix merge-retry` の直接呼び出しも **禁止** (merge worktree は worker 経由のみ)
+- merge branch は **リモートに push しない**。push は後続の PR 作成ステップ (parent 側) で行う
+- worker は flow.json を read-only で扱い、書き込みは必ず parent (dev-integrate) が行う
+
+## 前提
+
+- Claude Code >= 2.1.63 (`isolation: worktree` フィールド対応)
+- `.claude/agents/dev-kickoff-worker.md` がリポジトリに存在し、`mode: merge` 分岐が実装されていること
+
+## Subagent Dispatch 5要素
+
+共通規約 ([`_shared/references/subagent-dispatch.md`](../../_shared/references/subagent-dispatch.md)) に沿って以下を遵守する。
+
+1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに merge 用 branch `feature/issue-${ISSUE}-merge` (or `-merge-retry`) を isolated worktree で作成し、`merge-subtasks.sh` → 型チェック → `dev-validate` を実行して `{status, branch, worktree_path, commit_sha, merge_results, conflicts}` を返す」
+2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, merge_results: object, conflicts: number, phase_failed?: string, error?: string }` JSON。`merge_results` は `merge-subtasks.sh` の出力をそのまま埋め込む。
+3. **Tools** — worker frontmatter で許可: `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep`。dev-integrate 側から追加 tool 制約は付けない
+4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止 (merge branch も含む)、subtask / contract branch を rewrite しない、`git worktree add` を直接実行しない、flow.json を書き込まない (read-only)
+5. **Token cap** — worker 1 回あたり 2000 turn 以内 (`dev-kickoff-worker.md` 既定)、merge mode は通常 1 spawn で完結。失敗時のみ `-merge-retry` で最大 1 回 re-spawn する
+
+## Routing
+
+- merge worktree 作成 + merge 実行 → `dev-kickoff-worker` (sonnet, `isolation: worktree`, `mode: merge`)
+- merge 結果集約 / flow.json 書き込み → dev-integrate 親 (sonnet)
+- type check / validation 詳細は worker 内で完結 (dev-validate が委譲する)

--- a/tests/dev-integrate-worker-dispatch.sh
+++ b/tests/dev-integrate-worker-dispatch.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# AC1-AC5: dev-integrate が merge worktree 作成のために dev-kickoff-worker subagent を
+# Agent(isolation: worktree, mode: merge) で dispatch する経路の lint 検証。
+#
+# 検査対象: dev-integrate/SKILL.md および dev-integrate/references/ 配下
+#   - Step 4 で Agent(subagent_type: "dev-kickoff-worker", isolation: "worktree") を使用
+#   - 必須 prompt 引数 (issue_number / branch_name / base_ref / mode=merge / flow_state) が記述
+#   - merge worktree 作成で `git-prepare.sh --suffix merge` を直接呼び出していない
+#   - integration 結果 (merge_results / conflicts) が flow.json.integration に転記されることが文書化
+#   - merge-retry も worker 再 spawn (branch_name=...-merge-retry) で再現可能と文書化
+#
+# SKILL.md は progressive disclosure 方針で worker dispatch 詳細を references/ に分離するため、
+# Case 2/3/4/8/9 は SKILL.md + references/ の union を検査する。Case 5/6/7 は SKILL.md 本体のみ。
+#
+# Issue #82 で導入 (dev-decompose-worker-dispatch.sh と対称設計)。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL_MD="$REPO_ROOT/dev-integrate/SKILL.md"
+REFS_DIR="$REPO_ROOT/dev-integrate/references"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+pass() { echo "PASS: $1"; }
+
+# union: SKILL.md + 配下 references/*.md
+search_union() {
+    local pattern="$1"
+    grep -qE "$pattern" "$SKILL_MD" "$REFS_DIR"/*.md 2>/dev/null
+}
+
+# Case 1: SKILL.md exists
+[[ -f "$SKILL_MD" ]] || fail "Case 1: $SKILL_MD not found"
+pass "Case 1: dev-integrate/SKILL.md exists"
+
+# Case 2: Agent(subagent_type: "dev-kickoff-worker") is referenced (SKILL.md or references)
+search_union 'subagent_type:[[:space:]]*"dev-kickoff-worker"' \
+    || fail "Case 2: SKILL.md or references must reference subagent_type: \"dev-kickoff-worker\""
+pass "Case 2: SKILL.md/references reference dev-kickoff-worker subagent"
+
+# Case 3: isolation: "worktree" is specified for the dispatch (SKILL.md or references)
+search_union 'isolation:[[:space:]]*"worktree"' \
+    || fail "Case 3: SKILL.md or references must specify isolation: \"worktree\" for the worker dispatch"
+pass "Case 3: SKILL.md/references specify isolation: \"worktree\""
+
+# Case 4: required worker prompt fields are documented (SKILL.md or references)
+# merge mode は task_id を使わず flow_state を必須とする (single/parallel との差分)
+for field in issue_number branch_name base_ref mode flow_state; do
+    search_union "^[[:space:]]*${field}:" \
+        || fail "Case 4: SKILL.md or references must document worker prompt field '${field}:'"
+done
+# mode: merge であることが明示されていること
+search_union 'mode:[[:space:]]*merge' \
+    || fail "Case 4: SKILL.md or references must document 'mode: merge' for the dispatch"
+pass "Case 4: worker prompt fields (issue_number/branch_name/base_ref/mode=merge/flow_state) documented"
+
+# Case 5: merge worktree must NOT be created via direct git-prepare --suffix merge...
+# (SKILL.md 本体のみチェック。references の散文で禁止理由を述べるのは許容)
+if grep -nE '(^|[[:space:]])(\$[A-Z_]+/)?(.*/)?git-prepare\.sh[[:space:]]+[^#]*--suffix[[:space:]]+merge' "$SKILL_MD" >/dev/null 2>&1; then
+    echo "Offending line(s):" >&2
+    grep -nE '(^|[[:space:]])(\$[A-Z_]+/)?(.*/)?git-prepare\.sh[[:space:]]+[^#]*--suffix[[:space:]]+merge' "$SKILL_MD" >&2
+    fail "Case 5: dev-integrate/SKILL.md must not invoke git-prepare.sh --suffix merge... directly for merge worktree"
+fi
+pass "Case 5: no direct git-prepare.sh --suffix merge... invocation (worker dispatch required)"
+
+# Case 6: Subagent Dispatch Rules section is present in SKILL.md
+# (subagent-dispatch-lint requires the section to exist in SKILL.md because Agent( is mentioned there)
+grep -qE '^## Subagent Dispatch Rules' "$SKILL_MD" \
+    || fail "Case 6: SKILL.md must include '## Subagent Dispatch Rules' section"
+pass "Case 6: Subagent Dispatch Rules section present in SKILL.md"
+
+# Case 7: required 5 elements present in SKILL.md (global subagent-dispatch-lint との整合)
+for elem in "Objective" "Output format" "Tools" "Boundary" "Token cap"; do
+    grep -q -- "$elem" "$SKILL_MD" \
+        || fail "Case 7: required element '$elem' missing from SKILL.md (global lint requirement)"
+done
+pass "Case 7: required 5 elements present in dev-integrate/SKILL.md"
+
+# Case 8: integration result transcription is documented
+# worker JSON return (merge_results / conflicts) が flow.json.integration に転記されることが
+# SKILL.md か references のどこかに書かれている
+search_union 'merge_results' \
+    || fail "Case 8: SKILL.md/references must document worker return field 'merge_results'"
+search_union 'conflicts' \
+    || fail "Case 8: SKILL.md/references must document worker return field 'conflicts'"
+search_union '(flow\.json|flow-update|integration[^"]{0,40})' \
+    || fail "Case 8: SKILL.md/references must document writing the worker result back to flow.json integration section"
+pass "Case 8: integration result transcription documented (merge_results / conflicts → flow.json integration)"
+
+# Case 9: merge-retry pattern documented via worker re-spawn with branch_name: ...-merge-retry
+search_union 'merge-retry' \
+    || fail "Case 9: SKILL.md/references must document the merge-retry pattern (worker re-spawn)"
+pass "Case 9: merge-retry pattern documented via worker re-spawn"
+
+echo "OK: tests/dev-integrate-worker-dispatch.sh"

--- a/tests/dev-kickoff-worker-prompt.sh
+++ b/tests/dev-kickoff-worker-prompt.sh
@@ -61,4 +61,17 @@ echo "$BODY" | grep -qiE '(commit_sha|commit sha)' \
     || fail "Case 4c: body should mention commit_sha"
 pass "Case 4: return JSON contract documented (status/branch/commit_sha)"
 
+# Case 5: body documents `mode: merge` branch and merge-subtasks invocation (issue #82)
+# 3-mode 化 (single / parallel / merge) と、merge mode 内での merge-subtasks.sh / 型チェック /
+# dev-validate シーケンス、加えて merge_results / conflicts を return JSON に含める拡張を要求する
+echo "$BODY" | grep -qE '(mode:[[:space:]]*merge|Mode:[[:space:]]*merge|`merge`[[:space:]]*mode)' \
+    || fail "Case 5a: body must document 'mode: merge' branch"
+echo "$BODY" | grep -qE 'merge-subtasks(\.sh)?' \
+    || fail "Case 5b: body must document merge-subtasks invocation under merge mode"
+echo "$BODY" | grep -qE 'merge_results' \
+    || fail "Case 5c: body must document return field 'merge_results' for merge mode"
+echo "$BODY" | grep -qE 'conflicts' \
+    || fail "Case 5d: body must document return field 'conflicts' for merge mode"
+pass "Case 5: mode:merge branch documented with merge-subtasks invocation and extended JSON contract"
+
 echo "OK: tests/dev-kickoff-worker-prompt.sh"


### PR DESCRIPTION
## 概要

`dev-integrate` の merge worktree 作成を `git-prepare --suffix merge` 直接呼び出しから `dev-kickoff-worker` subagent (mode=merge, `isolation: worktree`) 経由に移行。

これにより worktree 作成パターンが dev-kickoff (single/parallel)・dev-decompose (parallel subtask)・dev-integrate (merge) の3者で完全に揃い、`git-prepare` 直接呼び出しを削除するロードマップ (#85) のクリティカルパスが解消される。

Parent: #79 / 前段: #81 (PR #85 merged)

## 主な変更

- **`.claude/agents/dev-kickoff-worker.md`**: 既存 mode (single/parallel) に `mode=merge` を追加。merge ブランチでは `dev-integrate/scripts/merge-subtasks.sh` を実行し、戻り値に `merge_results` / `conflicts` を含める拡張 JSON contract を documented
- **`dev-integrate/SKILL.md`**: Step 4 を `Agent(subagent_type: \"dev-kickoff-worker\", isolation: \"worktree\")` dispatch に書き換え。Subagent Dispatch Rules セクション追加、`git-prepare` 直接参照を削除
- **`dev-integrate/references/integration-guide.md`**: Step 4 / 4b / 5-7 / 8 + Scenario 1 を worker dispatch ベースに改訂。retry (--suffix merge-retry) も同パターンで再 spawn
- **`dev-integrate/references/worker-dispatch.md` (新規)**: Agent 呼び出しテンプレート、5 元素 (Objective / Output format / Tools / Boundary / Token cap)、retry パターン、親責務 (flow.json.integration 記録) を集約
- **`dev-flow/references/workflow-detail.md`**: parallel mode Step 6b の dev-integrate 記述を worker 経由に更新
- **`tests/dev-integrate-worker-dispatch.sh` (新規)**: 7 ケースで routing 検証 (worker subagent 参照 / isolation:worktree / 5 元素 / 直接 `git-prepare --suffix merge` 不在 / retry パターン / flow.json transcription)
- **`tests/dev-kickoff-worker-prompt.sh`**: Case 5 を追加 (mode=merge ブランチの merge-subtasks invocation / 拡張 JSON contract)

## 受け入れ条件

- [x] dev-integrate Phase 4 を Agent(`dev-kickoff-worker`, `isolation: \"worktree\"`) 経由に変更
- [x] merge 結果を worker JSON return value (`{status, merge_results, conflicts}`) で受け取り、flow.json.integration に記録
- [x] merge retry (--suffix merge-retry) も同パターンで再 spawn
- [x] dev-integrate / 関連 docs から `git-prepare` 直接参照削除
- [x] 既存 integration test GREEN 維持
- [x] 新規テスト: merge worker subagent の routing 検証

## 設計判断

`dev-kickoff-worker` を兼用 (新規 `dev-integrate-worker` 作らず) する選択。理由:

- すでに `mode=single` / `mode=parallel` で分岐済みで、`mode=merge` 追加で agent インベントリを増やさず統一できる
- merge-specific tools (git merge, conflict-resolution) は既存 `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep` で全カバー
- mode 切替は worker prompt 内の dispatch ロジックで分離

## テスト

```bash
$ for t in tests/*.sh; do bash \"$t\"; done
# 全 tests GREEN (7 / 30 / 3 / 3 / 0 / 0 / 0 fail across 7 test scripts)
```

## 関連

- Parent: #79
- 前段: #81 (PR #85 merged)
- 後段: #85 (git-prepare 完全削除)

Closes #82