### PR TITLE
docs(skills): no-backcompat 原則を CLAUDE.md / skill-creation-guide に明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ skills/
 - **Namespace 命名** — `dev-*`, `blog-*`, `git-*`, `sns-*` 等でグループ化
 - **既存パターンに従う** — 新規スキルは同カテゴリの既存スキルを参考にする
 - **共有処理は `_shared/` か `_lib/`** — スキル間で重複するロジックは共有化
+- **後方互換 scaffolding を作らない** — 内製スキル間の schema 変更で legacy fallback / version enum / dual-path を入れない。新形式のみ受理、out-of-enum は schema error。詳細: [skill-creation-guide.md → 設計原則 #9](docs/skill-creation-guide.md#設計原則)
 
 ## コミット規約
 

--- a/docs/skill-creation-guide.md
+++ b/docs/skill-creation-guide.md
@@ -235,6 +235,23 @@ User triggers /command
    format / test / secret 検査のように LLM の判断を介さず必ず走らせたい処理は、
    skill 化すると呼び出し漏れが起きる。hook での実装を検討すること。
    hook 実装は dotfiles repo の `claude-code/hooks/` を参照
+9. **後方互換 scaffolding を作らない**:
+   内製スキルは外部公開ライブラリではなく本 repo 内で完結するため、schema 変更や
+   dispatch 仕様変更時の **legacy fallback / version enum / dual-path 実装は禁止**。
+   旧形式を返す呼び出し元は merge 前に存在せず、互換マッピングの実用上の必要性がない。
+   逆に SKILL.md / scripts / tests に rollout 期間の説明を入れると常時コンテキスト消費・
+   複雑性のオーバーヘッドになる。
+   - schema 変更時は **新形式のみ受理**。out-of-enum は `unknown` バケット →
+     `journal failure --error-category schema_error` で顕在化させる
+   - 「version >= X.Y.Z なら新方式、未満なら legacy」のような分岐を作らない。
+     未満は明確な error で abort、要件として「>= X.Y.Z 必須」と明示する
+   - JSON schema や config の version enum は最新版 `const` で固定
+   - 「クリティカルな問題があったら修正すればいい」原則 — 移行コストよりメンテ
+     コストの方が高い場合は移行を即実行
+   - **例外**: 外部 API / 公開フォーマット（GitHub Action input、blog MDX 等の
+     ユーザー所有データ、SemVer 公開している lib）の互換性は維持する
+   - 過去事例: PR #80 / PR #94 で `detect-worker.sh` dual-path や
+     `legacy_success` / `legacy_fail` / `legacy_mapped` を入れて指摘・全削除
 
 ## Subagent Dispatch Rules
 


### PR DESCRIPTION
## 背景

PR #80 (issue #79) と PR #94 (issue #92) で立て続けに **「内製スキルに後方互換 scaffolding が入っている」** と指摘を受けた:

- PR #80: `detect-worker.sh` + dual-path + schema v1/v2 dual-support → 「クリティカルな問題があったら修正すればいい」 → 約 230 行削減
- PR #94: `legacy_success` / `legacy_fail` / `legacy_mapped` / 「後方互換」section を 11 ファイル / 153 行追加 → 「無駄にコンテクスト消費大きくしてない？」 → [commit bb113b3](https://github.com/it-all-playpark/skills/commit/bb113b3) で全削除

これまで個人 memory (`feedback_skill_no_backcompat.md`) に閉じ込められていたが、**2 回連続で同じ失敗**をしているのでプロジェクトルールに格上げする。

## 変更内容

### 1. `docs/skill-creation-guide.md` — 「設計原則」#9 を追加

```
9. **後方互換 scaffolding を作らない**:
   内製スキルは外部公開ライブラリではなく本 repo 内で完結するため、schema 変更や
   dispatch 仕様変更時の **legacy fallback / version enum / dual-path 実装は禁止**。
   ...
   - schema 変更時は **新形式のみ受理**。out-of-enum は `unknown` バケット →
     `journal failure --error-category schema_error` で顕在化させる
   - 「version >= X.Y.Z なら新方式、未満なら legacy」のような分岐を作らない。
     未満は明確な error で abort、要件として「>= X.Y.Z 必須」と明示する
   - JSON schema や config の version enum は最新版 `const` で固定
   - **例外**: 外部 API / 公開フォーマット（GitHub Action input、blog MDX 等の
     ユーザー所有データ、SemVer 公開している lib）の互換性は維持する
   - 過去事例: PR #80 / PR #94 で `detect-worker.sh` dual-path や
     `legacy_success` / `legacy_fail` / `legacy_mapped` を入れて指摘・全削除
```

### 2. `CLAUDE.md` — 「開発ルール」に 1 行サマリと参照リンク

```
- **後方互換 scaffolding を作らない** — 内製スキル間の schema 変更で legacy
  fallback / version enum / dual-path を入れない。新形式のみ受理、out-of-enum
  は schema error。詳細: skill-creation-guide.md → 設計原則 #9
```

## 効果

- CLAUDE.md は `@docs/skill-creation-guide.md` で常時注入されるため、今後の skill 開発で同じ指摘が再発しないようコンテキストに乗る
- 関連 follow-up: #95 (既存の legacy fallback 棚卸し)

## Test plan

- [ ] docs only の変更で skill の動作には影響なし
- [ ] CLAUDE.md → skill-creation-guide.md のリンクが正しく解決される