### PR TITLE
✨ chore: CLAUDE.md → AGENTS.md 移行 (Linux Foundation AAIF 標準対応、cross-agent context portability) (#101)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# Project overview
+
+Skills Repository — Claude Code Skills のモノレポ。cross-vendor の coding agent
+(Claude Code / Codex CLI / Cursor / Aider / Amp / Gemini CLI / GitHub Copilot /
+Devin / Jules / Zed / Continue / Roo Code / Factory Droids / Windsurf / Amazon Q)
+で共通の project context を提供する。
+
+This file follows the [agents.md](https://agents.md) standard (Linux Foundation AAIF, 2025-12).
+Subdirectory `AGENTS.md` files take precedence over this root file for their respective paths.
+
+## Setup commands
+
+```bash
+# bats (テストフレームワーク) のインストール
+brew install bats-core        # macOS
+apt-get install bats          # Ubuntu / Debian
+
+# テスト実行
+bash tests/run-all-bats.sh           # ローカル開発 (bats 未インストール時は graceful skip)
+bash tests/run-all-bats.sh --strict  # CI 用 (bats 未インストールを error 扱い)
+```
+
+ディレクトリ構造:
+
+```
+skills/
+├── skill-name/           # 各スキル
+│   ├── SKILL.md          # Frontmatter + ワークフロー
+│   ├── scripts/          # 決定論的処理
+│   └── references/       # 詳細ドキュメント
+├── _shared/              # 共有リソース (references, scripts)
+├── _lib/                 # 共有ライブラリ (common.sh, config.py)
+├── .agents/skills/       # 外部スキル (symlink)
+├── skill-config.json     # スキル固有設定 (ツール非依存)
+├── .claude/              # Claude Code 固有設定
+└── docs/                 # プロジェクトドキュメント
+```
+
+新規スキル作成は `/skill-creator` を使用。共有処理は `_shared/` か `_lib/` に配置。
+
+## Code style
+
+- **SKILL.md の description は簡潔に** — 常にコンテキスト消費される (15,000 文字 budget)
+- **決定論的処理はスクリプトに抽出** — ファイル検索・JSON操作・git操作・API呼び出し
+- **Progressive Disclosure** — SKILL.md は概要、詳細は `references/` に分離
+- **Namespace 命名** — `dev-*`, `blog-*`, `git-*`, `sns-*` 等でグループ化
+- **既存パターンに従う** — 新規スキルは同カテゴリの既存スキルを参考にする
+- **共有処理は `_shared/` か `_lib/`** — スキル間で重複するロジックは共有化
+- **後方互換 scaffolding を作らない** — schema 変更で legacy fallback / version enum / dual-path を入れない。新形式のみ受理
+
+SKILL.md description は third-person 命令形で書く (`Extracts ...`, `Converts ...`)。
+`Use when:` には具体トリガ語を列挙する。`"I"` / `"this skill"` 等の一人称は禁止。
+控えめに書くと Claude が呼ばない — push 気味に書く。
+
+## Testing instructions
+
+決定論的スクリプトには bats (`*.bats`) でユニットテストを書く。テストファイルは実装スクリプトの隣に配置:
+
+```
+skill-name/scripts/foo.sh      # 実装
+skill-name/scripts/foo.bats    # テスト (隣接配置)
+```
+
+実行:
+
+```bash
+bats skill-name/scripts/foo.bats          # 単体
+bash tests/run-all-bats.sh               # 全 bats 一括
+bash tests/run-all-bats.sh --strict      # CI 用 (bats なしを error 扱い)
+```
+
+bats が見つからない環境でも `tests/run-all-bats.sh` は exit 0 を返すため、
+ローカル開発を阻害しない。CI からは `--strict` を渡して bats のインストール漏れを検出する。
+
+## Architectural guardrails
+
+### dev-flow v2 (explicit mode)
+
+- `dev-flow <issue> [--force-single]` — 1 issue = 1 PR (default)
+- `dev-flow <issue> --child-split` — parent issue を child issue + integration branch + batch loop に分解
+
+multi-PR coordination は child-issue + integration branch + batch loop モデルで行う。
+旧 v1 の subtask DAG (depends_on) + Kahn 法 topological merge + contract branch は**完全削除済**。
+詳細: [`docs/ci-skip-recipe.md`](docs/ci-skip-recipe.md)
+
+### 設計原則 (要約)
+
+1. **機能特化** — 汎用ロール (QA engineer 等) ではなく機能特化スキルを作る
+2. **Progressive Disclosure** — description は簡潔に、詳細は `references/` に分離
+3. **決定論的処理の分離** — LLM に任せるべきでない処理はスクリプトに抽出
+4. **Namespace 命名** — `dev-*`, `blog-*`, `git-*` 等のプレフィックスで整理
+5. **小タスクは vanilla** — 小さいタスクは素の Claude Code の方が優秀
+6. **Journal Logging** — ワークフロー完了時に skill-retrospective 経由でログ記録
+7. **破壊的・大量変更系は `disable-model-invocation: true`** を検討
+8. **「毎回確定実行」したい挙動は skill ではなく hook で実装**
+9. **後方互換 scaffolding を作らない** — 内製スキルは新形式のみ受理、out-of-enum は schema error
+
+### child-split over DAG
+
+依存関係を持つ複数タスクの coordination は **layered linear batch 配列 + child-issue 分割** を選ぶ
+(任意 DAG / depends_on は使わない)。詳細は `docs/skill-creation-guide.md` § 設計原則 参照。
+
+### Subagent dispatch — 必須 5 要素
+
+Skill が `Task` / `Agent` tool 経由で subagent を呼び出す場合、以下 5 要素を**必ず含める**:
+
+1. **Objective** — 単一の明確なゴール
+2. **Output format** — 期待する構造 (JSON schema / Markdown section / 語数上限)
+3. **Tools** — 使用可能 tool と禁止 tool を明示
+4. **Boundary** — 触ってはいけないファイル / commit 禁止 / ネットワーク禁止 等
+5. **Token cap** — 計測可能な上限
+
+詳細: [`_shared/references/subagent-dispatch.md`](_shared/references/subagent-dispatch.md)
+
+## Commit / PR conventions
+
+Conventional Commits 形式:
+
+```
+feat(skill-name):    新規スキル / 機能追加
+fix(skill-name):     バグ修正
+refactor(skills):    リファクタリング
+chore(skill-name):   設定・ドキュメント等
+```
+
+dev-flow v2 の PR 運用: child PR は **draft** で作成 (CI suppress)、最終 `integration → main` PR は non-draft で full CI。
+
+@docs/skill-creation-guide.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,7 @@
-# Skills Repository
+# Skills Repository (Claude Code entry point)
 
-Claude Code Skills のモノレポ。
+本 repo の規約は `AGENTS.md` に集約されています (cross-vendor coding agent 対応のため
+[agents.md](https://agents.md) 標準に準拠)。Claude Code は下記 import 経由で同じ内容を読みます。
 
-## Skill 作成・編集ルール
-
-@docs/skill-creation-guide.md
-
-## プロジェクト構造
-
-```
-skills/
-├── skill-name/           # 各スキル
-│   ├── SKILL.md          # Frontmatter + ワークフロー
-│   ├── scripts/          # 決定論的処理
-│   └── references/       # 詳細ドキュメント
-├── _shared/              # 共有リソース（references, scripts）
-├── _lib/                 # 共有ライブラリ（common.sh, config.py）
-├── .agents/skills/       # 外部スキル（symlink）
-├── skill-config.json     # スキル固有設定（ツール非依存）
-├── .claude/              # Claude Code 固有設定
-└── docs/                 # プロジェクトドキュメント
-```
-
-## 開発ルール
-
-- **SKILL.md の description は簡潔に** — 常にコンテキスト消費される（15,000 文字 budget）
-- **決定論的処理はスクリプトに抽出** — ファイル検索、JSON操作、git操作、API呼び出し
-- **Progressive Disclosure** — SKILL.md は概要、詳細は `references/` に分離
-- **Namespace 命名** — `dev-*`, `blog-*`, `git-*`, `sns-*` 等でグループ化
-- **既存パターンに従う** — 新規スキルは同カテゴリの既存スキルを参考にする
-- **共有処理は `_shared/` か `_lib/`** — スキル間で重複するロジックは共有化
-- **後方互換 scaffolding を作らない** — 内製スキル間の schema 変更で legacy fallback / version enum / dual-path を入れない。新形式のみ受理、out-of-enum は schema error。詳細: [skill-creation-guide.md → 設計原則 #9](docs/skill-creation-guide.md#設計原則)
-
-## 開発ワークフロー (dev-flow v2)
-
-dev-flow は v2 で **explicit mode 選択** になった (auto-detect dry-run 廃止):
-
-- `dev-flow <issue> [--force-single]` — 1 issue = 1 PR (default)
-- `dev-flow <issue> --child-split` — parent issue を child issue + integration branch + batch loop に分解
-
-multi-PR coordination は **child-issue + integration branch + batch loop** モデルで行う:
-
-1. `dev-decompose --child-split` が parent issue を child issue 群に分解 → integration branch + v2 flow.json 生成
-2. `run-batch-loop.sh` が batch 配列 (serial / parallel) を消費し、各 child を `dev-flow --force-single --base integration/issue-*` で実装
-3. child PR は **draft** で作成 (CI suppress)、`auto-merge-guard.sh` 経由で `--admin` merge 許可 (base が `integration/issue-*` の場合のみ)
-4. 全 child 完了後、`dev-integrate` が type check + dev-validate
-5. 最終 `integration → dev/main` PR (non-draft) で full CI
-
-旧 v1 の subtask DAG (depends_on) + Kahn 法 topological merge + contract branch は完全削除済。詳細: [`docs/ci-skip-recipe.md`](docs/ci-skip-recipe.md)
-
-## コミット規約
-
-Conventional Commits 形式: `feat(skill-name):`, `fix(skill-name):`, `refactor(skills):`
+<!-- The line below imports AGENTS.md content for Claude Code -->
+@AGENTS.md


### PR DESCRIPTION
## 概要

Closes #101

cross-vendor coding agent (Claude Code / Codex CLI / Cursor / Aider / Amp / Gemini CLI /
GitHub Copilot / Devin / Jules / Zed / Continue / Roo Code / Factory Droids / Windsurf /
Amazon Q) で共通の project context を共有するため、`CLAUDE.md` の規約を
[agents.md](https://agents.md) 標準 (Linux Foundation AAIF 2025-12 寄贈) に準拠した
`AGENTS.md` に再構成しました。

## 動機

Claude Code 固有の `CLAUDE.md` に閉じたままだと、Codex CLI / Cursor / Amp / Copilot 等の
他 agent で同じ規約が読まれず、cross-agent portability が破綻するため。
Claude Code は `@AGENTS.md` import 経由で実体は AGENTS.md を読むため、
既存 Claude Code ユーザの体験は変わりません。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `AGENTS.md` (新規) | agents.md 標準 6 セクション (`# Project overview` / `## Setup commands` / `## Code style` / `## Testing instructions` / `## Architectural guardrails` / `## Commit / PR conventions`) + `@docs/skill-creation-guide.md` import |
| `CLAUDE.md` (置換) | 54 行 → 7 行の薄いラッパに置換。`@AGENTS.md` import で AGENTS.md の内容を Claude Code に読ませる |

### AGENTS.md セクション構成

- **`# Project overview`** — Skills monorepo の目的と対応 agent 一覧
- **`## Setup commands`** — bats install (brew / apt) + `tests/run-all-bats.sh` 起動方法 + ディレクトリ構造
- **`## Code style`** — SKILL.md description 簡潔ルール / Progressive Disclosure / namespace 命名 / 一人称禁止
- **`## Testing instructions`** — bats 隣接配置、`tests/run-all-bats.sh --strict` (CI 用)
- **`## Architectural guardrails`** — dev-flow v2 explicit mode / 設計原則 #1-#9 / child-split over DAG / Subagent dispatch 5要素
- **`## Commit / PR conventions`** — Conventional Commits + dev-flow v2 PR 運用 (child draft / integration non-draft)

## 検証

- [x] **AC1**: AGENTS.md に 6 セクション全てが存在 (`grep -E '^# Project overview|^## Setup commands|...'` で確認)
- [x] **AC2**: CLAUDE.md は 7 行で `@AGENTS.md` import を含む
- [x] **AC3**: AGENTS.md に `@docs/skill-creation-guide.md` import が存在
- [x] **AC4**: `tests/run-all-bats.sh` が exit 0 (docs-only 変更、bats 未インストール環境では graceful skip)
- [ ] **AC5** (任意・後追い): Codex CLI 等他 agent での smoke test (本 PR の scope 外)
- [x] Claude Code 起動時に `CLAUDE.md → @AGENTS.md` import 解決が動作 (Claude Code session で本 PR 内容を直接確認済)

## 影響評価

- **既存ユーザ (Claude Code)**: 体験変わらず (`@AGENTS.md` import 経由で同じ内容)
- **他 agent 利用者**: AGENTS.md がネイティブ対応のため、追加設定なしで規約反映
- **リスク**: 低 (1 ファイル分割の機械的作業 + 標準準拠への移行)

## Out of scope (別 issue で扱う)

- SKILL.md の portable subset 化 (adapter overlay パターン導入)
- orchestration skill (dev-flow / dev-kickoff) の bash coordinator 化
- `isolation: worktree` の portable script 化
- サブディレクトリ階層の `AGENTS.md` 追加 (必要が出た時点で別 PR)