### PR TITLE
refactor(dev-flow): 残存する legacy fallback の棚卸しと削除

### DIFF
--- a/_lib/schemas/flow.schema.json
+++ b/_lib/schemas/flow.schema.json
@@ -3,7 +3,7 @@
   "title": "Flow State",
   "description": "State persistence for dev-flow parallel subtask orchestration",
   "type": "object",
-  "required": ["version", "issue", "status", "subtasks", "config"],
+  "required": ["version", "issue", "status", "subtasks", "shared_findings", "config"],
   "properties": {
     "version": {
       "type": "string",
@@ -74,7 +74,7 @@
       "type": "array",
       "items": { "$ref": "#/$defs/shared_finding" },
       "default": [],
-      "description": "Cross-worker knowledge channel (Shared State pattern). Parallel dev-kickoff workers append breaking changes / design decisions here so other workers can incorporate them into their plans. dev-integrate verifies all findings are acknowledged before merging. Optional; legacy flow.json without this field remains valid."
+      "description": "Cross-worker knowledge channel (Shared State pattern). Parallel dev-kickoff workers append breaking changes / design decisions here so other workers can incorporate them into their plans. dev-integrate verifies all findings are acknowledged before merging."
     },
     "integration": {
       "$ref": "#/$defs/integration",

--- a/_shared/references/shared-findings.md
+++ b/_shared/references/shared-findings.md
@@ -40,7 +40,7 @@
 }
 ```
 
-`shared_findings` フィールドは optional（legacy flow.json は `[]` として扱われる）。
+`shared_findings` フィールドは flow.json 生成時に必ず初期化される（`init-flow.sh` が `[]` を書き込む）。
 
 ## 書き込み (worker 側 — Phase 4/5)
 
@@ -131,7 +131,7 @@ dev-integrate:
 - **Single-writer 原則の例外**: worker (= parallel 実行されるサブプロセス) からの書き込みは `flow-append-finding.sh` 経由で mkdir-based file lock を取るため安全。`flow-update.sh` は orchestrator 専用のまま。
 - **Ack は自己申告**: ack した = plan に反映した、という worker の自己申告。検証は人間側の責任範囲。
 - **Finding は append-only**: 一度書いた finding は変更しない。訂正が必要なら新しい finding を書く。
-- **後方互換**: `shared_findings` フィールドのない legacy flow.json はそのまま動く（空配列として扱う）。
+- **Reader robustness**: reader (`flow-read-findings.sh`) は欠落時に `// []` で空配列に fallback するが、これは graceful read のための保険であり、writer 側 (`init-flow.sh` / `flow-append-finding.sh`) が新規生成する flow.json では `shared_findings` フィールドは必ず存在する。
 
 ## 関連
 

--- a/_shared/scripts/detect-stuck-findings.py
+++ b/_shared/scripts/detect-stuck-findings.py
@@ -36,10 +36,6 @@ History schema (canonical)
   }
 ]
 
