### PR TITLE
refactor(skills): worker-dispatch refs を _shared/ で共通化

### DIFF
--- a/_shared/references/worker-dispatch.md
+++ b/_shared/references/worker-dispatch.md
@@ -1,0 +1,75 @@
+# dev-kickoff-worker Dispatch (Common)
+
+dev-flow family が `dev-kickoff-worker` subagent を `isolation: worktree` で spawn する際の共通規約。caller skill (`dev-decompose`, `dev-integrate`, 将来 `dev-kickoff` single mode) は本書を参照し、mode 固有の差分のみを自 refs に残す。
+
+## 適用 caller / mode
+
+| Caller skill | Mode | Refs (mode 固有) |
+|---|---|---|
+| `dev-decompose` | `parallel` | [`dev-decompose/references/worker-dispatch.md`](../../dev-decompose/references/worker-dispatch.md) |
+| `dev-integrate` | `merge` | [`dev-integrate/references/worker-dispatch.md`](../../dev-integrate/references/worker-dispatch.md) |
+| `dev-kickoff` | `single` / `parallel` | (SKILL.md 内に inline) |
+
+## Agent 呼び出しテンプレート
+
+```text
+Agent(
+  subagent_type: "dev-kickoff-worker",
+  isolation: "worktree",
+  prompt: "
+    issue_number: $ISSUE
+    branch_name: <mode-specific>
+    base_ref: <mode-specific>
+    mode: <single|parallel|merge>
+    task_id: <parallel mode only>
+    flow_state: <parallel/merge mode only>
+  "
+)
+```
+
+`branch_name` / `base_ref` / 追加パラメータの実値は mode 固有 refs を参照。
+
+## 共通 Output schema (last-line JSON)
+
+```json
+{
+  "status": "completed" | "failed",
+  "branch": "<branch name>",
+  "worktree_path": "<absolute path>",
+  "commit_sha": "<HEAD sha>",
+  "phase_failed": "<phase id, on failure>",
+  "error": "<message, on failure>"
+}
+```
+
+mode 別の拡張フィールド (例: `merge_results`, `conflicts`, `pr_url`) は mode 固有 refs に記載。
+
+## 共通制約
+
+- `git worktree add` の直接実行は **禁止**。worktree は worker 経由でのみ作成
+- worker は自身の isolated worktree 内のみで作業し、subtask / contract / merge branch を相互に書き換えない
+- subtask / contract / merge branch は **リモートに push しない**。push は PR 作成ステップで親が行う
+- worker は `flow.json` を **read-only** で扱う。書き込みは必ず親 skill が `_lib/scripts/flow-update.sh` 経由で行う
+
+## 前提
+
+- Claude Code >= 2.1.63 (`isolation: worktree` フィールド対応)
+- `.claude/agents/dev-kickoff-worker.md` がリポジトリに存在し、対象 mode 分岐が実装されていること
+
+## Subagent Dispatch 5要素 (共通部)
+
+基底規約は [`subagent-dispatch.md`](subagent-dispatch.md) を参照。worker dispatch では以下を全 caller で固定:
+
+| 要素 | 共通値 |
+|---|---|
+| Tools | worker frontmatter で許可: `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep`。caller 側から追加 tool 制約は付けない |
+| Token cap (worker 単位) | 1 spawn あたり 2000 turn 以内 (`dev-kickoff-worker.md` 既定) |
+| Boundary (共通) | worker は自 worktree 内のみ作業 / `git push` 禁止 / `git worktree add` 直接実行禁止 / `flow.json` read-only |
+
+`Objective` / `Output format` 詳細 / 追加 `Boundary` / `Token cap` の caller 単位上限 (例: subtask 数、retry 回数) は mode 固有 refs に記載。
+
+## Routing
+
+- worktree 作成 + worker 内ワークフロー → `dev-kickoff-worker` (sonnet, `isolation: worktree`)
+- 結果集約 / `flow.json` 書き込み / retry 判断 → caller skill 親
+- 探索 heavy / planning は worker ではなく caller 親 or 別 subagent (Explore/Plan)

