### PR TITLE
refactor(dev-plan-review): SKILL.md を portable subset 化 + adapter overlay 導入 (#106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ __pycache__/
 # Packaged skills
 *.skill
 
+# Adapter overlay build artifacts (issue #106, Q3=Y)
+# build-skill-overlay.sh のデフォルト出力先は $HOME/.cache/claude-skill-build/ (repo 外)
+# だが、開発者が --output で repo 内パスを指定したときの誤コミット防止のため defensive に ignore
+/.build/
+/dist/skills/
+
 # --- external skills (auto-managed) ---
 agent-browser
 api-contract-testing

--- a/_lib/scripts/build-skill-overlay.bats
+++ b/_lib/scripts/build-skill-overlay.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# build-skill-overlay.bats — unit tests for build-skill-overlay.sh
+# TDD: all tests are written RED first, then the implementation makes them GREEN.
+#
+# Test cases:
+#   1. usage              - print help and exit 1 when called without args
+#   2. portable-only      - pass-through when no overlay file exists (exit 0)
+#   3. merge-success      - portable + claude.yaml overlay produces correct merged SKILL.md
+#   4. missing-overlay    - missing adapter file causes exit 0 with portable content
+#   5. invalid-yaml       - malformed overlay YAML causes exit 2 + stderr message
+#   6. field-collision    - overlay field 'name' overrides portable value (overlay wins)
+#   7. output-to-file     - --output writes merged content to specified path
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+SCRIPT="$SCRIPT_DIR/build-skill-overlay.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Create a minimal portable SKILL.md in a temp directory.
+# Usage: make_portable_skill <dir> [<name>]
+make_portable_skill() {
+  local dir="$1"
+  local name="${2:-test-skill}"
+  mkdir -p "$dir/$name"
+  cat > "$dir/$name/SKILL.md" << EOF
+---
+name: $name
+description: |
+  A test skill for unit testing.
+  Use when: testing build-skill-overlay.sh
+version: 1.0.0
+tags:
+  - test
+agents:
+  - claude
+  - codex
+---
+
+# Test Skill Body
+
+This is the body of the test skill.
+
+## Usage
+
+/test-skill
+EOF
+}
+
+# Create a valid claude adapter overlay in <dir>/<name>/adapters/claude.yaml.
+make_claude_overlay() {
+  local dir="$1"
+  local name="${2:-test-skill}"
+  mkdir -p "$dir/$name/adapters"
+  cat > "$dir/$name/adapters/claude.yaml" << EOF
+# Claude Code adapter overlay for $name
+# Merged into SKILL.md frontmatter by build-skill-overlay.sh
+model: opus
+effort: max
+context: fork
+allowed-tools:
+  - Read
+  - Bash
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: usage — no args → exit 1 + help on stderr
+# ---------------------------------------------------------------------------
+@test "usage: exits 1 and prints help when called without args" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "usage" ]] || [[ "$stderr" =~ "usage" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: portable-only — no overlay → pass-through, exit 0
+# ---------------------------------------------------------------------------
+@test "portable-only: outputs SKILL.md unchanged when overlay is absent" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+
+  local out_file="$tmpdir/merged.md"
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file"
+  [ "$status" -eq 0 ]
+  [ -f "$out_file" ]
+  # Body must be preserved
+  grep -q "Test Skill Body" "$out_file"
+  # Portable fields must be present
+  grep -q "^name: test-skill" "$out_file"
+  # Claude-ext fields must NOT appear (no overlay)
+  ! grep -q "^model:" "$out_file"
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: merge-success — portable + overlay → all fields in output
+# ---------------------------------------------------------------------------
+@test "merge-success: merged SKILL.md contains both portable and overlay fields" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+  make_claude_overlay "$tmpdir"
+
+  local out_file="$tmpdir/merged.md"
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file"
+  [ "$status" -eq 0 ]
+  [ -f "$out_file" ]
+
+  # Portable fields preserved
+  grep -q "^name: test-skill" "$out_file"
+  grep -q "^version: 1.0.0" "$out_file"
+
+  # Claude-ext fields from overlay
+  grep -q "^model: opus" "$out_file"
+  grep -q "^effort: max" "$out_file"
+  grep -q "^context: fork" "$out_file"
+  grep -q "allowed-tools" "$out_file"
+
+  # Body preserved unchanged
+  grep -q "Test Skill Body" "$out_file"
+  grep -q "^## Usage" "$out_file"
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: missing-overlay — no adapter/claude.yaml → exit 0, portable content
+# ---------------------------------------------------------------------------
+@test "missing-overlay: exits 0 with portable passthrough when adapter file absent" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+  # NOTE: we do NOT create adapters/claude.yaml
+
+  local out_file="$tmpdir/merged.md"
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file"
+  [ "$status" -eq 0 ]
+  [ -f "$out_file" ]
+  grep -q "name: test-skill" "$out_file"
+  # No Claude-ext fields injected
+  ! grep -q "^model:" "$out_file"
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: invalid-yaml — malformed overlay → exit 2
+# ---------------------------------------------------------------------------
+@test "invalid-yaml-overlay: malformed adapter YAML causes exit 2 with error on stderr" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+  mkdir -p "$tmpdir/test-skill/adapters"
+  # Write syntactically invalid YAML
+  printf 'model: opus\ninvalid: [unclosed\n' > "$tmpdir/test-skill/adapters/claude.yaml"
+
+  local out_file="$tmpdir/merged.md"
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file"
+  [ "$status" -eq 2 ]
+  # Error message must appear in combined output
+  [[ "$output" =~ "error" ]] || [[ "$output" =~ "parse" ]] || [[ "$output" =~ "YAML" ]]
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: field-collision — overlay 'name' overrides portable 'name'
+# ---------------------------------------------------------------------------
+@test "field-collision: overlay wins when same key exists in portable (with warning)" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"  # name: test-skill
+  mkdir -p "$tmpdir/test-skill/adapters"
+  cat > "$tmpdir/test-skill/adapters/claude.yaml" << EOF
+model: opus
+name: overridden-name
+EOF
+
+  local out_file="$tmpdir/merged.md"
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file"
+  [ "$status" -eq 0 ]
+  [ -f "$out_file" ]
+  # Overlay wins: name should be overridden-name
+  grep -q "name: overridden-name" "$out_file"
+  # Warning must appear (in stdout or stderr)
+  [[ "$output" =~ "warning" ]] || [[ "$output" =~ "override" ]] || [[ "$output" =~ "overrides" ]]
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: output-to-file — --output writes to specified path
+# ---------------------------------------------------------------------------
+@test "output-to-file: --output writes merged SKILL.md to specified path" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+  make_claude_overlay "$tmpdir"
+
+  local out_dir="$tmpdir/out/nested"
+  local out_file="$out_dir/SKILL.md"
+
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file"
+  [ "$status" -eq 0 ]
+  [ -f "$out_file" ]
+  grep -q "model: opus" "$out_file"
+  grep -q "Test Skill Body" "$out_file"
+
+  rm -rf "$tmpdir"
+}

--- a/_lib/scripts/build-skill-overlay.sh
+++ b/_lib/scripts/build-skill-overlay.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# build-skill-overlay.sh — merge portable SKILL.md + adapter overlay into a
+# Claude Code-ready SKILL.md.
+#
+# This is the reference implementation for issue #106 (Phase C of #103).
+#
+# Design decisions (Q1-Q4, issue #106):
+#   Q1=A: adapter overlay lives at <skill>/adapters/<vendor>.yaml
+#   Q2=1: build script writes merged artifact to --output path
+#   Q3=Y: artifact is NOT committed to git (output path is outside the repo by default)
+#   Q4=A: build artifact contains context: fork so Claude Code subagent behavior is preserved
+#
+# Usage:
+#   build-skill-overlay.sh <skill-name> [--vendor <vendor>] [--skill-root <path>]
+#                          [--output <path>]
+#
+# Arguments:
+#   <skill-name>         name of the skill directory (e.g. dev-plan-review)
+#
+# Options:
+#   --vendor <vendor>    adapter vendor to use (default: claude)
+#   --skill-root <path>  root directory where skill subdirectories live
+#                        (default: parent of this script, i.e. the repo root)
+#   --output <path>      output path for merged SKILL.md
+#                        (default: $HOME/.cache/claude-skill-build/<skill-name>/SKILL.md)
+#   --help               print this help and exit 0
+#
+# Merge rules:
+#   1. Body comes entirely from portable SKILL.md (overlay has no body section)
+#   2. Frontmatter = union(portable_fm, overlay_fm)
+#   3. Same-key conflict → overlay wins + warning to stderr
+#   4. Missing overlay → portable passthrough (exit 0, log to stderr)
+#   5. Malformed YAML in overlay → exit 2 + error to stderr
+#   6. Malformed YAML in portable SKILL.md → exit 2 + error to stderr
+#
+# Exit codes:
+#   0  success
+#   1  usage / argument error
+#   2  YAML parse error or other I/O error
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Script location
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_MERGE_PY="$SCRIPT_DIR/yaml-merge.py"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  cat >&2 << EOF
+usage: $(basename "$0") <skill-name> [--vendor <vendor>] [--skill-root <path>] [--output <path>]
+
+  <skill-name>       skill directory name (required)
+  --vendor <vendor>  adapter vendor (default: claude)
+  --skill-root <p>   repo root that contains skill subdirs (default: auto-detect from BASH_SOURCE)
+  --output <path>    output path for merged SKILL.md
+                     default: \$HOME/.cache/claude-skill-build/<skill-name>/SKILL.md
+  --help             print this help and exit 0
+
+Merge rules:
+  - frontmatter: union(portable, overlay), overlay wins on key conflict
+  - body: from portable SKILL.md only (overlay must not contain body)
+  - missing overlay: portable passthrough (exit 0)
+  - malformed YAML: exit 2
+
+Exit codes: 0=success, 1=usage error, 2=YAML/IO error
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+SKILL_NAME=""
+VENDOR="claude"
+SKILL_ROOT=""
+OUTPUT_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vendor)    VENDOR="$2";     shift 2 ;;
+    --skill-root) SKILL_ROOT="$2"; shift 2 ;;
+    --output)    OUTPUT_PATH="$2"; shift 2 ;;
+    --help|-h)   usage; exit 0 ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "$SKILL_NAME" ]]; then
+        SKILL_NAME="$1"
+        shift
+      else
+        echo "error: unexpected argument: $1" >&2
+        usage
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$SKILL_NAME" ]]; then
+  echo "error: <skill-name> is required" >&2
+  usage
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+# Default skill-root: two directories up from this script (_lib/scripts → repo)
+if [[ -z "$SKILL_ROOT" ]]; then
+  SKILL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+PORTABLE_SKILL_MD="$SKILL_ROOT/$SKILL_NAME/SKILL.md"
+OVERLAY_FILE="$SKILL_ROOT/$SKILL_NAME/adapters/$VENDOR.yaml"
+
+# Default output: genuinely outside the repo to avoid overwriting tracked sources.
+# IMPORTANT: ~/.claude/skills may be a symlink TO the repo on some setups; use
+# $HOME/.cache/claude-skill-build/ as a safe, non-repo default.
+if [[ -z "$OUTPUT_PATH" ]]; then
+  OUTPUT_PATH="$HOME/.cache/claude-skill-build/$SKILL_NAME/SKILL.md"
+fi
+
+# ---------------------------------------------------------------------------
+# Validate inputs
+# ---------------------------------------------------------------------------
+if [[ ! -f "$PORTABLE_SKILL_MD" ]]; then
+  echo "error: portable SKILL.md not found: $PORTABLE_SKILL_MD" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Extract frontmatter and body from portable SKILL.md
+# ---------------------------------------------------------------------------
+# Frontmatter = content between first and second '---' delimiters.
+# Body = everything after the second '---'.
+#
+# We write frontmatter to a temp file and pass it to yaml-merge.py.
+# Body is preserved verbatim.
+
+TMPDIR_LOCAL="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+PORTABLE_FM_FILE="$TMPDIR_LOCAL/portable_fm.yaml"
+BODY_FILE="$TMPDIR_LOCAL/body.txt"
+
+# Use awk to split frontmatter / body (handles embedded '---' in body).
+# We pass file paths via -v to stay compatible with both GNU awk and macOS awk.
+awk -v fm_file="$PORTABLE_FM_FILE" -v body_file="$BODY_FILE" '
+  BEGIN { fm_open=0; fm_done=0; delimiter_count=0; }
+  /^---[[:space:]]*$/ {
+    delimiter_count++;
+    if (delimiter_count == 1) { fm_open=1; next }
+    if (delimiter_count == 2) { fm_done=1; fm_open=0; next }
+  }
+  fm_open  { print > fm_file; next }
+  fm_done  { print > body_file; next }
+' "$PORTABLE_SKILL_MD"
+
+# Verify frontmatter was extracted
+if [[ ! -s "$PORTABLE_FM_FILE" ]]; then
+  echo "error: portable SKILL.md does not have valid frontmatter: $PORTABLE_SKILL_MD" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Merge frontmatter
+# ---------------------------------------------------------------------------
+MERGED_FM_FILE="$TMPDIR_LOCAL/merged_fm.yaml"
+
+if [[ -f "$OVERLAY_FILE" ]]; then
+  # Overlay exists — merge portable + overlay (overlay wins on conflict).
+  # IMPORTANT: stderr (warnings, parse errors) must stay on stderr so it does
+  # not leak into MERGED_FM_FILE. Only stdout is the merged YAML.
+  if ! python3 "$YAML_MERGE_PY" "$PORTABLE_FM_FILE" "$OVERLAY_FILE" > "$MERGED_FM_FILE"; then
+    # yaml-merge.py already printed the error to stderr; propagate exit 2.
+    exit 2
+  fi
+  # Re-check that yaml-merge.py wrote non-empty output (unlikely to be empty on success).
+  if [[ ! -s "$MERGED_FM_FILE" ]]; then
+    echo "error: yaml-merge.py produced empty output for $SKILL_NAME" >&2
+    exit 2
+  fi
+else
+  # No overlay — portable passthrough.
+  echo "[build-skill-overlay] no overlay found: $OVERLAY_FILE (passthrough)" >&2
+  cp "$PORTABLE_FM_FILE" "$MERGED_FM_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# Assemble merged SKILL.md (atomic write via temp → mv)
+# ---------------------------------------------------------------------------
+MERGED_TMP_FILE="$TMPDIR_LOCAL/SKILL.md.tmp"
+
+{
+  printf -- '---\n'
+  cat "$MERGED_FM_FILE"
+  printf -- '---\n'
+  if [[ -s "$BODY_FILE" ]]; then
+    cat "$BODY_FILE"
+  fi
+} > "$MERGED_TMP_FILE"
+
+# ---------------------------------------------------------------------------
+# Write output (atomic)
+# ---------------------------------------------------------------------------
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+mv "$MERGED_TMP_FILE" "$OUTPUT_PATH"
+
+echo "[build-skill-overlay] written: $OUTPUT_PATH" >&2