-Legacy severity aliases are honored:
-  - "blocking"     -> "major"
-  - "non-blocking" -> "minor"
-
 Output (stdout, JSON)
 ---------------------
 {
@@ -68,9 +64,6 @@ SEVERITY_ALIAS = {
     "critical": "critical",
     "major": "major",
     "minor": "minor",
-    # Legacy (pre-#46) aliases
-    "blocking": "major",
-    "non-blocking": "minor",
 }
 
 

--- a/_shared/scripts/termination-record.sh
+++ b/_shared/scripts/termination-record.sh
@@ -6,8 +6,7 @@
 #   - phases.3b_plan_review (Phase 3 ⇄ 3b: dev-plan-impl ⇄ dev-plan-review)
 #   - phases.6_evaluate     (Phase 4-5 ⇄ 6: dev-implement/validate ⇄ dev-evaluate)
 #
-# Writes `phases[<phase>].termination` with the unified schema and
-# mirrors legacy fields for backward compatibility (deprecated, 1 release).
+# Writes `phases[<phase>].termination` using the unified schema.
 # See: dev-kickoff/references/kickoff-schema.md `termination` block.
 #
 # Usage:
@@ -166,41 +165,6 @@ if [[ -n "$FINAL_VERDICT" ]]; then
       | .phases[$phase].termination.final_verdict = $final_verdict
     '
 fi
-
-# -----------------------------------------------------------------
-# Legacy / mirror fields (deprecated, 1 release backward-compat)
-# -----------------------------------------------------------------
-
-case "$PHASE" in
-    3b_plan_review)
-        # Mirror escalation state based on reason
-        if [[ "$REASON" == "converged" ]]; then
-            JQ_FILTER+='
-              | .phases[$phase].escalated = false
-            '
-        else
-            JQ_FILTER+='
-              | .phases[$phase].escalated = true
-              | .phases[$phase].escalation_reason = $reason
-            '
-        fi
-        # Mirror last_verdict / last_score from the most recent verdict if present
-        JQ_FILTER+='
-          | (.phases[$phase].termination.verdict_history | last) as $lv
-          | if $lv then
-              (.phases[$phase].last_verdict = (if $lv.verdict then $lv.verdict else (.phases[$phase].last_verdict // null) end))
-              | (.phases[$phase].last_score = (if $lv.score then $lv.score else (.phases[$phase].last_score // null) end))
-            else . end
-          | .phases[$phase].current_iteration = .phases[$phase].termination.final_iteration
-        '
-        ;;
-    6_evaluate)
-        # Mirror current_iteration (state machine reads it)
-        JQ_FILTER+='
-          | .phases[$phase].current_iteration = .phases[$phase].termination.final_iteration
-        '
-        ;;
-esac
 
 # Apply update atomically
 TMP_FILE=$(mktemp)

--- a/dev-decompose/scripts/init-flow.sh
+++ b/dev-decompose/scripts/init-flow.sh
@@ -141,6 +141,7 @@ jq -n \
         issue: $issue,
         status: $status,
         subtasks: [],
+        shared_findings: [],
         contract: {
             files: [],
             branch: $contract_branch

--- a/dev-flow-doctor/references/baseline-comparison.md
+++ b/dev-flow-doctor/references/baseline-comparison.md
@@ -130,7 +130,7 @@ BASELINE_FILE=<path> tests/no-glue-errors.sh
 3. `compare-baseline.sh` を呼び、exit code に応じて:
    - 0 → "OK: no glue-error regression detected" + exit 0
    - 1 → "FAIL: glue-error regression detected (baseline=X, current=Y)" + findings 列挙 + exit 1
-   - 2 → warning（corrupt / window mismatch）+ exit 0（back-compat）
+   - 2 → warning（corrupt / window mismatch）+ exit 0（graceful degradation）
 
 ## CI 運用パターン (AC5)
 

--- a/dev-flow-doctor/references/diagnostic-checks.md
+++ b/dev-flow-doctor/references/diagnostic-checks.md
@@ -5,28 +5,18 @@
 Analyze how often single vs parallel mode is actually used.
 
 ```bash
-# New entries (with context.mode)
+# Entries with context.mode
 $SKILLS_DIR/skill-retrospective/scripts/journal.sh query --skill dev-flow --limit 200 | \
   jq 'group_by(.context.mode // "unknown") | map({mode: .[0].context.mode // "unknown", count: length})'
-
-# Legacy entries (without context.mode): infer from heuristics
-# - duration_turns <= 5 AND no "parallel" in args → likely single
-# - duration_turns >= 10 OR "parallel" in args → likely parallel
-$SKILLS_DIR/skill-retrospective/scripts/journal.sh query --skill dev-flow --limit 200 | \
-  jq '[.[] | select(.context.mode == null)] |
-    { legacy_count: length,
-      likely_single: [.[] | select(.duration_turns <= 5 and (.args // "" | test("parallel|force-parallel") | not))] | length,
-      likely_parallel: [.[] | select(.duration_turns >= 10 or (.args // "" | test("parallel|force-parallel")))] | length,
-      ambiguous: [.[] | select(.duration_turns > 5 and .duration_turns < 10 and (.args // "" | test("parallel|force-parallel") | not))] | length
-    }'
 ```
+
+context.mode が記録されていない entry は schema error として扱う。heuristics による推定は行わない。
 
 | Finding | Recommendation |
 |---------|----------------|
 | All single (no parallel ever) | Auto-detect may be too conservative, review decompose dry-run criteria |
 | Parallel used but only via --force-parallel | Auto-detect not triggering when it should |
 | Healthy mix of single/parallel | Auto-detect working as intended |
-| Many ambiguous legacy entries | No action (will resolve as new mode-tagged entries accumulate) |
 
 ## Check 2: Failure & Partial Distribution
 

--- a/dev-flow-doctor/tests/test-no-glue-errors-threshold.sh
+++ b/dev-flow-doctor/tests/test-no-glue-errors-threshold.sh
@@ -37,9 +37,9 @@ assert_eq() {
 printf 'Test suite: tests/no-glue-errors.sh threshold mode\n\n'
 
 # ----------------------------------------------------------------------------
-# Test 1: No baseline → exit 0 (backwards compat)
+# Test 1: No baseline → exit 0 (graceful degradation)
 # ----------------------------------------------------------------------------
-printf 'Test 1: no baseline file → exit 0 (back-compat)\n'
+printf 'Test 1: no baseline file → exit 0 (graceful degradation)\n'
 BASELINE_FILE="$WORKDIR/non-existent.json" \
 CLAUDE_JOURNAL_DIR="$JOURNAL_CLEAN" \
 SKILL_CONFIG_PATH="$EMPTY_CONFIG" \

--- a/dev-implement/SKILL.md
+++ b/dev-implement/SKILL.md
@@ -148,7 +148,7 @@ $SKILLS_DIR/dev-kickoff/scripts/append-progress.sh \
 - `feature_list[i].id` と `desc` は **書き換え禁止**。`update-feature.sh` は `status` のみ変更する。
 - `Edit` ツールで kickoff.json の `feature_list` を直接書き換えない。必ずスクリプトを使う。
 - `progress_log` は append-only。既存エントリに触れない。
-- 後方互換: `feature_list` が未定義 or 空の場合（standalone 実行時など）はスキップして通常実装を続行する。
+- Standalone モード: `feature_list` が未定義 or 空の場合（standalone 実行 / impl-plan.md 入力のみで起動した場合）はスキップして通常実装を続行する。
 
 ### Step 5: Validate
 

--- a/dev-kickoff/references/evaluate-retry.md
+++ b/dev-kickoff/references/evaluate-retry.md
@@ -210,7 +210,7 @@ detect-stuck-findings.py --history <plan-review-history.json> [--min-severity cr
 
 1. `current_iteration = len(history)`
 2. If `current_iteration < 2` -> `escalate: false`
-3. For the last two iterations, build fingerprint sets `{(dimension, topic)}` from findings whose severity is `>= min_severity` (default `major`). Legacy `blocking` aliases to `major`; `non-blocking` aliases to `minor`.
+3. For the last two iterations, build fingerprint sets `{(dimension, topic)}` from findings whose severity is `>= min_severity` (default `major`).
 4. `stuck = prev_keys & curr_keys`
 5. `escalate = bool(stuck)`
 
@@ -220,17 +220,12 @@ detect-stuck-findings.py --history <plan-review-history.json> [--min-severity cr
 STUCK_RESULT=$($SKILLS_DIR/_shared/scripts/detect-stuck-findings.py \
   --history "$WORKTREE/.claude/plan-review-history.json")
 if [[ "$(echo "$STUCK_RESULT" | jq -r .escalate)" == "true" ]]; then
-  STUCK=$(echo "$STUCK_RESULT" | jq -c .stuck_findings)
-  # New unified termination schema (issue #53) — also mirrors legacy escalation fields
+  # Unified termination schema (issue #53)
   $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 3b_plan_review done \
     --worktree "$WORKTREE" \
-    --termination-reason stuck \
-    --stuck-findings "$STUCK"
+    --termination-reason stuck
 fi
 ```
-
-> `--escalated` / `--escalation-reason` を直接指定する旧 API は後方互換のため残るが、
-> 新規利用は `--termination-reason` に移行する（v3.2.0 の deprecation、v3.3.0 で旧 API 削除予定）。
 
 > 参考: 以前は `references/evaluate-retry.md` に下記の擬似 Python コードを載せていた。現在は上記スクリプトが同等ロジックを実装している。
 >
@@ -284,11 +279,3 @@ fi
 ```
 
 - `max_diff_ratio`: iteration > 1 で dev-plan-impl が書き直した plan と前回 plan の差分比率が超えたら warning（`dev-plan-impl/scripts/check-diff-scale.sh`）。default 0.5。非数値を入れると起動時にエラーで fail する。
-
-### 後方互換
-
-旧 schema を返す古い dev-plan-review 実装が混じる場合の読み替え:
-
-- `verdict: "fail"` → `revise`（critical 級 finding があれば `block` に昇格）
-- `severity: "blocking"` → `major`（致命度に応じて `critical`）
-- `severity: "non-blocking"` → `minor`

--- a/dev-kickoff/references/kickoff-schema.md
+++ b/dev-kickoff/references/kickoff-schema.md
@@ -164,31 +164,9 @@
    `verdict_history` は append-only なので、同じ iteration を再度 append しないよう
    呼び出し側が重複排除する責任を持つ。
 
-### 後方互換（1 リリース間維持、v3.2.0 → v3.3.0 で削除予定）
+## Standalone モード時のオプショナル動作
 
-既存の Phase 3b escalation フィールドは **deprecated** だが termination block と並行して
-書き込まれる:
-
-| 旧フィールド | 新しい位置 | deprecation |
-|------------|-----------|-------------|
-| `phases.3b_plan_review.escalated` (bool) | `termination.reason != "converged"` で true | deprecated、v3.3.0 で削除予定 |
-| `phases.3b_plan_review.escalation_reason` | `termination.reason` | 同上 |
-| `phases.3b_plan_review.stuck_findings` | `termination.reason == "stuck"` の補足情報 | 同上、termination block の `verdict_history` では表現しない |
-| `phases.3b_plan_review.last_verdict` | `termination.final_verdict` | 同上 |
-| `phases.3b_plan_review.last_score` | 最後の `verdict_history[].score` | 同上 |
-| `phases.6_evaluate.iterations[]` | `termination.verdict_history` | `iterations[]` は eval_result 全文を残すため継続維持 |
-| `phases.6_evaluate.current_iteration` | `termination.final_iteration` | 継続維持（状態機械の読み取りに使用） |
-
-読み取り側は **termination block を優先** し、存在しなければ旧フィールドへフォールバックする。
-
-## 後方互換
-
-- 既存の kickoff.json に `feature_list` / `progress_log` が無い場合は **空配列扱い**。
-- 読み取り側は必ず `// []` フォールバックを使う:
-  ```bash
-  jq '.feature_list // []' kickoff.json
-  jq '.progress_log // []' kickoff.json
-  ```
+- `feature_list` / `progress_log` が無い kickoff.json は **standalone 実行**（`dev-plan-impl` を経由しない直接起動）として扱う。`feature_list` が空または未定義の場合、`dev-implement` / `dev-validate` はスキップして通常処理を続行する。
 - `append-progress.sh` / `update-feature.sh` は、フィールド未定義の kickoff.json に対して自動的にフィールドを作成する。
 
 ## SessionStart hook 連携

--- a/dev-kickoff/references/plan-review-loop.md
+++ b/dev-kickoff/references/plan-review-loop.md
@@ -2,7 +2,7 @@
 
 Phase 3 → Phase 3b は **evaluator-optimizer ループ**として最大 **3 iteration** 回る（Anthropic: Building effective agents 推奨パターン）。
 
-詳細フロー・Output JSON schema・reset コマンドは [`evaluate-retry.md`](evaluate-retry.md#plan-review-loop-phase-3b--evaluator-optimizer) を参照。本ドキュメントは dev-kickoff 側の運用ルール（ループ遷移・escalation・stuck detection・config・後方互換）をまとめる。
+詳細フロー・Output JSON schema・reset コマンドは [`evaluate-retry.md`](evaluate-retry.md#plan-review-loop-phase-3b--evaluator-optimizer) を参照。本ドキュメントは dev-kickoff 側の運用ルール（ループ遷移・escalation・stuck detection・config）をまとめる。
 
 ## ループ遷移（verdict ベース）
 
@@ -18,8 +18,7 @@ Phase 3b（dev-plan-review）の Output JSON schema は `{score, verdict, findin
 
 - **`max_iterations = 3`**（既定、`config.plan_review.max_iterations` で override 可）
 - 3 iteration で pass に達しない場合、**user escalate**:
-  - `kickoff.json` の `phases.3b_plan_review.termination.reason = "max_iterations"` を記録（issue #53 の統一 termination schema）
-  - 同時に legacy フィールド `escalated = true` / `escalation_reason = "max_iterations"` も書き込む（1 リリース backward-compat）
+  - `kickoff.json` の `phases.3b_plan_review.termination.reason = "max_iterations"` を記録（統一 termination schema）
   - Skill 出力に `⚠️ Plan did not converge after 3 iterations. Proceeding with last plan; please review manually.` を明示
   - 既定は warning 付きで Phase 4 に進行（ユーザー中断を妨げない）
 
@@ -39,13 +38,12 @@ ESCALATE=$(echo "$STUCK_RESULT" | jq -r '.escalate')
 STUCK_FINDINGS=$(echo "$STUCK_RESULT" | jq -c '.stuck_findings')
 
 if [[ "$ESCALATE" == "true" ]]; then
-  # iter 3 を待たず即 escalate — 統一 termination schema (issue #53) 経由で記録
+  # iter 3 を待たず即 escalate — 統一 termination schema 経由で記録
   $SKILLS_DIR/dev-kickoff/scripts/update-phase.sh 3b_plan_review done \
     --worktree "$WORKTREE" \
-    --termination-reason stuck \
-    --stuck-findings "$STUCK_FINDINGS"
+    --termination-reason stuck
   echo "⚠️ Plan-review loop stuck. Same finding persisted across iterations. Escalating to user."
-  echo "Stuck findings: $STUCK_FINDINGS"
+  # stuck_findings の詳細は termination.verdict_history から確認可能
   # proceed to Phase 4 with warning
 fi
 ```
@@ -53,8 +51,7 @@ fi
 **仕様**:
 - 入力: `plan-review-history.json`（canonical schema。不在・空・破損いずれも `escalate: false` で exit 0）
 - 出力: `{escalate, current_iteration, stuck_findings, checked_severities}`
-- severity threshold: default `major` 以上（`--min-severity` で override 可能）
-- 後方互換: 旧 severity `blocking` は `major` に読み替え
+- severity threshold: default `major` 以上（`--min-severity` で override 可能）。`critical` / `major` / `minor` のみ受理
 - `topic` が fingerprint として働くため、dev-plan-review は**同じ問題には同じ topic 文字列**を使う運用（dev-plan-review SKILL.md に明記済み）
 
 ## Feedback 受け渡し
@@ -93,14 +90,6 @@ fi
 ```
 
 - `max_diff_ratio`: iteration > 1 の `dev-plan-impl` で前回 plan と今回 plan の行差分比が超えたら warning（`check-diff-scale.sh`）。default 0.5。
-
-## 後方互換
-
-旧 schema（`verdict: "fail"`, `severity: "blocking" | "non-blocking"`）を返す古い dev-plan-review 実装がある場合は次のように読み替える:
-
-- `fail` → `revise`（critical 相当の finding がある場合は `block`）
-- `blocking` → `major`（critical 級は `critical` に昇格）
-- `non-blocking` → `minor`
 
 ## Fork failure
 

--- a/dev-kickoff/scripts/update-phase.sh
+++ b/dev-kickoff/scripts/update-phase.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # update-phase.sh - Update phase status in kickoff state
 # Usage: update-phase.sh <phase> <status> [--result "..."] [--error "..."] [--worktree PATH] [--reset-to PHASE] [--eval-result JSON]
-#        [--escalated true|false] [--escalation-reason max_iterations|stuck|fork_failure]
-#        [--stuck-findings JSON] [--review-iteration N] [--review-verdict pass|revise|block] [--review-score N]
 #        [--termination-reason converged|max_iterations|stuck|fork_failure]
 #        [--termination-final-verdict V] [--termination-verdict-history JSON] [--append-verdict JSON]
 
@@ -23,12 +21,6 @@ PR_URL=""
 PR_NUMBER=""
 RESET_TO=""
 EVAL_RESULT=""
-ESCALATED=""
-ESCALATION_REASON=""
-STUCK_FINDINGS=""
-REVIEW_ITERATION=""
-REVIEW_VERDICT=""
-REVIEW_SCORE=""
 TERMINATION_REASON=""
 TERMINATION_FINAL_VERDICT=""
 TERMINATION_VERDICT_HISTORY=""
@@ -49,12 +41,6 @@ while [[ $# -gt 0 ]]; do
         --pr-number) PR_NUMBER="$2"; shift 2 ;;
         --reset-to) RESET_TO="$2"; shift 2 ;;
         --eval-result) EVAL_RESULT="$2"; shift 2 ;;
-        --escalated) ESCALATED="$2"; shift 2 ;;
-        --escalation-reason) ESCALATION_REASON="$2"; shift 2 ;;
-        --stuck-findings) STUCK_FINDINGS="$2"; shift 2 ;;
-        --review-iteration) REVIEW_ITERATION="$2"; shift 2 ;;
-        --review-verdict) REVIEW_VERDICT="$2"; shift 2 ;;
-        --review-score) REVIEW_SCORE="$2"; shift 2 ;;
         --termination-reason) TERMINATION_REASON="$2"; shift 2 ;;
         --termination-final-verdict) TERMINATION_FINAL_VERDICT="$2"; shift 2 ;;
         --termination-verdict-history) TERMINATION_VERDICT_HISTORY="$2"; shift 2 ;;
@@ -192,58 +178,6 @@ if [[ -n "$EVAL_RESULT" ]]; then
     JQ_FILTER="$JQ_FILTER | .phases[\"6_evaluate\"].termination.final_iteration = .phases[\"6_evaluate\"].current_iteration"
 fi
 
-# Plan-Review Loop (Phase 3b) escalation / state fields
-if [[ -n "$ESCALATED" ]]; then
-    if [[ "$ESCALATED" != "true" && "$ESCALATED" != "false" ]]; then
-        die_json "--escalated must be 'true' or 'false'" 1
-    fi
-    JQ_ARGS+=(--argjson escalated "$ESCALATED")
-    JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalated = \$escalated"
-fi
-
-if [[ -n "$ESCALATION_REASON" ]]; then
-    case "$ESCALATION_REASON" in
-        max_iterations|stuck|fork_failure) ;;
-        *) die_json "--escalation-reason must be one of: max_iterations, stuck, fork_failure" 1 ;;
-    esac
-    JQ_ARGS+=(--arg escalation_reason "$ESCALATION_REASON")
-    JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalation_reason = \$escalation_reason"
-fi
-
-if [[ -n "$STUCK_FINDINGS" ]]; then
-    # Must be a JSON array
-    if ! echo "$STUCK_FINDINGS" | jq -e 'type == "array"' >/dev/null 2>&1; then
-        die_json "--stuck-findings must be a JSON array" 1
-    fi
-    JQ_ARGS+=(--argjson stuck_findings "$STUCK_FINDINGS")
-    JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].stuck_findings = \$stuck_findings"
-fi
-
-if [[ -n "$REVIEW_ITERATION" ]]; then
-    if ! [[ "$REVIEW_ITERATION" =~ ^[0-9]+$ ]]; then
-        die_json "--review-iteration must be a non-negative integer" 1
-    fi
-    JQ_ARGS+=(--argjson review_iteration "$REVIEW_ITERATION")
-    JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].current_iteration = \$review_iteration"
-fi
-
-if [[ -n "$REVIEW_VERDICT" ]]; then
-    case "$REVIEW_VERDICT" in
-        pass|revise|block) ;;
-        *) die_json "--review-verdict must be one of: pass, revise, block" 1 ;;
-    esac
-    JQ_ARGS+=(--arg review_verdict "$REVIEW_VERDICT")
-    JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].last_verdict = \$review_verdict"
-fi
-
-if [[ -n "$REVIEW_SCORE" ]]; then
-    if ! [[ "$REVIEW_SCORE" =~ ^[0-9]+$ ]]; then
-        die_json "--review-score must be a non-negative integer" 1
-    fi
-    JQ_ARGS+=(--argjson review_score "$REVIEW_SCORE")
-    JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].last_score = \$review_score"
-fi
-
 # ----------------------------------------------------------------------------
 # Termination block (issue #53) — unified Generator-Verifier loop state
 # Only applies to 3b_plan_review and 6_evaluate phases.
@@ -289,16 +223,6 @@ if [[ -n "$TERMINATION_REASON" ]]; then
 
     # Sync final_iteration from verdict_history length
     JQ_FILTER="$JQ_FILTER | .phases[\$phase].termination.final_iteration = (.phases[\$phase].termination.verdict_history | length)"
-
-    # Legacy mirror (deprecated, 1 release): escalated / escalation_reason on Phase 3b
-    if [[ "$PHASE" == "3b_plan_review" ]]; then
-        if [[ "$TERMINATION_REASON" == "converged" ]]; then
-            JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalated = false"
-        else
-            JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalated = true"
-            JQ_FILTER="$JQ_FILTER | .phases[\"3b_plan_review\"].escalation_reason = \$termination_reason"
-        fi
-    fi
 fi
 
 if [[ -n "$RESET_TO" ]]; then

--- a/dev-validate/SKILL.md
+++ b/dev-validate/SKILL.md
@@ -57,7 +57,7 @@ $SKILLS_DIR/dev-validate/scripts/validate-kickoff.sh --worktree <path>
 ```
 
 挙動:
-- `feature_list` が空 / 未定義 → silent pass（後方互換）
+- `feature_list` が空 / 未定義 → silent pass（standalone モード / kickoff.json 不在）
 - `kickoff.json` に git 履歴が無い → silent pass
 - `id` / `desc` が変更されている → stderr に warning を出力、JSON の `status: warning` を返す（exit 0、非致命）
 - `id` が削除されている → 同じく warning

--- a/dev-validate/scripts/validate-kickoff.sh
+++ b/dev-validate/scripts/validate-kickoff.sh
@@ -35,7 +35,7 @@ if [[ ! -f "$STATE_FILE" ]]; then
     exit 0
 fi
 
-# Silent pass if feature_list is empty or missing (backward compat)
+# Silent pass if feature_list is empty or missing (standalone mode)
 FEATURE_COUNT=$(jq '(.feature_list // []) | length' "$STATE_FILE" 2>/dev/null || echo 0)
 if [[ "$FEATURE_COUNT" -eq 0 ]]; then
     echo '{"status":"skipped","reason":"feature_list is empty"}'

--- a/tests/_shared/test-detect-stuck-findings.py
+++ b/tests/_shared/test-detect-stuck-findings.py
@@ -133,7 +133,8 @@ class TestDetectStuckFindings(unittest.TestCase):
         result = json.loads(proc.stdout)
         self.assertFalse(result["escalate"])
 
-    def test_legacy_blocking_severity_treated_as_major(self):
+    def test_unknown_severity_excluded(self):
+        """Unknown severity values (including removed aliases like 'blocking') are not fingerprinted."""
         self.assert_script_exists()
         finding = {"severity": "blocking", "dimension": "edge_cases", "topic": "Empty input"}
         history = [
@@ -144,8 +145,9 @@ class TestDetectStuckFindings(unittest.TestCase):
         proc = run_script(path)
         self.assertEqual(proc.returncode, 0, proc.stderr)
         result = json.loads(proc.stdout)
-        self.assertTrue(result["escalate"])
-        self.assertEqual(result["stuck_findings"][0]["topic"], "Empty input")
+        # "blocking" is no longer aliased to "major" — unknown severity is excluded from fingerprint
+        self.assertFalse(result["escalate"])
+        self.assertEqual(result["stuck_findings"], [])
 
     def test_critical_finding_escalates(self):
         self.assert_script_exists()

--- a/tests/_shared/test-flow-shared-findings.sh
+++ b/tests/_shared/test-flow-shared-findings.sh
@@ -35,23 +35,7 @@ make_flow() {
     {"id": "task2", "scope": "B", "files": ["b.ts"], "status": "completed", "checklist": [{"item":"x","done":true}]},
     {"id": "task3", "scope": "C", "files": ["c.ts"], "status": "completed", "checklist": [{"item":"x","done":true}]}
   ],
-  "config": {"strategy": "tdd", "depth": "standard", "lang": "ja", "base_branch": "dev", "env_mode": "hardlink"}
-}
-JSON
-}
-
-make_legacy_flow() {
-    # No shared_findings field at all, missing optional fields.
-    local path="$1"
-    cat > "$path" <<'JSON'
-{
-  "version": "1.0.0",
-  "issue": 99,
-  "status": "implementing",
-  "subtasks": [
-    {"id": "task1", "scope": "A", "files": ["a.ts"], "status": "completed", "checklist": [{"item":"x","done":true}]},
-    {"id": "task2", "scope": "B", "files": ["b.ts"], "status": "completed", "checklist": [{"item":"x","done":true}]}
-  ],
+  "shared_findings": [],
   "config": {"strategy": "tdd", "depth": "standard", "lang": "ja", "base_branch": "dev", "env_mode": "hardlink"}
 }
 JSON
@@ -109,20 +93,6 @@ if [[ "$(echo "$UNACK_T2_AFTER" | jq 'length')" == "0" ]] && [[ "$ACKED_BY" == "
     pass "ack-semantics"
 else
     fail "ack-semantics" "unack=$(echo "$UNACK_T2_AFTER" | jq 'length') acked_by=$ACKED_BY"
-fi
-
-# ---------- Test 6: backward-compat ----------
-T=$TMP_ROOT/t6; mkdir -p "$T"; FLOW=$T/flow.json; make_legacy_flow "$FLOW"
-LEGACY_READ=$("$READ_SH" --flow-state "$FLOW")
-if [[ "$(echo "$LEGACY_READ" | jq 'length')" != "0" ]]; then
-    fail "backward-compat-read" "legacy flow should return []"
-else
-    "$APPEND_SH" --flow-state "$FLOW" --task-id task1 --category dependency --title "x" --description "x" >/dev/null
-    if [[ "$(jq '.shared_findings | length' "$FLOW")" == "1" ]]; then
-        pass "backward-compat"
-    else
-        fail "backward-compat" "append should initialize the field"
-    fi
 fi
 
 # ---------- Test 7: integration-check-warning ----------

--- a/tests/_shared/test-termination-record.sh
+++ b/tests/_shared/test-termination-record.sh
@@ -95,9 +95,9 @@ else
   fail "recorded_at is populated" "got: $RECORDED"
 fi
 
-# converged should NOT set escalated=true
-ESCALATED=$(jq -r '.phases["3b_plan_review"].escalated // false' "$STATE")
-assert_eq "converged: escalated = false" "false" "$ESCALATED"
+# converged should NOT write escalated field at all
+ESCALATED=$(jq -r '.phases["3b_plan_review"].escalated' "$STATE")
+assert_eq "converged: escalated not written (null)" "null" "$ESCALATED"
 
 # ----------------------------------------------------------------------------
 # Test 3: append-verdict grows history and updates final_iteration
@@ -122,9 +122,9 @@ LAST_VERDICT=$(jq -r '.phases["3b_plan_review"].termination.verdict_history[-1].
 assert_eq "last verdict = pass" "pass" "$LAST_VERDICT"
 
 # ----------------------------------------------------------------------------
-# Test 4: stuck reason writes legacy escalation fields
+# Test 4: stuck reason records only termination block (no legacy fields)
 # ----------------------------------------------------------------------------
-printf '\nTest 4: stuck termination writes legacy fields\n'
+printf '\nTest 4: stuck termination records only termination block\n'
 WT=$(make_worktree wt3)
 "$SCRIPT" 3b_plan_review stuck \
   --worktree "$WT" \
@@ -134,14 +134,15 @@ WT=$(make_worktree wt3)
 STATE="$WT/.claude/kickoff.json"
 REASON=$(jq -r '.phases["3b_plan_review"].termination.reason' "$STATE")
 assert_eq "termination.reason = stuck" "stuck" "$REASON"
+FINAL_VERDICT_STUCK=$(jq -r '.phases["3b_plan_review"].termination.final_verdict' "$STATE")
+assert_eq "termination.final_verdict = revise" "revise" "$FINAL_VERDICT_STUCK"
+LAST_HIST_SCORE=$(jq -r '.phases["3b_plan_review"].termination.verdict_history[-1].score' "$STATE")
+assert_eq "last verdict_history score = 69" "69" "$LAST_HIST_SCORE"
+# Legacy fields must NOT be written
 ESC=$(jq -r '.phases["3b_plan_review"].escalated' "$STATE")
-assert_eq "legacy escalated = true" "true" "$ESC"
+assert_eq "stuck: escalated not written (null)" "null" "$ESC"
 ESC_REASON=$(jq -r '.phases["3b_plan_review"].escalation_reason' "$STATE")
-assert_eq "legacy escalation_reason = stuck" "stuck" "$ESC_REASON"
-LAST_VERDICT_LEGACY=$(jq -r '.phases["3b_plan_review"].last_verdict' "$STATE")
-assert_eq "legacy last_verdict = revise" "revise" "$LAST_VERDICT_LEGACY"
-LAST_SCORE_LEGACY=$(jq -r '.phases["3b_plan_review"].last_score' "$STATE")
-assert_eq "legacy last_score = 69" "69" "$LAST_SCORE_LEGACY"
+assert_eq "stuck: escalation_reason not written (null)" "null" "$ESC_REASON"
 
 # ----------------------------------------------------------------------------
 # Test 5: Phase 6 termination with feedback_target in verdict_history
@@ -166,9 +167,9 @@ HIST_LEN=$(jq -r '.phases["6_evaluate"].termination.verdict_history | length' "$
 assert_eq "phase 6 verdict_history length = 5" "5" "$HIST_LEN"
 FIRST_FT=$(jq -r '.phases["6_evaluate"].termination.verdict_history[0].feedback_target' "$STATE")
 assert_eq "first iteration feedback_target = design" "design" "$FIRST_FT"
-# current_iteration (legacy) should be synced as well
+# current_iteration legacy mirror must NOT be written by termination-record.sh
 CUR_ITER=$(jq -r '.phases["6_evaluate"].current_iteration' "$STATE")
-assert_eq "legacy current_iteration = 5" "5" "$CUR_ITER"
+assert_eq "phase 6 current_iteration not written by termination-record (stays init value 0)" "0" "$CUR_ITER"
 
 # ----------------------------------------------------------------------------
 # Test 6: invalid reason → exit non-zero

--- a/tests/dev-kickoff/test-update-phase-removed-options.sh
+++ b/tests/dev-kickoff/test-update-phase-removed-options.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# test-update-phase-removed-options.sh - Verify removed CLI options are rejected.
+#
+# Architecture Decision 1 (issue #95): --escalated / --escalation-reason /
+# --review-iteration / --review-verdict / --review-score / --stuck-findings
+# were legacy Phase 3b mirror options. All are removed from update-phase.sh.
+# Callers using these options must receive a non-zero exit with an error message.
+#
+# Run: bash tests/dev-kickoff/test-update-phase-removed-options.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/dev-kickoff/scripts/update-phase.sh"
+
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "${2:-}"; }
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+make_worktree() {
+  local name="$1"
+  local path="$TMP_ROOT/$name"
+  mkdir -p "$path/.claude"
+  cat > "$path/.claude/kickoff.json" <<'JSON'
+{
+  "version": "3.0.0",
+  "issue": 95,
+  "branch": "feature/issue-95-m",
+  "worktree": "/tmp/wt",
+  "base_branch": "main",
+  "started_at": "2026-05-14T00:00:00Z",
+  "updated_at": "2026-05-14T00:00:00Z",
+  "current_phase": "3b_plan_review",
+  "phases": {
+    "3b_plan_review": { "status": "in_progress" },
+    "6_evaluate": { "status": "pending", "iterations": [], "current_iteration": 0, "max_iterations": 5 }
+  },
+  "feature_list": [],
+  "progress_log": [],
+  "decisions": [],
+  "config": {}
+}
+JSON
+  echo "$path"
+}
+
+# ----------------------------------------------------------------------------
+# Test A: Removed options are rejected with non-zero exit
+# ----------------------------------------------------------------------------
+printf 'Test A: Removed options return non-zero exit with Unknown option error\n\n'
+
+WT=$(make_worktree wt_a)
+
+assert_option_rejected() {
+  local opt_label="$1" wt="$2"; shift 2
+  local tmp_out; tmp_out="$TMP_ROOT/out_${opt_label//[-]/_}.txt"
+  "$SCRIPT" "$@" >"$tmp_out" 2>&1; local ec=$?
+  if [[ $ec -ne 0 ]]; then
+    pass "${opt_label} returns non-zero"
+  else
+    fail "${opt_label} returns non-zero" "exit code was 0; output: $(cat "$tmp_out")"
+  fi
+  if grep -qi "unknown option\|${opt_label}" "$tmp_out"; then
+    pass "${opt_label} error message mentions option"
+  else
+    fail "${opt_label} error message mentions option" "got: $(cat "$tmp_out")"
+  fi
+}
+
+# A-1: --escalated
+printf '  A-1: --escalated\n'
+assert_option_rejected "--escalated" "$WT" 3b_plan_review done --worktree "$WT" --escalated true
+
+# A-2: --escalation-reason
+printf '  A-2: --escalation-reason\n'
+assert_option_rejected "--escalation-reason" "$WT" 3b_plan_review done --worktree "$WT" --escalation-reason stuck
+
+# A-3: --review-iteration
+printf '  A-3: --review-iteration\n'
+assert_option_rejected "--review-iteration" "$WT" 3b_plan_review done --worktree "$WT" --review-iteration 2
+
+# A-4: --review-verdict
+printf '  A-4: --review-verdict\n'
+assert_option_rejected "--review-verdict" "$WT" 3b_plan_review done --worktree "$WT" --review-verdict pass
+
+# A-5: --review-score
+printf '  A-5: --review-score\n'
+assert_option_rejected "--review-score" "$WT" 3b_plan_review done --worktree "$WT" --review-score 85
+
+# A-6: --stuck-findings
+printf '  A-6: --stuck-findings\n'
+assert_option_rejected "--stuck-findings" "$WT" 3b_plan_review done --worktree "$WT" --stuck-findings '[]'
+
+# ----------------------------------------------------------------------------
+# Test B: Remaining valid options still work (regression guard)
+# ----------------------------------------------------------------------------
+printf '\nTest B: Remaining valid options return exit 0 (regression guard)\n\n'
+
+WT_B=$(make_worktree wt_b)
+
+# B-1: minimal positional invocation
+printf '  B-1: minimal positional\n'
+OUT=$("$SCRIPT" 3b_plan_review in_progress --worktree "$WT_B" 2>&1)
+EC=$?
+if [[ $EC -eq 0 ]]; then
+  pass "positional phase/status exits 0"
+else
+  fail "positional phase/status exits 0" "got ec=$EC: $OUT"
+fi
+
+WT_B=$(make_worktree wt_b2)
+
+# B-2: --termination-reason
+printf '  B-2: --termination-reason\n'
+OUT=$("$SCRIPT" 3b_plan_review done \
+  --worktree "$WT_B" \
+  --termination-reason converged \
+  --termination-final-verdict pass 2>&1)
+EC=$?
+if [[ $EC -eq 0 ]]; then
+  pass "--termination-reason converged exits 0"
+else
+  fail "--termination-reason converged exits 0" "got ec=$EC: $OUT"
+fi
+
+WT_B=$(make_worktree wt_b3)
+
+# B-3: --termination-verdict-history
+printf '  B-3: --termination-verdict-history\n'
+OUT=$("$SCRIPT" 3b_plan_review done \
+  --worktree "$WT_B" \
+  --termination-reason converged \
+  --termination-verdict-history '[{"iteration":1,"verdict":"pass","score":90}]' 2>&1)
+EC=$?
+if [[ $EC -eq 0 ]]; then
+  pass "--termination-verdict-history exits 0"
+else
+  fail "--termination-verdict-history exits 0" "got ec=$EC: $OUT"
+fi
+
+WT_B=$(make_worktree wt_b4)
+
+# B-4: --append-verdict
+printf '  B-4: --append-verdict\n'
+OUT=$("$SCRIPT" 3b_plan_review done \
+  --worktree "$WT_B" \
+  --termination-reason converged \
+  --append-verdict '{"iteration":1,"verdict":"pass","score":88}' 2>&1)
+EC=$?
+if [[ $EC -eq 0 ]]; then
+  pass "--append-verdict exits 0"
+else
+  fail "--append-verdict exits 0" "got ec=$EC: $OUT"
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+printf '\n----------------------------------------\n'
+printf 'Summary: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/no-glue-errors.sh
+++ b/tests/no-glue-errors.sh
@@ -5,7 +5,7 @@
 # (with window taken from baseline.window — NOT hardcoded), compares against
 # BASELINE_FILE via compare-baseline.sh, and exits non-zero only when a real
 # regression is detected (compare exit 1). Corrupt baseline / window mismatch /
-# missing baseline → warning + exit 0 (back-compat).
+# missing baseline → warning + exit 0 (graceful degradation).
 #
 # Env:
 #   BASELINE_FILE     Path to baseline snapshot JSON.
@@ -39,7 +39,7 @@ if [[ ! -f "$BASELINE_FILE" ]]; then
     echo "WARNING: baseline file not found at $BASELINE_FILE; falling back to template $TEMPLATE_FALLBACK"
     BASELINE_FILE="$TEMPLATE_FALLBACK"
   else
-    echo "WARNING: baseline file not found at $BASELINE_FILE and no template fallback available; skipping regression check (exit 0, back-compat)"
+    echo "WARNING: baseline file not found at $BASELINE_FILE and no template fallback available; skipping regression check (exit 0, graceful degradation)"
     echo "        Regenerate via: ./dev-flow-doctor/scripts/run-diagnostics.sh --update-baseline $DEFAULT_BASELINE"
     exit 0
   fi
@@ -104,7 +104,7 @@ case "$COMPARE_RC" in
     ;;
   2)
     echo "WARNING: compare-baseline.sh returned exit 2 (corrupt baseline / window mismatch / IO error)"
-    echo "         baseline=$BASELINE_COUNT, current=$CURRENT_COUNT; skipping regression check (exit 0, back-compat)"
+    echo "         baseline=$BASELINE_COUNT, current=$CURRENT_COUNT; skipping regression check (exit 0, graceful degradation)"
     exit 0
     ;;
   *)


### PR DESCRIPTION
Closes #95

## 概要

PR #94 で確立した「内製スキルに legacy fallback を作らない」原則に従い、PR #94 スコープ外で残存している legacy fallback / dual-path を dev-flow family から撤去する。

## 変更内容

### C1: escalated / escalation_reason legacy mirror を撤去
- `dev-kickoff/scripts/update-phase.sh`: `--escalated` / `--escalation-reason` / `--review-iteration` / `--review-verdict` / `--review-score` / `--stuck-findings` CLI option を削除
- `_shared/scripts/termination-record.sh`: Legacy mirror ブロックを削除
- ドキュメント更新: kickoff-schema.md, evaluate-retry.md, plan-review-loop.md から legacy 説明を削除
- テスト更新: test-termination-record.sh を新 schema 向けに更新、test-update-phase-removed-options.sh を新規追加（removed option rejection を検証）

### C2: severity blocking/non-blocking 読み替えを撤去
- `_shared/scripts/detect-stuck-findings.py`: SEVERITY_ALIAS から legacy alias を削除
- テスト: test_legacy_blocking_severity_treated_as_major を test_unknown_severity_excluded に置換

### C3: shared_findings 欠落 flow.json fallback を撤去
- `_lib/schemas/flow.schema.json`: shared_findings を required に追加
- `dev-decompose/scripts/init-flow.sh`: shared_findings: [] を初期化
- テスト: make_flow() に shared_findings を追加、Test 6 (backward-compat) を削除

### C4: legacy_count heuristics を撤去
- `dev-flow-doctor/references/diagnostic-checks.md`: legacy entry heuristics ブロック削除

### C5: 「後方互換」ラベル統一
- dev-implement/SKILL.md, dev-validate/SKILL.md, validate-kickoff.sh, test-no-glue-errors-threshold.sh, baseline-comparison.md, tests/no-glue-errors.sh で「後方互換」を「Standalone モード」「graceful degradation」などの正確な用語に置換

## テスト結果

- [x] test-termination-record.sh: 23 passed
- [x] test-update-phase-removed-options.sh: 16 passed
- [x] test-flow-shared-findings.sh: 8 passed
- [x] test-detect-stuck-findings.py: 11 passed
- [x] test-no-glue-errors-threshold.sh: 6 passed
- [x] AC3: dev-flow family 内で legacy/後方互換/backward mention なし

## 受け入れ基準

- [x] 削除対象 9 ファイルから legacy fallback を撤去
- [x] 判断必要項目について ラベルを正確な用語に置換
- [x] grep で legacy/後方互換/backward mention が消える
- [x] 既存テスト全 pass (regression なし)
- [x] PR body から「rollout 期間中」などの文言が消える