--- a/dev-decompose/references/worker-dispatch.md
+++ b/dev-decompose/references/worker-dispatch.md
@@ -1,47 +1,22 @@
-# Step 8: Worker Subagent Dispatch
+# Step 8: Worker Subagent Dispatch (parallel mode)
 
-各 subtask に対し `dev-kickoff-worker` subagent を `isolation: worktree` モードで起動し、contract branch をベースに subtask 用 worktree を作成する。
+各 subtask に対し `dev-kickoff-worker` を `mode: parallel` で spawn し、contract branch をベースに subtask 用 worktree を作成する。
 
-## Agent 呼び出し
+共通規約 (Agent テンプレート、共通 Output schema、共通制約、5要素のうち共通部、Routing) は [`_shared/references/worker-dispatch.md`](../../_shared/references/worker-dispatch.md) を参照。本書は parallel mode 固有の差分のみ記載する。
 
-```text
-Agent(
-  subagent_type: "dev-kickoff-worker",
-  isolation: "worktree",
-  prompt: "
-    issue_number: $ISSUE
-    branch_name: feature/issue-${ISSUE}-task${INDEX}
-    base_ref: feature/issue-${ISSUE}-contract
-    mode: parallel
-    task_id: task${INDEX}
-    flow_state: $FLOW_STATE
-  "
-)
-```
+## Prompt パラメータ (parallel mode 差分)
 
-worker が返す値: `{status, branch, worktree_path, commit_sha}`（last-line JSON contract）。
+| Field | Value |
+|---|---|
+| `branch_name` | `feature/issue-${ISSUE}-task${INDEX}` |
+| `base_ref` | `feature/issue-${ISSUE}-contract` |
+| `mode` | `parallel` |
+| `task_id` | `task${INDEX}` |
+| `flow_state` | `$FLOW_STATE` (path) |
 
-## 制約
+返却値は共通 Output schema (拡張フィールドなし)。worker は parallel mode で `git push` をスキップする。
 
-- 直接 `git worktree add` の実行は **禁止**（subtask 用 worktree は worker 経由のみ）
-- subtask / contract branch は **リモートに push しない**。push が必要なのは最終 merge ブランチのみ（PR 作成時）。worker は parallel mode で `git push` をスキップする
+## 5要素 (parallel mode 固有)
 