--- a/_lib/scripts/yaml-merge.py
+++ b/_lib/scripts/yaml-merge.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""yaml-merge.py — internal YAML merge helper for build-skill-overlay.sh.
+
+Merges two YAML frontmatter dicts (portable + overlay) with overlay-wins semantics.
+Emits a unified YAML document to stdout.
+
+Usage:
+  python3 yaml-merge.py <portable.yaml> <overlay.yaml>
+
+Exit codes:
+  0  success — merged YAML written to stdout
+  1  usage error (wrong number of args)
+  2  YAML parse error in either file
+
+stdout: merged YAML (key: value pairs, sorted=False to preserve insertion order)
+stderr: warnings and error messages
+"""
+
+import sys
+import os
+
+try:
+    import yaml
+except ImportError:
+    print("error: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+def load_yaml(path: str) -> dict:
+    """Load YAML from file; exit 2 on parse error."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        print(f"error: failed to parse YAML in '{path}': {exc}", file=sys.stderr)
+        sys.exit(2)
+    except OSError as exc:
+        print(f"error: cannot read '{path}': {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        print(
+            f"error: expected YAML mapping in '{path}', got {type(data).__name__}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return data
+
+
+def merge(portable: dict, overlay: dict) -> dict:
+    """Merge overlay into portable with overlay-wins semantics.
+
+    Keys present in both → overlay wins (warn to stderr).
+    Keys only in overlay → added to result.
+    Keys only in portable → kept as-is.
+    """
+    result = dict(portable)
+    for key, val in overlay.items():
+        if key in portable:
+            print(
+                f"[yaml-merge] warning: overlay field '{key}' overrides portable value",
+                file=sys.stderr,
+            )
+        result[key] = val
+    return result
+
+
+def _str_representer(dumper, data):
+    """Represent multi-line strings as block scalar (|) to preserve readability.
+
+    Single-line strings use the default style; strings containing newlines are
+    emitted as literal block scalars so that `description: |` style is preserved
+    in the merged frontmatter (matches the original portable SKILL.md style).
+    """
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("usage: yaml-merge.py <portable.yaml> <overlay.yaml>", file=sys.stderr)
+        sys.exit(1)
+
+    portable_path = sys.argv[1]
+    overlay_path = sys.argv[2]
+
+    portable = load_yaml(portable_path)
+    overlay = load_yaml(overlay_path)
+
+    merged = merge(portable, overlay)
+
+    # Register block-style representer for multi-line strings before dumping.
+    yaml.add_representer(str, _str_representer)
+
+    # Dump merged YAML preserving insertion order, block style.
+    print(
+        yaml.dump(
+            merged,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+            width=1000,
+        ),
+        end="",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/_shared/references/portable-coordinator.md
+++ b/_shared/references/portable-coordinator.md
@@ -303,6 +303,46 @@ agents:
 [`docs/skill-creation-guide.md` § Portable subset と Claude Code 拡張](../../docs/skill-creation-guide.md)
 を参照 (PR #104 で改訂)。
 
+### Adapter overlay (reference 実装, issue #106)
+
+Claude Code 拡張 frontmatter を portable SKILL.md から分離し、build script で merge する仕組み。
+[`dev-plan-review`](../../dev-plan-review/SKILL.md) が **最初の reference 実装** (#103 Phase C)。
+
+```
+<skill-name>/
+├── SKILL.md                 # portable subset のみ (cross-agent で parse 可能)
+├── adapters/
+│   └── claude.yaml          # Claude Code 拡張 (model / effort / context / allowed-tools)
+└── ...                      # references/, scripts/ など既存構造
+        │
+        ▼
+[ _lib/scripts/build-skill-overlay.sh dev-plan-review ]
+        │
+        ▼
+$HOME/.cache/claude-skill-build/dev-plan-review/SKILL.md   ← Claude Code が読む merge artifact
+                                                           ← Codex CLI / agy は元の portable SKILL.md を直接読む
+```
+
+設計判断 (issue #106 推奨採用):
+
+| # | 判断 | 採用案 |
+|---|------|--------|
+| Q1 | adapter overlay の置き場所 | A: `<skill>/adapters/<vendor>.yaml` |
+| Q2 | Claude への merge 方法 | 1: build script artifact (runtime merge 不要) |
+| Q3 | artifact の git 管理 | Y: git ignore + CI/hook で再生成 |
+| Q4 | Claude Code subagent (`context: fork`) | A: build artifact に merge して既存挙動維持 |
+
+merge ルールと CLI 詳細は [`docs/skill-creation-guide.md` § Adapter Overlay 規約](../../docs/skill-creation-guide.md)
+を参照。
+
+実装ファイル:
+- `_lib/scripts/build-skill-overlay.sh` — bash entry point (frontmatter 抽出 / atomic write)
+- `_lib/scripts/yaml-merge.py` — PyYAML 6.x ベースの薄い merge helper (overlay-wins + block scalar 保持)
+- `_lib/scripts/build-skill-overlay.bats` — 単体テスト 7 ケース
+- `dev-plan-review/adapters/claude.yaml` — Claude Code 拡張 4 field の reference
+
+残り 52 skill (本 PR で 53→52) の移行は別 issue で機械的に進める。
+
 ### Lint and Audit scripts
 
 #### Invariant lint (PR #104 で追加、CI 連携前提)
@@ -383,7 +423,8 @@ bash coordinator 経由なら **どの agent でも nesting 制限なし** (別 
 - [x] SKILL.md portable subset 化 — Phase A/B 基盤整備 ([PR #104](https://github.com/it-all-playpark/skills/pull/104) merge 済)
   - `lint-portable-frontmatter.sh` 追加 (CI 連携前提)
   - `docs/skill-creation-guide.md` に portability 規約セクション追加
-- [ ] SKILL.md portable subset 化 — Phase C: 既存 skill の段階移行 (53/75 skill 残)
+- [x] SKILL.md portable subset 化 — Phase C reference 実装 (`dev-plan-review` + `build-skill-overlay.sh`、issue #106)
+- [ ] SKILL.md portable subset 化 — Phase C: 残り 52 skill の段階移行 (本 PR で 53→52)
 - [x] portable adapter PoC (`invoke-skill-poc.sh`)
 - [x] worktree adapter (`worktree-create.sh` + `worktree-finalize.sh`)
 - [x] SKILL.md audit / lint script

--- a/dev-plan-review/SKILL.md
+++ b/dev-plan-review/SKILL.md
@@ -6,16 +6,15 @@ description: |
   (3) standalone review of any impl-plan.md,
   (4) keywords: plan review, 計画レビュー, devil's advocate, 批判的レビュー
   Accepts args: [<issue-number>] [--worktree <path>] [--plan <path>] [--pass-threshold 80]
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Bash(~/.claude/skills/skill-retrospective/scripts/*)
-  - Bash(git:*)
-  - Bash(gh:*)
-model: opus
-effort: max
-context: fork
+version: 1.0.0
+author: it-all-playpark
+tags:
+  - dev-flow
+  - review
+agents:
+  - claude
+  - codex
+  - agy
 ---
 
 # Plan Review

--- a/dev-plan-review/adapters/claude.yaml
+++ b/dev-plan-review/adapters/claude.yaml
@@ -1,0 +1,25 @@
+# Claude Code adapter overlay for dev-plan-review
+#
+# このファイルは Claude Code 固有の frontmatter 拡張を保持する。
+# `_lib/scripts/build-skill-overlay.sh dev-plan-review` を実行すると
+# SKILL.md (portable subset) と本ファイルが merge され、Claude Code 用
+# build artifact (`$HOME/.cache/claude-skill-build/dev-plan-review/SKILL.md` または
+# `--output` で指定したパス) が生成される。
+#
+# 設計判断: issue #106 (#103 Phase C)
+#   Q1=A: adapter overlay は `<skill>/adapters/<vendor>.yaml`
+#   Q4=A: `context: fork` を build artifact に merge して Claude Code subagent 化を維持
+#
+# 注意: 他 agent (Codex CLI / Antigravity) は本ファイルを読まない。
+# それらは SKILL.md (portable subset) のみを参照する。
+
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(~/.claude/skills/skill-retrospective/scripts/*)
+  - Bash(git:*)
+  - Bash(gh:*)
+model: opus
+effort: max
+context: fork

--- a/docs/skill-creation-guide.md
+++ b/docs/skill-creation-guide.md
@@ -111,6 +111,95 @@ bash _lib/scripts/lint-portable-frontmatter.sh --root . --strict
 3. `disable-model-invocation: true` / `user-invocable: false` などの Claude 固有挙動が
    必須なら、portable subset 不可能と明記して上記制約を accept
 
+#### Adapter Overlay 規約 (issue #106, Phase C reference 実装)
+
+Claude Code 拡張を portable SKILL.md から分離して保持する仕組み。Codex CLI / Antigravity
+(agy) は portable な SKILL.md だけを読み、Claude Code は build artifact (portable + adapter overlay
+の merge 結果) を読む。**reference 実装は `dev-plan-review`** で、他 skill の段階移行は
+本 PR の規約を踏襲する。
+
+##### ディレクトリ構造
+
+```
+<skill-name>/
+├── SKILL.md                # portable subset のみ (cross-agent で parse 可能)
+├── adapters/
+│   └── claude.yaml         # Claude Code 拡張 4 field (model / effort / context / allowed-tools 等)
+└── ...
+```
+
+`<skill>/adapters/<vendor>.yaml` 形式 (Q1=A 採用)。将来 Cursor / Amp 等が独自 frontmatter
+拡張を持つようになった場合は `cursor.yaml`, `amp.yaml` 等を追加可能。
+
+##### `claude.yaml` のスキーマ
+
+`adapters/claude.yaml` には Claude Code 拡張 12 field のうち skill が必要とするものを記述
+する。最小例:
+
+```yaml
+# Claude Code adapter overlay
+model: opus           # 実行モデル
+effort: max           # 推論深度
+context: fork         # subagent 化
+allowed-tools:
+  - Read
+  - Bash(git:*)
+```
+
+`name` / `description` 等の portable field は **記述してはいけない** (重複定義になる)。ただし
+意図的に override したい場合は overlay 側が勝つ (warn 出力)。
+
+##### Build script
+
+`_lib/scripts/build-skill-overlay.sh` が portable SKILL.md + adapter overlay を merge して
+Claude Code 用 SKILL.md を生成する。
+
+```bash
+bash _lib/scripts/build-skill-overlay.sh <skill-name> \
+  [--vendor <vendor>]        # default: claude
+  [--skill-root <path>]      # default: repo root (auto-detect)
+  [--output <path>]          # default: $HOME/.cache/claude-skill-build/<skill-name>/SKILL.md
+```
+
+| 入力 | 出力 |
+|------|------|
+| `<repo>/<skill>/SKILL.md` (portable subset) | `--output` で指定した path に merged SKILL.md |
+| `<repo>/<skill>/adapters/<vendor>.yaml` (overlay) | (frontmatter union + body は portable のもの) |
+
+##### Merge ルール
+
+1. **body**: portable SKILL.md の body をそのまま使用 (overlay には body を持たせない)
+2. **frontmatter**: `union(portable_fm, overlay_fm)`、insertion order は portable → overlay の順
+3. **同一 key 衝突**: overlay が勝つ + warn を stderr に出す (意図的 override を許容しつつ意識させる)
+4. **overlay 不在**: portable をそのまま passthrough (`exit 0`、log のみ)
+5. **不正な YAML overlay**: PyYAML が parse error を stderr に出し `exit 2` (atomic write のため
+   partial file は生成しない)
+6. 複数行 string は **block scalar (`|`) 形式で保持** (description の見栄え保持)
+
+##### Build artifact のライフサイクル
+
+- デフォルト出力先 `$HOME/.cache/claude-skill-build/<skill>/SKILL.md` は **repo 外** なので
+  `.gitignore` 設定は不要 (Q3=Y 採用)
+- 開発者が `--output ./.build/...` のように repo 内パスを指定する場合に備え `.gitignore` に
+  `/.build/` と `/dist/skills/` を defensive に追加済
+- artifact 自体は **commit しない**。`_lib/scripts/build-skill-overlay.sh` で **再生成可能** な
+  derived data として扱う
+- 将来: pre-commit hook で SKILL.md / adapter overlay の変更を検知して自動 rebuild、
+  CI で `--check` モードで diff 比較する案あり (本 PR では未実装)
+
+##### Lint
+
+```bash
+# 拡張 field が残っている skill を集計
+bash _lib/scripts/lint-portable-frontmatter.sh --root . --json | jq .files_with_ext_fields
+
+# portable subset 化進捗の可視化
+bash _lib/scripts/lint-portable-frontmatter.sh --root . --json | jq .ext_field_usage
+```
+
+reference 実装 (`dev-plan-review`) では本 PR で `files_with_ext_fields: 53 → 52` の減少を
+確認している。残り 52 skill は別 issue で機械的に portable subset 化する。
+
 ### Frontmatter 全 20 フィールド (一覧)
 
 | Field | Portable? | Required | Description |


### PR DESCRIPTION
## 概要

[#103](https://github.com/it-all-playpark/skills/issues/103) Phase C (SKILL.md portable subset 化) の **reference 実装**。`dev-plan-review` を最初の portable subset + adapter overlay 例として書き換え、Claude Code 拡張 4 field (`allowed-tools`, `model`, `effort`, `context`) を `dev-plan-review/adapters/claude.yaml` に分離。両者を merge して Claude Code 用 SKILL.md を生成する `_lib/scripts/build-skill-overlay.sh` を新規実装。

これにより:
- **Codex CLI / Antigravity (agy)** は portable な SKILL.md を直接 parse 可能 (strict YAML parser でも error なし)
- **Claude Code** は build artifact (portable + adapter overlay の merge 結果) を読むことで `context: fork` + `model: opus` 等の既存挙動を保ったまま動作
- 残り 52 skill (本 PR で 53→52) は本 PR で確立した規約に沿って機械的に移行可能

closes #106

## 設計判断 (issue #106 推奨をそのまま採用)

| # | 判断 | 採用案 | 理由 (主要) |
|---|------|--------|-------------|
| Q1 | adapter overlay の置き場所 | A: \`<skill>/adapters/<vendor>.yaml\` | skill 内完結、`<skill>/adapters/*.yaml` glob で CI lint 容易、`codex.yaml` / `agy.yaml` 等の追加もスケール |
| Q2 | Claude への merge 方法 | 1: build script で artifact 出力 | Claude Code runtime 変更不要、DRY 維持 |
| Q3 | artifact の git 管理 | Y: git ignore + 必要に応じ再生成 | 同期漏れ / 大量 diff 回避。本 PR ではデフォルト出力先が repo 外 (`$HOME/.cache/...`) なので gitignore は defensive (`/.build/` `/dist/skills/`) のみ |
| Q4 | Claude Code subagent (`context: fork`) | A: build artifact に merge して維持 | portable のみだとメイン context 圧迫で回帰、`context: fork` の isolation を捨てない |

不採用案の詳細は [`docs/skill-creation-guide.md` § Adapter Overlay 規約](../tree/feature/issue-106-portable-dev-plan-review/docs/skill-creation-guide.md) 参照。

## Build script 仕様

\`\`\`
bash _lib/scripts/build-skill-overlay.sh <skill-name> \\
  [--vendor <vendor>]        # default: claude
  [--skill-root <path>]      # default: repo root (auto-detect)
  [--output <path>]          # default: \$HOME/.cache/claude-skill-build/<skill-name>/SKILL.md
\`\`\`

### 入出力

| | |
|---|---|
| 入力 portable | \`<repo>/<skill>/SKILL.md\` |
| 入力 overlay | \`<repo>/<skill>/adapters/<vendor>.yaml\` (省略可、不在なら passthrough) |
| 出力 artifact | \`--output\` 指定先 (default: \`\$HOME/.cache/claude-skill-build/<skill>/SKILL.md\`) |

### Merge ルール

1. **body**: portable SKILL.md の body をそのまま使用 (overlay は body を持たない)
2. **frontmatter**: `union(portable_fm, overlay_fm)`、insertion order = portable → overlay
3. **同一 key 衝突**: overlay が勝つ + warn を stderr に出力 (意図的 override 許容、無意識上書き検知)
4. **overlay 不在**: portable のまま passthrough (exit 0)、log のみ
5. **不正な YAML**: PyYAML parse error を stderr に出して exit 2 (atomic write のため partial 出力なし)
6. 複数行 string は **block scalar (`|`) を保持** (description の見栄えを portable のまま保持)

## 変更ファイル

- `dev-plan-review/SKILL.md` — portable subset 化 (Claude 拡張 4 field 削除、`version` / `author` / `tags` / `agents` 追加)
- `dev-plan-review/adapters/claude.yaml` — 新規、Claude 拡張 4 field を分離保持
- `_lib/scripts/build-skill-overlay.sh` — 新規、bash entry point (frontmatter 抽出 / atomic write / overlay 検出)
- `_lib/scripts/yaml-merge.py` — 新規、PyYAML 6.x ベースの merge helper (overlay-wins + block scalar 保持)
- `_lib/scripts/build-skill-overlay.bats` — 新規、単体テスト 7 ケース (usage / portable-only / merge-success / missing-overlay / invalid-yaml / field-collision / output-to-file)
- `.gitignore` — `/.build/` `/dist/skills/` を defensive 追加 (build artifact が repo 内に出力された場合の保険)
- `docs/skill-creation-guide.md` — "Adapter Overlay 規約" セクション新規 (ディレクトリ構造 / claude.yaml schema / build script / merge ルール / ライフサイクル / lint)
- `_shared/references/portable-coordinator.md` — Section 6 に reference 実装の構造図 + 設計判断テーブル追加、Stage 1 の Phase C reference 実装項目に check

## 検証

### 自動検証

| Check | Command | Result |
|-------|---------|--------|
| lint stats 減少 | `bash _lib/scripts/lint-portable-frontmatter.sh --root . --json \| jq .files_with_ext_fields` | 53 → 52 ✓ |
| 4 field 全減 | `... .ext_field_usage` | `allowed-tools` 23→22, `model` 39→38, `effort` 24→23, `context` 21→20 ✓ |
| build artifact 生成 | `bash _lib/scripts/build-skill-overlay.sh dev-plan-review --output /tmp/merged.md` | 元の SKILL.md と semantically + visually 等価な artifact 生成 ✓ |
| merge frontmatter 正しさ | head /tmp/merged.md | `name` / `description` (block scalar 保持) / `version` / `tags` / `agents` / `allowed-tools` / `model: opus` / `effort: max` / `context: fork` 全て含まれる ✓ |
| missing overlay | overlay 削除して再実行 | exit 0、portable をそのまま出力 ✓ |
| invalid YAML | `printf 'a: [unclosed\n' > .../claude.yaml` | exit 2、stderr に parse error ✓ |
| collision | overlay に `name: overridden` 追加 | exit 0、overlay 値採用 + warn を stderr ✓ |
| bats graceful skip | `bash tests/run-all-bats.sh` (non-strict) | bats 未 install で exit 0 ✓ |

### Manual smoke (本 PR では skip、follow-up で対応)

- **Codex CLI**: `codex exec --sandbox read-only "/dev-plan-review --plan /tmp/sample.md"` で skill 起動 (現状 `pr-review` で出ていた "invalid YAML at line 5" が再現しないこと)
- **Antigravity (agy)**: `agy -p "/dev-plan-review --plan /tmp/sample.md"` で skill 起動
- **3 agent E2E**: 同一 sample plan input → 同等 JSON output 比較

これらは本 PR で確立した規約の動作確認なので、別 PR (`invoke-skill-poc.bats` 拡張) でまとめて自動化する。本 PR は規約確立 + reference 実装に focus。

## Out of scope (別 issue)

- 残り 52 skill (本 PR 後) の portable 化 — 別 PR で機械的に進める
- Stage 2 (decision script + state machine) — 本 issue 完了後に着手
- Cursor / Amp の adapter 追加
- `build-skill-overlay.sh --check` mode (CI 連携用、別 issue)
- `lint-portable-frontmatter.sh` の adapter overlay フィールド検証拡張 (本 issue で「任意」と明記)
- 3 agent E2E の完全自動化

## Test plan

- [ ] CI で `bash _lib/scripts/lint-portable-frontmatter.sh --root . --json` が `files_with_ext_fields: 52` を返す
- [ ] CI で `bash tests/run-all-bats.sh --strict` が build-skill-overlay.bats を含めて緑 (bats install 済前提)
- [ ] reviewer が手元で `bash _lib/scripts/build-skill-overlay.sh dev-plan-review` を実行し、`~/.cache/claude-skill-build/dev-plan-review/SKILL.md` に元の SKILL.md と等価な内容が生成されることを確認
- [ ] reviewer が dev-kickoff Phase 3b の plan-review loop が build artifact 経由でも従来通り動くことを smoke 確認 (任意、本 PR の規約確立がメインなので必須ではない)