-## 前提
-
-- Claude Code >= 2.1.63（`isolation: worktree` フィールド対応）
-- `.claude/agents/dev-kickoff-worker.md` がリポジトリに存在すること
-
-## Subagent Dispatch 5要素
-
-共通規約 ([`_shared/references/subagent-dispatch.md`](../../_shared/references/subagent-dispatch.md)) に沿って以下を遵守する。
-
-1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに subtask `task${INDEX}` 用の branch `feature/issue-${ISSUE}-task${INDEX}` を isolated worktree で作成し、`{status, branch, worktree_path, commit_sha}` を返す」（Phase 1 のみ。Phase 2-7 は dev-kickoff から `--task-id` で再呼び出し）
-2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, phase_failed?: string, error?: string }` JSON
-3. **Tools** — worker frontmatter で許可: `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep`。dev-decompose 側から追加 tool 制約は付けない
-4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止（parallel mode）、subtask 外の branch を触らない、`git worktree add` を直接実行しない
-5. **Token cap** — worker 1 回あたり 2000 turn 以内（`dev-kickoff-worker.md` 既定）、Step 8 全体で subtask 数 ≤ 5 を推奨
-
-## Routing
-
-- subtask worktree 作成 → `dev-kickoff-worker` (sonnet, isolation: worktree)
-- 通常の探索 / planning → dev-decompose 自身 (opus, effort: max)
+- **Objective** — 「contract branch をベースに `feature/issue-${ISSUE}-task${INDEX}` を isolated worktree で作成し、共通 schema を返す」(Phase 1 のみ。Phase 2-7 は dev-kickoff から `--task-id` で再呼び出し)
+- **Token cap (caller 上限)** — Step 8 全体で subtask 数 ≤ 5 を推奨

--- a/dev-integrate/references/worker-dispatch.md
+++ b/dev-integrate/references/worker-dispatch.md
@@ -1,49 +1,28 @@
 # Step 4: Worker Subagent Dispatch (merge mode)
 
-dev-integrate の merge worktree 作成は、`dev-kickoff-worker` を `isolation: worktree` + `mode: merge` で spawn することで行う。
+dev-integrate の merge worktree 作成は、`dev-kickoff-worker` を `mode: merge` で spawn することで行う。
 
-## Agent 呼び出し
+共通規約 (Agent テンプレート、共通 Output schema、共通制約、5要素のうち共通部、Routing) は [`_shared/references/worker-dispatch.md`](../../_shared/references/worker-dispatch.md) を参照。本書は merge mode 固有の差分のみ記載する。
 
-```text
-Agent(
-  subagent_type: "dev-kickoff-worker",
-  isolation: "worktree",
-  prompt: "
-    issue_number: $ISSUE
-    branch_name: feature/issue-${ISSUE}-merge
-    base_ref: feature/issue-${ISSUE}-contract
-    mode: merge
-    flow_state: $FLOW_STATE
-  "
-)
-```
+## Prompt パラメータ (merge mode 差分)
 
-retry 時は `branch_name` に `-merge-retry` suffix を付ける:
+| Field | Value (初回) | Value (retry) |
+|---|---|---|
+| `branch_name` | `feature/issue-${ISSUE}-merge` | `feature/issue-${ISSUE}-merge-retry` |
+| `base_ref` | `feature/issue-${ISSUE}-contract` | (同左) |
+| `mode` | `merge` | (同左) |
+| `flow_state` | `$FLOW_STATE` (path) | (同左) |
 
-```text
-Agent(
-  subagent_type: "dev-kickoff-worker",
-  isolation: "worktree",
-  prompt: "
-    issue_number: $ISSUE
-    branch_name: feature/issue-${ISSUE}-merge-retry
-    base_ref: feature/issue-${ISSUE}-contract
-    mode: merge
-    flow_state: $FLOW_STATE
-  "
-)
-```
+`task_id` は使用しない。
 
-worker が返す値 (last-line JSON):
+## Output schema (merge mode 拡張)
+
+共通 schema に以下を追加:
 
 ```json
 {
-  "status": "completed",
-  "branch": "feature/issue-${ISSUE}-merge",
-  "worktree_path": "/abs/path/to/isolated/worktree",
-  "commit_sha": "<HEAD sha>",
   "merge_results": {
-    "status": "success",
+    "status": "success" | "failed",
     "total_subtasks": 3,
     "merged": 3,
     "conflicts": 0,
@@ -55,24 +34,11 @@ worker が返す値 (last-line JSON):
 }
 ```
 
-失敗時 (unresolvable conflict / type check fail / validation fail):
-
-```json
-{
-  "status": "failed",
-  "phase_failed": "merge",
-  "branch": "feature/issue-${ISSUE}-merge",
-  "worktree_path": "/abs/path",
-  "commit_sha": "<best-effort sha>",
-  "merge_results": {"status": "failed", "results": [...]},
-  "conflicts": 1,
-  "error": "unresolvable conflict in src/foo.ts"
-}
-```
+失敗時は共通 schema の `status: "failed"` / `phase_failed: "merge"` / `error` に加え、`merge_results.status: "failed"` と `conflicts: <count>` が入る。
 
 ## Parent (dev-integrate) の責務
 
-worker から返った JSON をそのまま `flow.json.integration` に転記する。dev-integrate 親は worktree を直接操作せず、状態管理に専念する:
+worker から返った JSON をそのまま `flow.json.integration` に転記する。parent は worktree を直接操作せず、状態管理に専念する:
 
 ```bash
 $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state "$FLOW_STATE" \
@@ -85,29 +51,12 @@ $SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state "$FLOW_STATE" \
     integration --field conflicts --value "$CONFLICTS_COUNT"
 ```
 
-## 制約
+## 5要素 (merge mode 固有)
 
-- 直接 `git worktree add` の実行は **禁止** (merge worktree は worker 経由のみ)
-- merge branch は **リモートに push しない**。push は後続の PR 作成ステップ (parent 側) で行う
-- worker は flow.json を read-only で扱い、書き込みは必ず parent (dev-integrate) が行う
+- **Objective** — 「contract branch をベースに `feature/issue-${ISSUE}-merge` (or `-merge-retry`) を isolated worktree で作成し、`merge-subtasks.sh` → 型チェック → `dev-validate` を実行して `{..., merge_results, conflicts}` を返す」
+- **Boundary (追加)** — subtask / contract branch を rewrite しない
+- **Token cap (caller 上限)** — 通常 1 spawn で完結。失敗時のみ `-merge-retry` で最大 1 回 re-spawn
 
-## 前提
+## Routing 追記
 
-- Claude Code >= 2.1.63 (`isolation: worktree` フィールド対応)
-- `.claude/agents/dev-kickoff-worker.md` がリポジトリに存在し、`mode: merge` 分岐が実装されていること
-
-## Subagent Dispatch 5要素
-
-共通規約 ([`_shared/references/subagent-dispatch.md`](../../_shared/references/subagent-dispatch.md)) に沿って以下を遵守する。
-
-1. **Objective** — 「contract branch `feature/issue-${ISSUE}-contract` をベースに merge 用 branch `feature/issue-${ISSUE}-merge` (or `-merge-retry`) を isolated worktree で作成し、`merge-subtasks.sh` → 型チェック → `dev-validate` を実行して `{status, branch, worktree_path, commit_sha, merge_results, conflicts}` を返す」
-2. **Output format** — `{ status: "completed"|"failed", branch: string, worktree_path: string, commit_sha: string, merge_results: object, conflicts: number, phase_failed?: string, error?: string }` JSON。`merge_results` は `merge-subtasks.sh` の出力をそのまま埋め込む。
-3. **Tools** — worker frontmatter で許可: `Bash, Read, Write, Edit, Skill, TodoWrite, Glob, Grep`。dev-integrate 側から追加 tool 制約は付けない
-4. **Boundary** — worker は自身の isolated worktree 内のみで作業、`git push` 禁止 (merge branch も含む)、subtask / contract branch を rewrite しない、`git worktree add` を直接実行しない、flow.json を書き込まない (read-only)
-5. **Token cap** — worker 1 回あたり 2000 turn 以内 (`dev-kickoff-worker.md` 既定)、merge mode は通常 1 spawn で完結。失敗時のみ `-merge-retry` で最大 1 回 re-spawn する
-
-## Routing
-
-- merge worktree 作成 + merge 実行 → `dev-kickoff-worker` (sonnet, `isolation: worktree`, `mode: merge`)
-- merge 結果集約 / flow.json 書き込み → dev-integrate 親 (sonnet)
-- type check / validation 詳細は worker 内で完結 (dev-validate が委譲する)
+- type check / validation 詳細は worker 内で完結 (`dev-validate` が委譲する)


### PR DESCRIPTION
## Summary

- dev-decompose / dev-integrate / 将来の dev-kickoff single mode で重複していた `dev-kickoff-worker` dispatch 規約を `_shared/references/worker-dispatch.md` に共通化
- 各 caller の `references/worker-dispatch.md` は mode 固有差分 (parallel / merge) のみに圧縮
- Agent 呼び出しテンプレート / 共通 Output schema / 共通制約 / 5要素共通部 / Routing を共通 ref に集約

## Test plan

- [ ] `_shared/references/worker-dispatch.md` の相対リンクが解決できる
- [ ] dev-decompose / dev-integrate の mode 固有 ref が共通 ref を正しく参照している
- [ ] mode 固有差分 (parallel: task_id / merge: merge_results) が抜けていない