### PR TITLE
fix(issue-110): adapter overlay wiring for dev-plan-review

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,6 +15,7 @@
 # Environment overrides (for testing):
 #   BUILD_SKILL_OVERLAY   — path to build-skill-overlay.sh (default: auto-detect)
 #   REPO_ROOT             — repo root path (default: git rev-parse --show-toplevel)
+#   VENDOR                — adapter vendor / build namespace (default: claude)
 
 set -euo pipefail
 
@@ -38,6 +39,8 @@ fi
 if [[ -z "${BUILD_SKILL_OVERLAY:-}" ]]; then
   BUILD_SKILL_OVERLAY="$REPO_ROOT/_lib/scripts/build-skill-overlay.sh"
 fi
+
+VENDOR="${VENDOR:-claude}"
 
 # ---------------------------------------------------------------------------
 # Check PyYAML availability (build-skill-overlay.sh depends on it)
@@ -92,12 +95,13 @@ fail_count=0
 while IFS= read -r skill_name; do
   [[ -z "$skill_name" ]] && continue
   skill_root="$REPO_ROOT"
-  output_path="$REPO_ROOT/.build/skills/$skill_name/SKILL.md"
+  output_path="$REPO_ROOT/.build/skills/$VENDOR/$skill_name/SKILL.md"
 
   echo "[pre-commit] rebuilding: $skill_name" >&2
 
   if ! bash "$BUILD_SKILL_OVERLAY" "$skill_name" \
       --skill-root "$skill_root" \
+      --vendor "$VENDOR" \
       --output "$output_path" \
       --subdir-strategy symlink \
       2>&1 >&2; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit — rebuild skill overlay artifacts for changed skills.
+#
+# Triggered on: git commit (when core.hooksPath = .githooks)
+#
+# Behavior:
+#   - Reads staged file list from `git diff --cached --name-only`
+#   - For each changed file matching <skill>/SKILL.md or <skill>/adapters/*.yaml,
+#     rebuilds that skill's overlay artifact via build-skill-overlay.sh
+#   - Exits non-zero if any rebuild fails (blocking the commit)
+#
+# Escape hatch:
+#   SKIP_SKILL_REBUILD=1  — skip all rebuilds (useful for hotfixes)
+#
+# Environment overrides (for testing):
+#   BUILD_SKILL_OVERLAY   — path to build-skill-overlay.sh (default: auto-detect)
+#   REPO_ROOT             — repo root path (default: git rev-parse --show-toplevel)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Escape hatch
+# ---------------------------------------------------------------------------
+if [[ "${SKIP_SKILL_REBUILD:-}" == "1" ]]; then
+  echo "[pre-commit] SKIP_SKILL_REBUILD=1: skipping skill rebuild" >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z "${REPO_ROOT:-}" ]]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+fi
+
+if [[ -z "${BUILD_SKILL_OVERLAY:-}" ]]; then
+  BUILD_SKILL_OVERLAY="$REPO_ROOT/_lib/scripts/build-skill-overlay.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Check PyYAML availability (build-skill-overlay.sh depends on it)
+# ---------------------------------------------------------------------------
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "[pre-commit] warning: PyYAML not available, skipping skill rebuild" >&2
+  echo "[pre-commit] install: pip3 install pyyaml" >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Get list of staged files
+# ---------------------------------------------------------------------------
+staged_files="$(git diff --cached --name-only)"
+
+if [[ -z "$staged_files" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Identify skills to rebuild
+# ---------------------------------------------------------------------------
+skills_to_rebuild=""  # newline-separated list of skill names (deduplicated)
+
+while IFS= read -r file; do
+  skill_name=""
+  # Match: <skill>/SKILL.md
+  if [[ "$file" =~ ^([^/]+)/SKILL\.md$ ]]; then
+    skill_name="${BASH_REMATCH[1]}"
+  # Match: <skill>/adapters/*.yaml
+  elif [[ "$file" =~ ^([^/]+)/adapters/[^/]+\.yaml$ ]]; then
+    skill_name="${BASH_REMATCH[1]}"
+  fi
+
+  if [[ -n "$skill_name" ]]; then
+    # Deduplicate
+    if ! printf '%s\n' "$skills_to_rebuild" | grep -qxF "$skill_name"; then
+      skills_to_rebuild="${skills_to_rebuild:+$skills_to_rebuild$'\n'}$skill_name"
+    fi
+  fi
+done <<< "$staged_files"
+
+if [[ -z "$skills_to_rebuild" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Rebuild affected skills
+# ---------------------------------------------------------------------------
+fail_count=0
+
+while IFS= read -r skill_name; do
+  [[ -z "$skill_name" ]] && continue
+  skill_root="$REPO_ROOT"
+  output_path="$REPO_ROOT/.build/skills/$skill_name/SKILL.md"
+
+  echo "[pre-commit] rebuilding: $skill_name" >&2
+
+  if ! bash "$BUILD_SKILL_OVERLAY" "$skill_name" \
+      --skill-root "$skill_root" \
+      --output "$output_path" \
+      --subdir-strategy symlink \
+      2>&1 >&2; then
+    echo "[pre-commit] FAILED: $skill_name rebuild failed" >&2
+    ((fail_count++)) || true
+  fi
+done <<< "$skills_to_rebuild"
+
+if [[ $fail_count -gt 0 ]]; then
+  echo "[pre-commit] $fail_count skill(s) failed to rebuild. Commit blocked." >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit.bats
+++ b/.githooks/pre-commit.bats
@@ -31,7 +31,7 @@ make_portable_skill() {
   local root="$1"
   local name="$2"
   mkdir -p "$root/$name"
-  printf '---\nname: %s\ndescription: Test.\n---\n# Body\n' "$name" > "$root/$name/SKILL.md"
+  printf '%s\n' '---' "name: $name" 'description: Test.' '---' '# Body' > "$root/$name/SKILL.md"
 }
 
 # Run the hook with a mocked git diff output and capture rebuilt skills

--- a/.githooks/pre-commit.bats
+++ b/.githooks/pre-commit.bats
@@ -1,0 +1,283 @@
+#!/usr/bin/env bats
+# pre-commit.bats — unit tests for .githooks/pre-commit
+# TDD: tests written RED first.
+#
+# Test cases:
+#   1. skill-md-change      - SKILL.md change triggers rebuild of that skill only
+#   2. adapter-change       - adapters/claude.yaml change triggers rebuild
+#   3. unrelated-change     - unrelated file change is a no-op (no rebuild)
+#   4. skip-rebuild-env     - SKIP_SKILL_REBUILD=1 skips all rebuild
+#   5. rebuild-failure      - rebuild failure causes hook to exit non-zero
+#
+# The hook is tested by providing a mock git diff output and a fake
+# build-skill-overlay.sh that records calls.
+
+HOOK_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+HOOK="$HOOK_DIR/pre-commit"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+make_git_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "test@test.com"
+  git -C "$dir" config user.name "Test"
+}
+
+make_portable_skill() {
+  local root="$1"
+  local name="$2"
+  mkdir -p "$root/$name"
+  printf '---\nname: %s\ndescription: Test.\n---\n# Body\n' "$name" > "$root/$name/SKILL.md"
+}
+
+# Run the hook with a mocked git diff output and capture rebuilt skills
+run_hook_with_diff() {
+  local tmpdir="$1"
+  local diff_files="$2"   # newline-separated list of changed files
+  local expect_exit="${3:-0}"
+
+  # Create a fake build-skill-overlay.sh that records calls
+  local fake_build="$tmpdir/fake_build.sh"
+  cat > "$fake_build" << 'FAKE'
+#!/usr/bin/env bash
+# Record which skill was rebuilt
+skill_name="$1"
+echo "$skill_name" >> "$TMPDIR_HOOK/rebuilt_skills.txt"
+exit 0
+FAKE
+  chmod +x "$fake_build"
+
+  # Create a fake git that returns controlled diff output
+  local fake_git="$tmpdir/fake_git"
+  mkdir -p "$fake_git"
+  cat > "$fake_git/git" << GITFAKE
+#!/usr/bin/env bash
+if [[ "\$*" == "diff --cached --name-only" ]]; then
+  printf '%s\n' $diff_files
+  exit 0
+fi
+exec /usr/bin/git "\$@"
+GITFAKE
+  chmod +x "$fake_git/git"
+
+  export TMPDIR_HOOK="$tmpdir"
+  export BUILD_SKILL_OVERLAY="$fake_build"
+  export PATH="$fake_git:$PATH"
+  export REPO_ROOT="$tmpdir/repo"
+
+  bash "$HOOK"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: SKILL.md change → rebuild of that skill only
+# ---------------------------------------------------------------------------
+@test "skill-md-change: SKILL.md change triggers rebuild of affected skill" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local repo="$tmpdir/repo"
+  make_git_repo "$repo"
+  make_portable_skill "$repo" "my-skill"
+
+  touch "$tmpdir/rebuilt_skills.txt"
+
+  export TMPDIR_HOOK="$tmpdir"
+  export BUILD_SKILL_OVERLAY="$tmpdir/fake_build.sh"
+  export REPO_ROOT="$repo"
+
+  # Create fake build script
+  cat > "$tmpdir/fake_build.sh" << 'BEOF'
+#!/usr/bin/env bash
+echo "$1" >> "$TMPDIR_HOOK/rebuilt_skills.txt"
+exit 0
+BEOF
+  chmod +x "$tmpdir/fake_build.sh"
+
+  # Create fake git diff returning my-skill/SKILL.md
+  local fake_git_dir="$tmpdir/fakebin"
+  mkdir -p "$fake_git_dir"
+  cat > "$fake_git_dir/git" << 'GEOF'
+#!/usr/bin/env bash
+if [[ "$*" == "diff --cached --name-only" ]]; then
+  echo "my-skill/SKILL.md"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+GEOF
+  chmod +x "$fake_git_dir/git"
+
+  PATH="$fake_git_dir:$PATH" run bash "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -q "my-skill" "$tmpdir/rebuilt_skills.txt"
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: adapters/claude.yaml change → rebuild
+# ---------------------------------------------------------------------------
+@test "adapter-change: adapters/claude.yaml change triggers rebuild of that skill" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local repo="$tmpdir/repo"
+  make_git_repo "$repo"
+  make_portable_skill "$repo" "my-skill"
+  mkdir -p "$repo/my-skill/adapters"
+  printf 'model: opus\n' > "$repo/my-skill/adapters/claude.yaml"
+
+  touch "$tmpdir/rebuilt_skills.txt"
+  export TMPDIR_HOOK="$tmpdir"
+  export BUILD_SKILL_OVERLAY="$tmpdir/fake_build.sh"
+  export REPO_ROOT="$repo"
+
+  cat > "$tmpdir/fake_build.sh" << 'BEOF'
+#!/usr/bin/env bash
+echo "$1" >> "$TMPDIR_HOOK/rebuilt_skills.txt"
+exit 0
+BEOF
+  chmod +x "$tmpdir/fake_build.sh"
+
+  local fake_git_dir="$tmpdir/fakebin"
+  mkdir -p "$fake_git_dir"
+  cat > "$fake_git_dir/git" << 'GEOF'
+#!/usr/bin/env bash
+if [[ "$*" == "diff --cached --name-only" ]]; then
+  echo "my-skill/adapters/claude.yaml"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+GEOF
+  chmod +x "$fake_git_dir/git"
+
+  PATH="$fake_git_dir:$PATH" run bash "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -q "my-skill" "$tmpdir/rebuilt_skills.txt"
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: unrelated-change → no rebuild
+# ---------------------------------------------------------------------------
+@test "unrelated-change: non-skill file change does not trigger rebuild" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local repo="$tmpdir/repo"
+  make_git_repo "$repo"
+
+  touch "$tmpdir/rebuilt_skills.txt"
+  export TMPDIR_HOOK="$tmpdir"
+  export BUILD_SKILL_OVERLAY="$tmpdir/fake_build.sh"
+  export REPO_ROOT="$repo"
+
+  cat > "$tmpdir/fake_build.sh" << 'BEOF'
+#!/usr/bin/env bash
+echo "$1" >> "$TMPDIR_HOOK/rebuilt_skills.txt"
+exit 0
+BEOF
+  chmod +x "$tmpdir/fake_build.sh"
+
+  local fake_git_dir="$tmpdir/fakebin"
+  mkdir -p "$fake_git_dir"
+  cat > "$fake_git_dir/git" << 'GEOF'
+#!/usr/bin/env bash
+if [[ "$*" == "diff --cached --name-only" ]]; then
+  echo "README.md"
+  echo "docs/some-doc.md"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+GEOF
+  chmod +x "$fake_git_dir/git"
+
+  PATH="$fake_git_dir:$PATH" run bash "$HOOK"
+  [ "$status" -eq 0 ]
+  # rebuilt_skills.txt must be empty
+  [ ! -s "$tmpdir/rebuilt_skills.txt" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: SKIP_SKILL_REBUILD=1 → no rebuild
+# ---------------------------------------------------------------------------
+@test "skip-rebuild-env: SKIP_SKILL_REBUILD=1 skips all rebuilds" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local repo="$tmpdir/repo"
+  make_git_repo "$repo"
+  make_portable_skill "$repo" "my-skill"
+
+  touch "$tmpdir/rebuilt_skills.txt"
+  export TMPDIR_HOOK="$tmpdir"
+  export BUILD_SKILL_OVERLAY="$tmpdir/fake_build.sh"
+  export REPO_ROOT="$repo"
+
+  cat > "$tmpdir/fake_build.sh" << 'BEOF'
+#!/usr/bin/env bash
+echo "$1" >> "$TMPDIR_HOOK/rebuilt_skills.txt"
+exit 0
+BEOF
+  chmod +x "$tmpdir/fake_build.sh"
+
+  local fake_git_dir="$tmpdir/fakebin"
+  mkdir -p "$fake_git_dir"
+  cat > "$fake_git_dir/git" << 'GEOF'
+#!/usr/bin/env bash
+if [[ "$*" == "diff --cached --name-only" ]]; then
+  echo "my-skill/SKILL.md"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+GEOF
+  chmod +x "$fake_git_dir/git"
+
+  SKIP_SKILL_REBUILD=1 PATH="$fake_git_dir:$PATH" run bash "$HOOK"
+  [ "$status" -eq 0 ]
+  [ ! -s "$tmpdir/rebuilt_skills.txt" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: rebuild failure → hook exits non-zero
+# ---------------------------------------------------------------------------
+@test "rebuild-failure: failed rebuild causes hook to exit non-zero" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local repo="$tmpdir/repo"
+  make_git_repo "$repo"
+  make_portable_skill "$repo" "my-skill"
+
+  export TMPDIR_HOOK="$tmpdir"
+  export BUILD_SKILL_OVERLAY="$tmpdir/fake_build.sh"
+  export REPO_ROOT="$repo"
+
+  # Fake build that fails
+  cat > "$tmpdir/fake_build.sh" << 'BEOF'
+#!/usr/bin/env bash
+echo "$1" >&2
+exit 2
+BEOF
+  chmod +x "$tmpdir/fake_build.sh"
+
+  local fake_git_dir="$tmpdir/fakebin"
+  mkdir -p "$fake_git_dir"
+  cat > "$fake_git_dir/git" << 'GEOF'
+#!/usr/bin/env bash
+if [[ "$*" == "diff --cached --name-only" ]]; then
+  echo "my-skill/SKILL.md"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+GEOF
+  chmod +x "$fake_git_dir/git"
+
+  PATH="$fake_git_dir:$PATH" run bash "$HOOK"
+  [ "$status" -ne 0 ]
+
+  /bin/rm -rf "$tmpdir"
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,3 +67,49 @@ jobs:
         run: |
           chmod +x tests/run-all-bats.sh
           ./tests/run-all-bats.sh --strict
+
+  merged-skill-build:
+    name: Merged Skill Build + Overlay Lint (issue #110)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PyYAML
+        shell: bash
+        run: |
+          pip3 install pyyaml
+
+      - name: Build all skill overlay artifacts
+        shell: bash
+        run: |
+          chmod +x _lib/scripts/build-all-skills.sh \
+                   _lib/scripts/build-skill-overlay.sh \
+                   _lib/scripts/lint-merged-frontmatter.sh
+          make skills
+
+      - name: Assert dev-plan-review artifact exists
+        shell: bash
+        run: |
+          [[ -f .build/skills/dev-plan-review/SKILL.md ]] || {
+            echo "error: .build/skills/dev-plan-review/SKILL.md not found" >&2
+            exit 1
+          }
+
+      - name: Lint dev-plan-review merged frontmatter
+        shell: bash
+        run: |
+          ./_lib/scripts/lint-merged-frontmatter.sh \
+            .build/skills/dev-plan-review/SKILL.md \
+            --require "model,effort,context,allowed-tools"
+
+      - name: Assert discover count equals built count
+        shell: bash
+        run: |
+          discovered=$(bash _lib/scripts/build-all-skills.sh --list-discovered | wc -l | tr -d ' ')
+          built=$(find .build/skills -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+          echo "Discovered: $discovered, Built: $built"
+          [[ "$discovered" -eq "$built" ]] || {
+            echo "error: discovered ($discovered) != built ($built)" >&2
+            exit 1
+          }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Assert dev-plan-review artifact exists
         shell: bash
         run: |
-          [[ -f .build/skills/dev-plan-review/SKILL.md ]] || {
-            echo "error: .build/skills/dev-plan-review/SKILL.md not found" >&2
+          [[ -f .build/skills/claude/dev-plan-review/SKILL.md ]] || {
+            echo "error: .build/skills/claude/dev-plan-review/SKILL.md not found" >&2
             exit 1
           }
 
@@ -100,14 +100,14 @@ jobs:
         shell: bash
         run: |
           ./_lib/scripts/lint-merged-frontmatter.sh \
-            .build/skills/dev-plan-review/SKILL.md \
+            .build/skills/claude/dev-plan-review/SKILL.md \
             --require "model,effort,context,allowed-tools"
 
       - name: Assert discover count equals built count
         shell: bash
         run: |
           discovered=$(bash _lib/scripts/build-all-skills.sh --list-discovered | wc -l | tr -d ' ')
-          built=$(find .build/skills -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+          built=$(find .build/skills/claude -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
           echo "Discovered: $discovered, Built: $built"
           [[ "$discovered" -eq "$built" ]] || {
             echo "error: discovered ($discovered) != built ($built)" >&2

--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,9 @@ __pycache__/
 # Packaged skills
 *.skill
 
-# Adapter overlay build artifacts (issue #106, Q3=Y)
-# build-skill-overlay.sh のデフォルト出力先は $HOME/.cache/claude-skill-build/ (repo 外)
-# だが、開発者が --output で repo 内パスを指定したときの誤コミット防止のため defensive に ignore
+# Adapter overlay build artifacts (issue #106 / #110)
+# build-skill-overlay.sh / build-all-skills.sh のデフォルト出力先は <repo>/.build/skills/ (issue #110)。
+# merge artifact は derived data なので commit せず ignore する (make skills で再生成可能)。
 /.build/
 /dist/skills/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,10 +152,12 @@ portable SKILL.md + `adapters/claude.yaml` を Claude Code に届けるための
 
 **解決**: `make setup` + `make install-link` で以下を構築:
 
-1. `make skills` → `build-all-skills.sh` が `<repo>/.build/skills/<skill>/SKILL.md`
-   (portable + overlay merge artifact) を生成
+1. `make skills` → `build-all-skills.sh` が `<repo>/.build/skills/<vendor>/<skill>/SKILL.md`
+   (portable + overlay merge artifact) を生成。merge artifact は vendor 固有 frontmatter を
+   注入するため **vendor 名で namespace 化** する (default `claude`)。Codex / agy 等の他 agent は
+   portable な `<repo>/<skill>/SKILL.md` を直接読むので build artifact は不要。
 2. `make install-link` → `~/.claude/skills` を **real directory + per-skill symlink** に変換:
-   - overlay あり skill → `~/.claude/skills/<skill>` → `<repo>/.build/skills/<skill>/`
+   - overlay あり skill → `~/.claude/skills/<skill>` → `<repo>/.build/skills/claude/<skill>/`
    - overlay なし skill → `~/.claude/skills/<skill>` → `<repo>/<skill>/`
 
 **worktree での注意**: 各 worktree は独立した `.build/skills/` を持つ。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,16 @@ Subdirectory `AGENTS.md` files take precedence over this root file for their res
 ## Setup commands
 
 ```bash
+# 初回セットアップ (git hooks + skill build artifacts)
+# PyYAML が必要: pip3 install pyyaml
+make setup           # = git config core.hooksPath .githooks + make skills
+
+# Claude Code の ~/.claude/skills を per-skill symlink 構成に変換
+make install-link    # = install-claude-skills-link.sh install
+
+# 元の ~/.claude/skills に戻す
+make uninstall-link  # = install-claude-skills-link.sh restore
+
 # bats (テストフレームワーク) のインストール
 brew install bats-core        # macOS
 apt-get install bats          # Ubuntu / Debian
@@ -18,6 +28,9 @@ apt-get install bats          # Ubuntu / Debian
 # テスト実行
 bash tests/run-all-bats.sh           # ローカル開発 (bats 未インストール時は graceful skip)
 bash tests/run-all-bats.sh --strict  # CI 用 (bats 未インストールを error 扱い)
+
+# Skill build artifacts のみ再生成
+make skills          # = build-all-skills.sh (idempotent full rebuild)
 ```
 
 ディレクトリ構造:
@@ -129,6 +142,30 @@ bash _lib/scripts/lint-portable-frontmatter.sh --root . --strict
 (`<skill>/adapters/claude.yaml`) 化を念頭に置いて設計すること。
 
 詳細: `docs/skill-creation-guide.md` § Portable subset と Claude Code 拡張
+
+### Adapter overlay wiring (issue #110)
+
+portable SKILL.md + `adapters/claude.yaml` を Claude Code に届けるための wiring。
+
+**問題**: `~/.claude/skills` が `<repo>` への単一 symlink では `<skill>/adapters/claude.yaml`
+が Claude Code に届かない (PR #107 で確認)。
+
+**解決**: `make setup` + `make install-link` で以下を構築:
+
+1. `make skills` → `build-all-skills.sh` が `<repo>/.build/skills/<skill>/SKILL.md`
+   (portable + overlay merge artifact) を生成
+2. `make install-link` → `~/.claude/skills` を **real directory + per-skill symlink** に変換:
+   - overlay あり skill → `~/.claude/skills/<skill>` → `<repo>/.build/skills/<skill>/`
+   - overlay なし skill → `~/.claude/skills/<skill>` → `<repo>/<skill>/`
+
+**worktree での注意**: 各 worktree は独立した `.build/skills/` を持つ。
+`make skills` を worktree 内で実行すると worktree ローカルの `.build/` が生成される。
+
+**CI**: `.github/workflows/lint.yml` の `merged-skill-build` job が
+`make skills` → `lint-merged-frontmatter.sh` で merge artifact の内容を検証。
+discover 件数 == built 件数の drift check も含む (固定数値は使わない)。
+
+詳細: `_shared/references/portable-coordinator.md` § 6
 
 ### Subagent dispatch — 必須 5 要素
 

--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,21 @@ skills:
 # Developer setup: configure core.hooksPath + build skills
 # FORCE_HOOKS_PATH can be set to override conflicting core.hooksPath (use with caution)
 setup:
-	@result=$$(bash $(LIB_SCRIPTS)/check-hooks-path.sh --apply --repo-root "$(REPO_ROOT)" 2>&1) && \
-	  status=$$(echo "$$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])" 2>/dev/null); \
-	  if [ "$$status" = "conflict" ]; then \
+	@result=$$(bash $(LIB_SCRIPTS)/check-hooks-path.sh --check --repo-root "$(REPO_ROOT)" 2>/dev/null); \
+	  status=$$(printf '%s' "$$result" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])" 2>/dev/null); \
+	  if [ "$$status" = "conflict" ] && [ "$(FORCE_HOOKS_PATH)" != "1" ]; then \
+	    current=$$(printf '%s' "$$result" | python3 -c "import sys,json; print(json.load(sys.stdin)['current'])" 2>/dev/null); \
 	    echo "error: core.hooksPath is already set to a different value:"; \
-	    echo "$$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print('  current: ' + d['current'])" 2>/dev/null; \
+	    echo "  current: $$current"; \
 	    echo "  target: .githooks"; \
 	    echo "To override, run: make setup FORCE_HOOKS_PATH=1"; \
 	    exit 1; \
+	  fi; \
+	  if [ "$(FORCE_HOOKS_PATH)" = "1" ]; then \
+	    bash $(LIB_SCRIPTS)/check-hooks-path.sh --apply --force --repo-root "$(REPO_ROOT)"; \
+	  else \
+	    bash $(LIB_SCRIPTS)/check-hooks-path.sh --apply --repo-root "$(REPO_ROOT)"; \
 	  fi
-	@if [ "$(FORCE_HOOKS_PATH)" = "1" ]; then \
-	  bash $(LIB_SCRIPTS)/check-hooks-path.sh --apply --force --repo-root "$(REPO_ROOT)"; \
-	fi
 	@$(MAKE) skills
 
 # Install per-skill symlinks in ~/.claude/skills

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+# Makefile — skills repo build automation
+#
+# Targets:
+#   make skills        — build all skill overlay artifacts (idempotent full rebuild)
+#   make setup         — configure git hooks + build skills (developer setup)
+#   make install-link  — install per-skill symlinks in ~/.claude/skills
+#   make uninstall-link — restore previous ~/.claude/skills state
+#   make test          — run all bats tests
+#   make help          — show this help
+
+SHELL := bash
+.SHELLFLAGS := -euo pipefail -c
+
+REPO_ROOT := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
+LIB_SCRIPTS := $(REPO_ROOT)/_lib/scripts
+
+.PHONY: skills setup install-link uninstall-link test help
+
+# Build all skill overlay artifacts
+skills:
+	@bash $(LIB_SCRIPTS)/build-all-skills.sh --repo-root "$(REPO_ROOT)"
+
+# Developer setup: configure core.hooksPath + build skills
+# FORCE_HOOKS_PATH can be set to override conflicting core.hooksPath (use with caution)
+setup:
+	@result=$$(bash $(LIB_SCRIPTS)/check-hooks-path.sh --apply --repo-root "$(REPO_ROOT)" 2>&1) && \
+	  status=$$(echo "$$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])" 2>/dev/null); \
+	  if [ "$$status" = "conflict" ]; then \
+	    echo "error: core.hooksPath is already set to a different value:"; \
+	    echo "$$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print('  current: ' + d['current'])" 2>/dev/null; \
+	    echo "  target: .githooks"; \
+	    echo "To override, run: make setup FORCE_HOOKS_PATH=1"; \
+	    exit 1; \
+	  fi
+	@if [ "$(FORCE_HOOKS_PATH)" = "1" ]; then \
+	  bash $(LIB_SCRIPTS)/check-hooks-path.sh --apply --force --repo-root "$(REPO_ROOT)"; \
+	fi
+	@$(MAKE) skills
+
+# Install per-skill symlinks in ~/.claude/skills
+install-link: skills
+	@bash $(LIB_SCRIPTS)/install-claude-skills-link.sh install \
+	  --repo-root "$(REPO_ROOT)"
+
+# Restore previous ~/.claude/skills state
+uninstall-link:
+	@bash $(LIB_SCRIPTS)/install-claude-skills-link.sh restore
+
+# Run all bats tests
+test:
+	@bash $(REPO_ROOT)/tests/run-all-bats.sh
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "  skills        Build all skill overlay artifacts (.build/skills/)"
+	@echo "  setup         Configure git hooks (core.hooksPath) + build skills"
+	@echo "  install-link  Install per-skill symlinks in ~/.claude/skills"
+	@echo "  uninstall-link Restore previous ~/.claude/skills state"
+	@echo "  test          Run all bats tests"
+	@echo "  help          Show this help"

--- a/_lib/scripts/build-all-skills.bats
+++ b/_lib/scripts/build-all-skills.bats
@@ -98,19 +98,19 @@ EOF
   # First run
   run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
   [ "$status" -eq 0 ]
-  [ -d "$fake_repo/.build/skills/skill-alpha" ]
+  [ -d "$fake_repo/.build/skills/claude/skill-alpha" ]
 
-  # Inject stale ghost entry
-  mkdir -p "$fake_repo/.build/skills/_ghost-deleted"
+  # Inject stale ghost entry under the vendor namespace
+  mkdir -p "$fake_repo/.build/skills/claude/_ghost-deleted"
 
   # Second run — should remove the ghost
   run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
   [ "$status" -eq 0 ]
 
   # Ghost must be gone
-  [ ! -d "$fake_repo/.build/skills/_ghost-deleted" ]
+  [ ! -d "$fake_repo/.build/skills/claude/_ghost-deleted" ]
   # Real skill still present
-  [ -d "$fake_repo/.build/skills/skill-alpha" ]
+  [ -d "$fake_repo/.build/skills/claude/skill-alpha" ]
 
   /bin/rm -rf "$tmpdir"
 }
@@ -135,7 +135,7 @@ EOF
   discovered_count="$(bash "$SCRIPT" --repo-root "$fake_repo" --list-discovered 2>/dev/null | wc -l | tr -d ' ')"
 
   local built_count
-  built_count="$(find "$fake_repo/.build/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  built_count="$(find "$fake_repo/.build/skills/claude" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
 
   [ "$discovered_count" -eq "$built_count" ]
 

--- a/_lib/scripts/build-all-skills.bats
+++ b/_lib/scripts/build-all-skills.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+# build-all-skills.bats — unit tests for build-all-skills.sh
+# TDD: all tests written RED first, then implementation makes them GREEN.
+#
+# Test cases:
+#   1. idempotent         - two consecutive runs produce identical artifact hashes
+#   2. stale-deletion     - stale .build/skills/<ghost>/ removed between runs
+#   3. coverage           - discover count == built count (dynamic, no hardcoded number)
+#   4. failure-exit       - exits non-zero when a skill build fails
+#   5. list-discovered    - --list-discovered outputs skill names without building
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+SCRIPT="$SCRIPT_DIR/build-all-skills.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+make_portable_skill() {
+  local root="$1"
+  local name="$2"
+  mkdir -p "$root/$name"
+  cat > "$root/$name/SKILL.md" << EOF
+---
+name: $name
+description: Test skill $name.
+version: 1.0.0
+---
+
+# $name Body
+EOF
+}
+
+make_broken_skill() {
+  local root="$1"
+  local name="$2"
+  mkdir -p "$root/$name"
+  # Write SKILL.md with no frontmatter (will cause build-skill-overlay to fail on it)
+  printf '# Just a body, no frontmatter\n' > "$root/$name/SKILL.md"
+}
+
+make_claude_overlay() {
+  local root="$1"
+  local name="$2"
+  mkdir -p "$root/$name/adapters"
+  cat > "$root/$name/adapters/claude.yaml" << EOF
+model: opus
+effort: max
+context: fork
+allowed-tools:
+  - Read
+  - Bash
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: idempotent — two consecutive runs produce identical artifact hashes
+# ---------------------------------------------------------------------------
+@test "idempotent: two runs produce identical SKILL.md content" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local fake_repo="$tmpdir/repo"
+  mkdir -p "$fake_repo"
+
+  make_portable_skill "$fake_repo" "skill-alpha"
+  make_portable_skill "$fake_repo" "skill-beta"
+  make_claude_overlay "$fake_repo" "skill-alpha"
+
+  run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
+  [ "$status" -eq 0 ]
+
+  local hash1
+  hash1="$(find "$fake_repo/.build/skills" -name 'SKILL.md' | sort | xargs md5 2>/dev/null || find "$fake_repo/.build/skills" -name 'SKILL.md' | sort | xargs md5sum 2>/dev/null)"
+
+  # Run again
+  run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
+  [ "$status" -eq 0 ]
+
+  local hash2
+  hash2="$(find "$fake_repo/.build/skills" -name 'SKILL.md' | sort | xargs md5 2>/dev/null || find "$fake_repo/.build/skills" -name 'SKILL.md' | sort | xargs md5sum 2>/dev/null)"
+
+  [ "$hash1" = "$hash2" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: stale-deletion — ghost dir removed between runs
+# ---------------------------------------------------------------------------
+@test "stale-deletion: stale .build/skills/<ghost>/ is removed on rebuild" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local fake_repo="$tmpdir/repo"
+  mkdir -p "$fake_repo"
+
+  make_portable_skill "$fake_repo" "skill-alpha"
+
+  # First run
+  run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
+  [ "$status" -eq 0 ]
+  [ -d "$fake_repo/.build/skills/skill-alpha" ]
+
+  # Inject stale ghost entry
+  mkdir -p "$fake_repo/.build/skills/_ghost-deleted"
+
+  # Second run — should remove the ghost
+  run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
+  [ "$status" -eq 0 ]
+
+  # Ghost must be gone
+  [ ! -d "$fake_repo/.build/skills/_ghost-deleted" ]
+  # Real skill still present
+  [ -d "$fake_repo/.build/skills/skill-alpha" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: coverage — discovered skill count == built skill count
+# ---------------------------------------------------------------------------
+@test "coverage: discovered skill count equals built artifact count" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local fake_repo="$tmpdir/repo"
+  mkdir -p "$fake_repo"
+
+  make_portable_skill "$fake_repo" "skill-alpha"
+  make_portable_skill "$fake_repo" "skill-beta"
+  make_portable_skill "$fake_repo" "skill-gamma"
+
+  run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
+  [ "$status" -eq 0 ]
+
+  local discovered_count
+  discovered_count="$(bash "$SCRIPT" --repo-root "$fake_repo" --list-discovered 2>/dev/null | wc -l | tr -d ' ')"
+
+  local built_count
+  built_count="$(find "$fake_repo/.build/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+
+  [ "$discovered_count" -eq "$built_count" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: failure-exit — exits non-zero when at least one skill build fails
+# ---------------------------------------------------------------------------
+@test "failure-exit: exits non-zero when a skill has malformed SKILL.md" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local fake_repo="$tmpdir/repo"
+  mkdir -p "$fake_repo"
+
+  make_portable_skill "$fake_repo" "skill-good"
+  make_broken_skill "$fake_repo" "skill-broken"
+
+  run bash "$SCRIPT" --repo-root "$fake_repo" 2>/dev/null
+  [ "$status" -ne 0 ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: list-discovered — --list-discovered outputs names without building
+# ---------------------------------------------------------------------------
+@test "list-discovered: outputs skill names to stdout without building" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  local fake_repo="$tmpdir/repo"
+  mkdir -p "$fake_repo"
+
+  make_portable_skill "$fake_repo" "skill-alpha"
+  make_portable_skill "$fake_repo" "skill-beta"
+
+  run bash "$SCRIPT" --repo-root "$fake_repo" --list-discovered
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "skill-alpha" ]]
+  [[ "$output" =~ "skill-beta" ]]
+
+  # Must NOT have built anything
+  [ ! -d "$fake_repo/.build/skills" ]
+
+  /bin/rm -rf "$tmpdir"
+}

--- a/_lib/scripts/build-all-skills.sh
+++ b/_lib/scripts/build-all-skills.sh
@@ -7,7 +7,8 @@
 #       <repo>/*/SKILL.md           (root-level skills)
 #       <repo>/.claude/skills/*/SKILL.md   (internal tooling skills)
 #       <repo>/.agents/skills/*/SKILL.md   (external agent skills)
-#   - Cleans <repo>/.build/skills/ before rebuilding (idempotent, no stale entries)
+#   - Cleans <repo>/.build/skills/<vendor>/ before rebuilding (idempotent per-vendor,
+#     no stale entries; other vendors' artifacts are left intact)
 #   - Each skill is built by calling build-skill-overlay.sh
 #   - If any skill build fails, exits non-zero (all failures reported before exit)
 #   - Priority for same-name conflicts: root > .claude/skills > .agents/skills
@@ -136,9 +137,10 @@ if $LIST_DISCOVERED; then
 fi
 
 # ---------------------------------------------------------------------------
-# Clean build directory (idempotent: removes stale entries)
+# Clean build directory (idempotent per-vendor: removes stale entries for this
+# vendor only, leaving other vendors' artifacts intact)
 # ---------------------------------------------------------------------------
-BUILD_DIR="$REPO_ROOT/.build/skills"
+BUILD_DIR="$REPO_ROOT/.build/skills/$VENDOR"
 if [[ -d "$BUILD_DIR" ]]; then
   /bin/rm -rf "$BUILD_DIR"
 fi
@@ -152,7 +154,7 @@ total=0
 
 for skill_name in $(printf '%s\n' "${!SKILL_MAP[@]}" | sort); do
   skill_root="${SKILL_MAP[$skill_name]}"
-  output_path="$REPO_ROOT/.build/skills/$skill_name/SKILL.md"
+  output_path="$REPO_ROOT/.build/skills/$VENDOR/$skill_name/SKILL.md"
   ((total++)) || true
 
   echo "[build-all-skills] building: $skill_name (from $skill_root)" >&2

--- a/_lib/scripts/build-all-skills.sh
+++ b/_lib/scripts/build-all-skills.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# build-all-skills.sh — discover all skills in the repo and build their
+# Claude Code-ready SKILL.md artifacts via build-skill-overlay.sh.
+#
+# Design:
+#   - Discovers skills from:
+#       <repo>/*/SKILL.md           (root-level skills)
+#       <repo>/.claude/skills/*/SKILL.md   (internal tooling skills)
+#       <repo>/.agents/skills/*/SKILL.md   (external agent skills)
+#   - Cleans <repo>/.build/skills/ before rebuilding (idempotent, no stale entries)
+#   - Each skill is built by calling build-skill-overlay.sh
+#   - If any skill build fails, exits non-zero (all failures reported before exit)
+#   - Priority for same-name conflicts: root > .claude/skills > .agents/skills
+#
+# Usage:
+#   build-all-skills.sh [--repo-root <path>] [--vendor <vendor>]
+#                       [--subdir-strategy symlink|copy] [--list-discovered]
+#
+# Options:
+#   --repo-root <path>     repo root directory (default: auto-detect from BASH_SOURCE)
+#   --vendor <vendor>      adapter vendor (default: claude)
+#   --subdir-strategy      symlink|copy (default: symlink)
+#   --list-discovered      print discovered skill names to stdout (no build), exit 0
+#   --help                 print this help and exit 0
+#
+# Exit codes:
+#   0  all skills built successfully (or --list-discovered)
+#   1  usage / argument error
+#   2  one or more skills failed to build
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Script location
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_SKILL_OVERLAY="$SCRIPT_DIR/build-skill-overlay.sh"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  cat >&2 << EOF
+usage: $(basename "$0") [--repo-root <path>] [--vendor <vendor>] [--subdir-strategy symlink|copy] [--list-discovered]
+
+  --repo-root <path>     root directory of the skills repo (default: auto-detect)
+  --vendor <vendor>      adapter vendor to use (default: claude)
+  --subdir-strategy <s>  symlink (default) or copy
+  --list-discovered      list discovered skill names to stdout without building
+  --help                 print this help and exit 0
+
+Exit codes: 0=success or --list-discovered, 1=usage error, 2=build failure
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+REPO_ROOT=""
+VENDOR="claude"
+SUBDIR_STRATEGY="symlink"
+LIST_DISCOVERED=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)    REPO_ROOT="$2"; shift 2 ;;
+    --vendor)       VENDOR="$2"; shift 2 ;;
+    --subdir-strategy)
+      SUBDIR_STRATEGY="$2"
+      if [[ "$SUBDIR_STRATEGY" != "symlink" && "$SUBDIR_STRATEGY" != "copy" ]]; then
+        echo "error: --subdir-strategy must be 'symlink' or 'copy', got: $SUBDIR_STRATEGY" >&2
+        usage
+        exit 1
+      fi
+      shift 2 ;;
+    --list-discovered) LIST_DISCOVERED=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage
+      exit 1 ;;
+    *)
+      echo "error: unexpected argument: $1" >&2
+      usage
+      exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve repo root
+# ---------------------------------------------------------------------------
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+# ---------------------------------------------------------------------------
+# Discover skills
+# Priority: root > .claude/skills > .agents/skills (first-seen wins on conflict)
+# ---------------------------------------------------------------------------
+declare -A SKILL_MAP  # skill_name -> source_dir
+
+discover_from() {
+  local base_dir="$1"
+  local skill_root="$2"  # the skill-root to pass to build-skill-overlay.sh
+  [[ -d "$base_dir" ]] || return 0
+
+  for skill_md in "$base_dir"/*/SKILL.md; do
+    [[ -f "$skill_md" ]] || continue
+    local skill_name
+    skill_name="$(basename "$(dirname "$skill_md")")"
+    # Skip internal dirs
+    [[ "$skill_name" == "_lib" ]] && continue
+    [[ "$skill_name" == "_shared" ]] && continue
+    # First-seen wins (priority: caller order)
+    if [[ -z "${SKILL_MAP[$skill_name]+x}" ]]; then
+      SKILL_MAP["$skill_name"]="$skill_root"
+    fi
+  done
+}
+
+# Root-level skills (highest priority)
+discover_from "$REPO_ROOT" "$REPO_ROOT"
+# .claude/skills/* (internal tooling)
+discover_from "$REPO_ROOT/.claude/skills" "$REPO_ROOT/.claude/skills"
+# .agents/skills/* (external agent skills)
+discover_from "$REPO_ROOT/.agents/skills" "$REPO_ROOT/.agents/skills"
+
+# ---------------------------------------------------------------------------
+# --list-discovered: print skill names and exit
+# ---------------------------------------------------------------------------
+if $LIST_DISCOVERED; then
+  for skill_name in $(printf '%s\n' "${!SKILL_MAP[@]}" | sort); do
+    echo "$skill_name"
+  done
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Clean build directory (idempotent: removes stale entries)
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_ROOT/.build/skills"
+if [[ -d "$BUILD_DIR" ]]; then
+  /bin/rm -rf "$BUILD_DIR"
+fi
+mkdir -p "$BUILD_DIR"
+
+# ---------------------------------------------------------------------------
+# Build all discovered skills
+# ---------------------------------------------------------------------------
+fail_count=0
+total=0
+
+for skill_name in $(printf '%s\n' "${!SKILL_MAP[@]}" | sort); do
+  skill_root="${SKILL_MAP[$skill_name]}"
+  output_path="$REPO_ROOT/.build/skills/$skill_name/SKILL.md"
+  ((total++)) || true
+
+  echo "[build-all-skills] building: $skill_name (from $skill_root)" >&2
+
+  if bash "$BUILD_SKILL_OVERLAY" "$skill_name" \
+      --skill-root "$skill_root" \
+      --vendor "$VENDOR" \
+      --output "$output_path" \
+      --subdir-strategy "$SUBDIR_STRATEGY" \
+      2>&1 >&2; then
+    : # success
+  else
+    echo "[build-all-skills] FAILED: $skill_name" >&2
+    ((fail_count++)) || true
+  fi
+done
+
+echo "[build-all-skills] done: $total discovered, $fail_count failed" >&2
+
+if [[ $fail_count -gt 0 ]]; then
+  exit 2
+fi
+exit 0

--- a/_lib/scripts/build-skill-overlay.bats
+++ b/_lib/scripts/build-skill-overlay.bats
@@ -10,6 +10,9 @@
 #   5. invalid-yaml       - malformed overlay YAML causes exit 2 + stderr message
 #   6. field-collision    - overlay field 'name' overrides portable value (overlay wins)
 #   7. output-to-file     - --output writes merged content to specified path
+#   8. default-output-build-dir  - default output is <repo>/.build/skills/<skill>/SKILL.md
+#   9. subdir-strategy-symlink   - --subdir-strategy symlink creates absolute symlinks for subdirs
+#  10. subdir-strategy-copy      - --subdir-strategy copy creates deep copies of subdirs
 
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
 SCRIPT="$SCRIPT_DIR/build-skill-overlay.sh"
@@ -209,6 +212,92 @@ EOF
   [ -f "$out_file" ]
   grep -q "model: opus" "$out_file"
   grep -q "Test Skill Body" "$out_file"
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: default-output-build-dir — default output is <repo>/.build/skills/<skill>/SKILL.md
+# ---------------------------------------------------------------------------
+@test "default-output-build-dir: default output path is <skill-root>/.build/skills/<skill>/SKILL.md" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+
+  # Run WITHOUT --output so default path is used
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir"
+  [ "$status" -eq 0 ]
+
+  local expected_path="$tmpdir/.build/skills/test-skill/SKILL.md"
+  [ -f "$expected_path" ]
+  grep -q "name: test-skill" "$expected_path"
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: subdir-strategy-symlink — --subdir-strategy symlink creates absolute symlinks
+# ---------------------------------------------------------------------------
+@test "subdir-strategy-symlink: creates absolute symlinks for skill subdirs in build artifact dir" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+  make_claude_overlay "$tmpdir"
+  # Create a references/ subdir in the source skill
+  mkdir -p "$tmpdir/test-skill/references"
+  echo "# Reference doc" > "$tmpdir/test-skill/references/guide.md"
+  mkdir -p "$tmpdir/test-skill/scripts"
+  echo "#!/usr/bin/env bash" > "$tmpdir/test-skill/scripts/run.sh"
+
+  local out_file="$tmpdir/.build/skills/test-skill/SKILL.md"
+
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file" --subdir-strategy symlink
+  [ "$status" -eq 0 ]
+  [ -f "$out_file" ]
+
+  # references/ and scripts/ should be symlinks in the build artifact dir
+  local build_dir
+  build_dir="$(dirname "$out_file")"
+  [ -L "$build_dir/references" ]
+  [ -L "$build_dir/scripts" ]
+
+  # Symlinks must be absolute (not relative)
+  local ref_target
+  ref_target="$(readlink "$build_dir/references")"
+  [[ "$ref_target" == /* ]]
+
+  # Symlink should resolve correctly (file inside is accessible)
+  [ -f "$build_dir/references/guide.md" ]
+
+  rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: subdir-strategy-copy — --subdir-strategy copy creates deep copies
+# ---------------------------------------------------------------------------
+@test "subdir-strategy-copy: creates deep copies of skill subdirs in build artifact dir" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_portable_skill "$tmpdir"
+  make_claude_overlay "$tmpdir"
+  # Create a references/ subdir in the source skill
+  mkdir -p "$tmpdir/test-skill/references"
+  echo "# Reference doc" > "$tmpdir/test-skill/references/guide.md"
+
+  local out_file="$tmpdir/.build/skills/test-skill/SKILL.md"
+
+  run bash "$SCRIPT" test-skill --skill-root "$tmpdir" --output "$out_file" --subdir-strategy copy
+  [ "$status" -eq 0 ]
+  [ -f "$out_file" ]
+
+  local build_dir
+  build_dir="$(dirname "$out_file")"
+  # references/ must NOT be a symlink but a real directory
+  [ -d "$build_dir/references" ]
+  [ ! -L "$build_dir/references" ]
+
+  # File inside should be present as a copy
+  [ -f "$build_dir/references/guide.md" ]
 
   rm -rf "$tmpdir"
 }

--- a/_lib/scripts/build-skill-overlay.bats
+++ b/_lib/scripts/build-skill-overlay.bats
@@ -217,18 +217,18 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 8: default-output-build-dir — default output is <repo>/.build/skills/<skill>/SKILL.md
+# Test 8: default-output-build-dir — default output is <repo>/.build/skills/<vendor>/<skill>/SKILL.md
 # ---------------------------------------------------------------------------
-@test "default-output-build-dir: default output path is <skill-root>/.build/skills/<skill>/SKILL.md" {
+@test "default-output-build-dir: default output path is <skill-root>/.build/skills/<vendor>/<skill>/SKILL.md" {
   local tmpdir
   tmpdir="$(mktemp -d)"
   make_portable_skill "$tmpdir"
 
-  # Run WITHOUT --output so default path is used
+  # Run WITHOUT --output so default path is used (default vendor = claude)
   run bash "$SCRIPT" test-skill --skill-root "$tmpdir"
   [ "$status" -eq 0 ]
 
-  local expected_path="$tmpdir/.build/skills/test-skill/SKILL.md"
+  local expected_path="$tmpdir/.build/skills/claude/test-skill/SKILL.md"
   [ -f "$expected_path" ]
   grep -q "name: test-skill" "$expected_path"
 

--- a/_lib/scripts/build-skill-overlay.sh
+++ b/_lib/scripts/build-skill-overlay.sh
@@ -12,7 +12,7 @@
 #
 # Usage:
 #   build-skill-overlay.sh <skill-name> [--vendor <vendor>] [--skill-root <path>]
-#                          [--output <path>]
+#                          [--output <path>] [--subdir-strategy symlink|copy]
 #
 # Arguments:
 #   <skill-name>         name of the skill directory (e.g. dev-plan-review)
@@ -22,7 +22,10 @@
 #   --skill-root <path>  root directory where skill subdirectories live
 #                        (default: parent of this script, i.e. the repo root)
 #   --output <path>      output path for merged SKILL.md
-#                        (default: $HOME/.cache/claude-skill-build/<skill-name>/SKILL.md)
+#                        (default: <skill-root>/.build/skills/<skill-name>/SKILL.md)
+#   --subdir-strategy    how to handle skill subdirs (references/, scripts/, etc.)
+#                        symlink: create absolute symlinks (default)
+#                        copy:    deep copy the subdirectory
 #   --help               print this help and exit 0
 #
 # Merge rules:
@@ -51,14 +54,18 @@ YAML_MERGE_PY="$SCRIPT_DIR/yaml-merge.py"
 # ---------------------------------------------------------------------------
 usage() {
   cat >&2 << EOF
-usage: $(basename "$0") <skill-name> [--vendor <vendor>] [--skill-root <path>] [--output <path>]
+usage: $(basename "$0") <skill-name> [--vendor <vendor>] [--skill-root <path>] [--output <path>] [--subdir-strategy symlink|copy]
 
-  <skill-name>       skill directory name (required)
-  --vendor <vendor>  adapter vendor (default: claude)
-  --skill-root <p>   repo root that contains skill subdirs (default: auto-detect from BASH_SOURCE)
-  --output <path>    output path for merged SKILL.md
-                     default: \$HOME/.cache/claude-skill-build/<skill-name>/SKILL.md
-  --help             print this help and exit 0
+  <skill-name>              skill directory name (required)
+  --vendor <vendor>         adapter vendor (default: claude)
+  --skill-root <p>          repo root that contains skill subdirs (default: auto-detect from BASH_SOURCE)
+  --output <path>           output path for merged SKILL.md
+                            default: <skill-root>/.build/skills/<skill-name>/SKILL.md
+  --subdir-strategy <s>     how to wire subdirs (references/, scripts/) into the build artifact dir
+                            symlink: create absolute symlinks pointing to <skill-root>/<skill>/<subdir>/
+                            copy:    deep copy the subdirectory
+                            default: symlink
+  --help                    print this help and exit 0
 
 Merge rules:
   - frontmatter: union(portable, overlay), overlay wins on key conflict
@@ -77,12 +84,21 @@ SKILL_NAME=""
 VENDOR="claude"
 SKILL_ROOT=""
 OUTPUT_PATH=""
+SUBDIR_STRATEGY="symlink"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --vendor)    VENDOR="$2";     shift 2 ;;
     --skill-root) SKILL_ROOT="$2"; shift 2 ;;
     --output)    OUTPUT_PATH="$2"; shift 2 ;;
+    --subdir-strategy)
+      SUBDIR_STRATEGY="$2"
+      if [[ "$SUBDIR_STRATEGY" != "symlink" && "$SUBDIR_STRATEGY" != "copy" ]]; then
+        echo "error: --subdir-strategy must be 'symlink' or 'copy', got: $SUBDIR_STRATEGY" >&2
+        usage
+        exit 1
+      fi
+      shift 2 ;;
     --help|-h)   usage; exit 0 ;;
     -*)
       echo "error: unknown option: $1" >&2
@@ -119,11 +135,12 @@ fi
 PORTABLE_SKILL_MD="$SKILL_ROOT/$SKILL_NAME/SKILL.md"
 OVERLAY_FILE="$SKILL_ROOT/$SKILL_NAME/adapters/$VENDOR.yaml"
 
-# Default output: genuinely outside the repo to avoid overwriting tracked sources.
-# IMPORTANT: ~/.claude/skills may be a symlink TO the repo on some setups; use
-# $HOME/.cache/claude-skill-build/ as a safe, non-repo default.
+# Default output: <skill-root>/.build/skills/<skill-name>/SKILL.md
+# This places the artifact inside the repo tree (gitignored via /.build/) so that
+# per-skill symlinks from ~/.claude/skills/<skill>/ can resolve subdirs via absolute symlinks.
+# Note: $HOME/.cache/... was the old default; changed in issue #110 to support adapter overlay wiring.
 if [[ -z "$OUTPUT_PATH" ]]; then
-  OUTPUT_PATH="$HOME/.cache/claude-skill-build/$SKILL_NAME/SKILL.md"
+  OUTPUT_PATH="$SKILL_ROOT/.build/skills/$SKILL_NAME/SKILL.md"
 fi
 
 # ---------------------------------------------------------------------------
@@ -213,3 +230,42 @@ mkdir -p "$(dirname "$OUTPUT_PATH")"
 mv "$MERGED_TMP_FILE" "$OUTPUT_PATH"
 
 echo "[build-skill-overlay] written: $OUTPUT_PATH" >&2
+
+# ---------------------------------------------------------------------------
+# Wire skill subdirs (references/, scripts/, etc.) into build artifact dir
+# ---------------------------------------------------------------------------
+# For each subdir that exists in the source skill, create either an absolute
+# symlink (--subdir-strategy symlink, default) or a deep copy
+# (--subdir-strategy copy) inside the build artifact directory.
+# This allows Claude Code to resolve references/ etc. when loading the skill
+# from ~/.claude/skills/<skill>/ → <repo>/.build/skills/<skill>/ per-skill symlink.
+
+BUILD_DIR="$(dirname "$OUTPUT_PATH")"
+SKILL_SRC_DIR="$SKILL_ROOT/$SKILL_NAME"
+
+for subdir in "$SKILL_SRC_DIR"/*/; do
+  # Skip if glob expands to nothing
+  [ -d "$subdir" ] || continue
+
+  subdir_name="$(basename "$subdir")"
+
+  # Skip the adapters/ directory (not needed in build artifact)
+  [[ "$subdir_name" == "adapters" ]] && continue
+
+  target="$BUILD_DIR/$subdir_name"
+
+  # Remove existing (stale symlink or old copy)
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    rm -rf "$target"
+  fi
+
+  if [[ "$SUBDIR_STRATEGY" == "symlink" ]]; then
+    # Absolute symlink: <build-dir>/<subdir> → <skill-root>/<skill>/<subdir>
+    ln -s "$SKILL_SRC_DIR/$subdir_name" "$target"
+    echo "[build-skill-overlay] subdir symlink: $target → $SKILL_SRC_DIR/$subdir_name" >&2
+  else
+    # Deep copy
+    cp -r "$SKILL_SRC_DIR/$subdir_name" "$target"
+    echo "[build-skill-overlay] subdir copy: $target" >&2
+  fi
+done

--- a/_lib/scripts/build-skill-overlay.sh
+++ b/_lib/scripts/build-skill-overlay.sh
@@ -22,7 +22,7 @@
 #   --skill-root <path>  root directory where skill subdirectories live
 #                        (default: parent of this script, i.e. the repo root)
 #   --output <path>      output path for merged SKILL.md
-#                        (default: <skill-root>/.build/skills/<skill-name>/SKILL.md)
+#                        (default: <skill-root>/.build/skills/<vendor>/<skill-name>/SKILL.md)
 #   --subdir-strategy    how to handle skill subdirs (references/, scripts/, etc.)
 #                        symlink: create absolute symlinks (default)
 #                        copy:    deep copy the subdirectory
@@ -60,7 +60,7 @@ usage: $(basename "$0") <skill-name> [--vendor <vendor>] [--skill-root <path>] [
   --vendor <vendor>         adapter vendor (default: claude)
   --skill-root <p>          repo root that contains skill subdirs (default: auto-detect from BASH_SOURCE)
   --output <path>           output path for merged SKILL.md
-                            default: <skill-root>/.build/skills/<skill-name>/SKILL.md
+                            default: <skill-root>/.build/skills/<vendor>/<skill-name>/SKILL.md
   --subdir-strategy <s>     how to wire subdirs (references/, scripts/) into the build artifact dir
                             symlink: create absolute symlinks pointing to <skill-root>/<skill>/<subdir>/
                             copy:    deep copy the subdirectory
@@ -135,12 +135,14 @@ fi
 PORTABLE_SKILL_MD="$SKILL_ROOT/$SKILL_NAME/SKILL.md"
 OVERLAY_FILE="$SKILL_ROOT/$SKILL_NAME/adapters/$VENDOR.yaml"
 
-# Default output: <skill-root>/.build/skills/<skill-name>/SKILL.md
+# Default output: <skill-root>/.build/skills/<vendor>/<skill-name>/SKILL.md
+# The artifact is namespaced by vendor because each vendor's merge injects different
+# vendor-specific frontmatter (e.g. claude's model/effort that other agents reject).
 # This places the artifact inside the repo tree (gitignored via /.build/) so that
 # per-skill symlinks from ~/.claude/skills/<skill>/ can resolve subdirs via absolute symlinks.
 # Note: $HOME/.cache/... was the old default; changed in issue #110 to support adapter overlay wiring.
 if [[ -z "$OUTPUT_PATH" ]]; then
-  OUTPUT_PATH="$SKILL_ROOT/.build/skills/$SKILL_NAME/SKILL.md"
+  OUTPUT_PATH="$SKILL_ROOT/.build/skills/$VENDOR/$SKILL_NAME/SKILL.md"
 fi
 
 # ---------------------------------------------------------------------------
@@ -238,7 +240,7 @@ echo "[build-skill-overlay] written: $OUTPUT_PATH" >&2
 # symlink (--subdir-strategy symlink, default) or a deep copy
 # (--subdir-strategy copy) inside the build artifact directory.
 # This allows Claude Code to resolve references/ etc. when loading the skill
-# from ~/.claude/skills/<skill>/ → <repo>/.build/skills/<skill>/ per-skill symlink.
+# from ~/.claude/skills/<skill>/ → <repo>/.build/skills/<vendor>/<skill>/ per-skill symlink.
 
 BUILD_DIR="$(dirname "$OUTPUT_PATH")"
 SKILL_SRC_DIR="$SKILL_ROOT/$SKILL_NAME"

--- a/_lib/scripts/check-hooks-path.bats
+++ b/_lib/scripts/check-hooks-path.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+# check-hooks-path.bats — unit tests for check-hooks-path.sh
+# TDD: tests written RED first.
+#
+# Test cases:
+#   1. unset → --apply sets .githooks, status "set"
+#   2. already .githooks → --apply is no-op, status "already_set"
+#   3. conflict path → --apply exits non-zero, status "conflict"; --force overrides
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-hooks-path.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers: Create an isolated git repo with a controlled core.hooksPath setting
+# ---------------------------------------------------------------------------
+
+setup_git_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "test@test.com"
+  git -C "$dir" config user.name "Test"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: unset → --apply sets .githooks, status "set"
+# ---------------------------------------------------------------------------
+@test "unset: --apply sets core.hooksPath to .githooks and returns status=set" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  setup_git_repo "$tmpdir"
+
+  # Ensure core.hooksPath is not set
+  git -C "$tmpdir" config --unset core.hooksPath 2>/dev/null || true
+
+  run bash "$SCRIPT" --apply --repo-root "$tmpdir"
+  [ "$status" -eq 0 ]
+
+  # Output must be JSON with status = "set"
+  local out_status
+  out_status="$(echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])")"
+  [ "$out_status" = "set" ]
+
+  # core.hooksPath must now be .githooks
+  local current
+  current="$(git -C "$tmpdir" config core.hooksPath)"
+  [ "$current" = ".githooks" ]
+
+  # JSON must contain target key
+  local out_target
+  out_target="$(echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['target'])")"
+  [ "$out_target" = ".githooks" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: already .githooks → --apply is no-op, status "already_set"
+# ---------------------------------------------------------------------------
+@test "already-set: --apply returns status=already_set when core.hooksPath is .githooks" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  setup_git_repo "$tmpdir"
+  git -C "$tmpdir" config core.hooksPath ".githooks"
+
+  run bash "$SCRIPT" --apply --repo-root "$tmpdir"
+  [ "$status" -eq 0 ]
+
+  local out_status
+  out_status="$(echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])")"
+  [ "$out_status" = "already_set" ]
+
+  # Still .githooks
+  local current
+  current="$(git -C "$tmpdir" config core.hooksPath)"
+  [ "$current" = ".githooks" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3a: conflict path → --apply exits non-zero with status "conflict"
+# ---------------------------------------------------------------------------
+@test "conflict: --apply exits non-zero with status=conflict when different hooksPath is set" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  setup_git_repo "$tmpdir"
+  git -C "$tmpdir" config core.hooksPath "custom-hooks"
+
+  run bash "$SCRIPT" --apply --repo-root "$tmpdir"
+  [ "$status" -ne 0 ]
+
+  local out_status
+  out_status="$(echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])")"
+  [ "$out_status" = "conflict" ]
+
+  # current key must be present
+  local out_current
+  out_current="$(echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['current'])")"
+  [ "$out_current" = "custom-hooks" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3b: conflict + --force → overrides successfully
+# ---------------------------------------------------------------------------
+@test "conflict-force: --force overrides conflicting hooksPath" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  setup_git_repo "$tmpdir"
+  git -C "$tmpdir" config core.hooksPath "custom-hooks"
+
+  run bash "$SCRIPT" --apply --force --repo-root "$tmpdir"
+  [ "$status" -eq 0 ]
+
+  local out_status
+  out_status="$(echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['status'])")"
+  [ "$out_status" = "set" ]
+
+  # core.hooksPath must now be .githooks
+  local current
+  current="$(git -C "$tmpdir" config core.hooksPath)"
+  [ "$current" = ".githooks" ]
+
+  /bin/rm -rf "$tmpdir"
+}

--- a/_lib/scripts/check-hooks-path.sh
+++ b/_lib/scripts/check-hooks-path.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# check-hooks-path.sh — verify or set git core.hooksPath for the repo.
+#
+# Used by Makefile `setup` target to configure the repo's hook path.
+#
+# Usage:
+#   check-hooks-path.sh --apply [--force] [--repo-root <path>] [--target <path>]
+#   check-hooks-path.sh --check [--repo-root <path>] [--target <path>]
+#
+# Options:
+#   --check              only inspect current state (no change), exit 0
+#   --apply              apply the target hook path if not already set
+#   --force              with --apply, override an existing conflicting hooksPath
+#   --target <path>      target hooksPath value (default: .githooks)
+#   --repo-root <path>   git repo directory (default: current directory)
+#   --help               print this help and exit 0
+#
+# Output (stdout): JSON with keys: status, current, target
+#   status:
+#     "set"          — applied successfully (was unset or --force override)
+#     "already_set"  — already matches target (--apply is no-op)
+#     "conflict"     — different path set; --apply without --force exits 1
+#     "unset"        — --check only: core.hooksPath is not configured
+#
+# Exit codes:
+#   0  success (set, already_set, or unset/check-only)
+#   1  usage / argument error
+#   2  conflict detected (--apply without --force) or git command failed
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+MODE=""
+FORCE=false
+TARGET=".githooks"
+REPO_ROOT="."
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  cat >&2 << EOF
+usage: $(basename "$0") (--check | --apply) [--force] [--target <path>] [--repo-root <path>]
+
+  --check              inspect current core.hooksPath state (no changes)
+  --apply              set core.hooksPath to target if not already set
+  --force              with --apply, override conflicting hooksPath
+  --target <path>      desired hooksPath value (default: .githooks)
+  --repo-root <path>   git repo root (default: current dir)
+  --help               print this help
+
+Output: JSON { "status": "set|already_set|conflict|unset", "current": "...", "target": "..." }
+Exit codes: 0=ok, 1=usage error, 2=conflict or git error
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)    MODE="check"; shift ;;
+    --apply)    MODE="apply"; shift ;;
+    --force)    FORCE=true; shift ;;
+    --target)   TARGET="$2"; shift 2 ;;
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --help|-h)  usage; exit 0 ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage
+      exit 1 ;;
+    *)
+      echo "error: unexpected argument: $1" >&2
+      usage
+      exit 1 ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "error: one of --check or --apply is required" >&2
+  usage
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Get current core.hooksPath
+# ---------------------------------------------------------------------------
+CURRENT=""
+if CURRENT="$(git -C "$REPO_ROOT" config core.hooksPath 2>/dev/null)"; then
+  : # got a value
+else
+  CURRENT=""
+fi
+
+# ---------------------------------------------------------------------------
+# Determine status and act
+# ---------------------------------------------------------------------------
+emit_json() {
+  local status="$1"
+  local current="${2:-}"
+  printf '{"status":"%s","current":"%s","target":"%s"}\n' "$status" "$current" "$TARGET"
+}
+
+if [[ "$MODE" == "check" ]]; then
+  if [[ -z "$CURRENT" ]]; then
+    emit_json "unset" ""
+  elif [[ "$CURRENT" == "$TARGET" ]]; then
+    emit_json "already_set" "$CURRENT"
+  else
+    emit_json "conflict" "$CURRENT"
+  fi
+  exit 0
+fi
+
+# MODE == "apply"
+if [[ -z "$CURRENT" ]]; then
+  # Not set — apply
+  git -C "$REPO_ROOT" config core.hooksPath "$TARGET"
+  emit_json "set" "$CURRENT"
+  exit 0
+elif [[ "$CURRENT" == "$TARGET" ]]; then
+  # Already the right value — no-op
+  emit_json "already_set" "$CURRENT"
+  exit 0
+else
+  # Conflict
+  if $FORCE; then
+    git -C "$REPO_ROOT" config core.hooksPath "$TARGET"
+    emit_json "set" "$CURRENT"
+    exit 0
+  else
+    emit_json "conflict" "$CURRENT" >&1
+    exit 2
+  fi
+fi

--- a/_lib/scripts/install-claude-skills-link.bats
+++ b/_lib/scripts/install-claude-skills-link.bats
@@ -48,14 +48,14 @@ make_claude_overlay() {
   printf 'model: opus\neffort: max\ncontext: fork\n' > "$root/$name/adapters/claude.yaml"
 }
 
-# Pre-build the .build/skills artifact for overlay skills (mimics `make skills`)
+# Pre-build the .build/skills artifact for overlay skills (mimics `make skills`).
+# Uses the build script's default vendor-namespaced output path (.build/skills/claude/<skill>/).
 prebuild_skill() {
   local repo_root="$1"
   local skill_name="$2"
   bash "$SCRIPT_DIR/build-skill-overlay.sh" \
     "$skill_name" \
     --skill-root "$repo_root" \
-    --output "$repo_root/.build/skills/$skill_name/SKILL.md" \
     --subdir-strategy symlink \
     2>/dev/null
 }
@@ -80,8 +80,8 @@ prebuild_skill() {
   [ -L "$fake_home/.claude/skills/my-skill" ]
   local target
   target="$(readlink "$fake_home/.claude/skills/my-skill")"
-  # Must point to .build/skills/my-skill (not the source skill dir)
-  [[ "$target" == *".build/skills/my-skill"* ]]
+  # Must point to vendor-namespaced .build/skills/claude/my-skill (not the source skill dir)
+  [[ "$target" == *".build/skills/claude/my-skill"* ]]
 
   /bin/rm -rf "$tmpdir"
 }

--- a/_lib/scripts/install-claude-skills-link.bats
+++ b/_lib/scripts/install-claude-skills-link.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+# install-claude-skills-link.bats — unit tests for install-claude-skills-link.sh
+# TDD: tests written RED first, implementation makes them GREEN.
+# HOME isolation: all tests set HOME=$BATS_TMPDIR/fake-home to avoid touching
+# the actual ~/.claude/skills directory.
+#
+# Test cases:
+#   1. overlay-skill    - skill with adapters/claude.yaml → symlink to .build/skills/<skill>/
+#   2. plain-skill      - skill without overlay → symlink to <repo>/<skill>/
+#   3. backup           - existing ~/.claude/skills → renamed to .bak-<ts> with manifest.json
+#   4. mirror-subdirs   - .claude/skills/* and .agents/skills/* are mirrored
+#   5. restore          - restore reverts install
+#   6. round-trip       - install → restore preserves original state
+#   7. dry-run          - --dry-run makes no filesystem changes
+#
+# Note: These tests use --repo-root to specify the test repo, and HOME override for isolation.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+SCRIPT="$SCRIPT_DIR/install-claude-skills-link.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+make_portable_skill() {
+  local root="$1"
+  local name="$2"
+  mkdir -p "$root/$name"
+  printf '---\nname: %s\ndescription: Test.\n---\n# Body\n' "$name" > "$root/$name/SKILL.md"
+}
+
+make_claude_overlay() {
+  local root="$1"
+  local name="$2"
+  mkdir -p "$root/$name/adapters"
+  printf 'model: opus\neffort: max\ncontext: fork\n' > "$root/$name/adapters/claude.yaml"
+}
+
+# Pre-build the .build/skills artifact for overlay skills (mimics `make skills`)
+prebuild_skill() {
+  local repo_root="$1"
+  local skill_name="$2"
+  bash "$SCRIPT_DIR/build-skill-overlay.sh" \
+    "$skill_name" \
+    --skill-root "$repo_root" \
+    --output "$repo_root/.build/skills/$skill_name/SKILL.md" \
+    --subdir-strategy symlink \
+    2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: overlay-skill — skill with overlay → .build/skills/<skill>/
+# ---------------------------------------------------------------------------
+@test "overlay-skill: skill with adapters/claude.yaml symlinks to .build/skills/<skill>/" {
+  local tmpdir fake_home
+  tmpdir="$(mktemp -d)"
+  fake_home="$tmpdir/home"
+  mkdir -p "$fake_home/.claude"
+
+  make_portable_skill "$tmpdir/repo" "my-skill"
+  make_claude_overlay "$tmpdir/repo" "my-skill"
+  prebuild_skill "$tmpdir/repo" "my-skill"
+
+  HOME="$fake_home" run bash "$SCRIPT" install \
+    --repo-root "$tmpdir/repo" 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  [ -L "$fake_home/.claude/skills/my-skill" ]
+  local target
+  target="$(readlink "$fake_home/.claude/skills/my-skill")"
+  # Must point to .build/skills/my-skill (not the source skill dir)
+  [[ "$target" == *".build/skills/my-skill"* ]]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: plain-skill — skill without overlay → <repo>/<skill>/
+# ---------------------------------------------------------------------------
+@test "plain-skill: skill without overlay symlinks directly to <repo>/<skill>/" {
+  local tmpdir fake_home
+  tmpdir="$(mktemp -d)"
+  fake_home="$tmpdir/home"
+  mkdir -p "$fake_home/.claude"
+
+  make_portable_skill "$tmpdir/repo" "plain-skill"
+  # No overlay
+
+  HOME="$fake_home" run bash "$SCRIPT" install \
+    --repo-root "$tmpdir/repo" 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  [ -L "$fake_home/.claude/skills/plain-skill" ]
+  local target
+  target="$(readlink "$fake_home/.claude/skills/plain-skill")"
+  # Must point directly to <repo>/plain-skill
+  [[ "$target" == "$tmpdir/repo/plain-skill" ]]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: backup — existing ~/.claude/skills (symlink) → renamed to .bak-<ts>
+# ---------------------------------------------------------------------------
+@test "backup: existing ~/.claude/skills is renamed to .bak-<ts>/ with manifest.json" {
+  local tmpdir fake_home
+  tmpdir="$(mktemp -d)"
+  fake_home="$tmpdir/home"
+  mkdir -p "$fake_home/.claude"
+
+  # Simulate existing ~/.claude/skills as a symlink
+  ln -s "$tmpdir/some-old-target" "$fake_home/.claude/skills"
+
+  make_portable_skill "$tmpdir/repo" "skill-a"
+
+  HOME="$fake_home" run bash "$SCRIPT" install \
+    --repo-root "$tmpdir/repo" 2>/dev/null
+
+  [ "$status" -eq 0 ]
+
+  # Original symlink must be gone, backup dir must exist
+  [ ! -L "$fake_home/.claude/skills" ]
+  local bak_dir
+  bak_dir="$(find "$fake_home/.claude" -maxdepth 1 -name 'skills.bak-*' -type d | head -1)"
+  [ -n "$bak_dir" ]
+  # manifest.json must exist in bak dir
+  [ -f "$bak_dir/manifest.json" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: mirror-subdirs — .claude/skills/* and .agents/skills/* are mirrored
+# ---------------------------------------------------------------------------
+@test "mirror-subdirs: .claude/skills/* and .agents/skills/* entries are included" {
+  local tmpdir fake_home
+  tmpdir="$(mktemp -d)"
+  fake_home="$tmpdir/home"
+  mkdir -p "$fake_home/.claude"
+
+  # Root skill
+  make_portable_skill "$tmpdir/repo" "root-skill"
+  # .claude/skills skill
+  make_portable_skill "$tmpdir/repo/.claude/skills" "claude-skill"
+  # .agents/skills skill
+  make_portable_skill "$tmpdir/repo/.agents/skills" "agent-skill"
+
+  HOME="$fake_home" run bash "$SCRIPT" install \
+    --repo-root "$tmpdir/repo" 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  [ -L "$fake_home/.claude/skills/root-skill" ]
+  [ -L "$fake_home/.claude/skills/claude-skill" ]
+  [ -L "$fake_home/.claude/skills/agent-skill" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: restore — restore reverts to backup
+# ---------------------------------------------------------------------------
+@test "restore: restore reverts ~/.claude/skills to the latest backup" {
+  local tmpdir fake_home
+  tmpdir="$(mktemp -d)"
+  fake_home="$tmpdir/home"
+  mkdir -p "$fake_home/.claude"
+
+  # Pre-create a bak dir with a marker file
+  local bak_dir="$fake_home/.claude/skills.bak-20240101-120000"
+  mkdir -p "$bak_dir"
+  echo "marker" > "$bak_dir/marker.txt"
+  cat > "$bak_dir/manifest.json" << 'MEOF'
+{"original_type":"directory","original_path":""}
+MEOF
+
+  # Install first to get a real ~/.claude/skills
+  make_portable_skill "$tmpdir/repo" "skill-x"
+  HOME="$fake_home" bash "$SCRIPT" install --repo-root "$tmpdir/repo" 2>/dev/null || true
+
+  # Now restore
+  HOME="$fake_home" run bash "$SCRIPT" restore 2>/dev/null
+  [ "$status" -eq 0 ]
+
+  # The backup content should be restored
+  [ -f "$fake_home/.claude/skills/marker.txt" ] || [ -d "$fake_home/.claude/skills" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: round-trip — install → restore preserves initial state hash
+# ---------------------------------------------------------------------------
+@test "round-trip: install then restore returns to original state" {
+  local tmpdir fake_home
+  tmpdir="$(mktemp -d)"
+  fake_home="$tmpdir/home"
+  mkdir -p "$fake_home/.claude"
+
+  # Simulate existing ~/.claude/skills as a plain directory with some content
+  mkdir -p "$fake_home/.claude/skills/my-personal-skill"
+  echo "personal" > "$fake_home/.claude/skills/my-personal-skill/SKILL.md"
+
+  local before_hash
+  before_hash="$(find "$fake_home/.claude/skills" -type f | sort | xargs md5 2>/dev/null | md5)"
+
+  make_portable_skill "$tmpdir/repo" "repo-skill"
+
+  HOME="$fake_home" bash "$SCRIPT" install --repo-root "$tmpdir/repo" 2>/dev/null
+  HOME="$fake_home" bash "$SCRIPT" restore 2>/dev/null
+
+  local after_hash
+  after_hash="$(find "$fake_home/.claude/skills" -type f | sort | xargs md5 2>/dev/null | md5)"
+
+  [ "$before_hash" = "$after_hash" ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: dry-run — no filesystem changes
+# ---------------------------------------------------------------------------
+@test "dry-run: --dry-run makes no changes to filesystem" {
+  local tmpdir fake_home
+  tmpdir="$(mktemp -d)"
+  fake_home="$tmpdir/home"
+  mkdir -p "$fake_home/.claude"
+
+  # No ~/.claude/skills initially
+  make_portable_skill "$tmpdir/repo" "skill-a"
+
+  HOME="$fake_home" run bash "$SCRIPT" install \
+    --repo-root "$tmpdir/repo" \
+    --dry-run 2>/dev/null
+
+  [ "$status" -eq 0 ]
+  # ~/.claude/skills must NOT have been created
+  [ ! -e "$fake_home/.claude/skills" ]
+
+  /bin/rm -rf "$tmpdir"
+}

--- a/_lib/scripts/install-claude-skills-link.bats
+++ b/_lib/scripts/install-claude-skills-link.bats
@@ -26,7 +26,7 @@ make_portable_skill() {
   local root="$1"
   local name="$2"
   mkdir -p "$root/$name"
-  printf '---\nname: %s\ndescription: Test.\n---\n# Body\n' "$name" > "$root/$name/SKILL.md"
+  printf '%s\n' '---' "name: $name" 'description: Test.' '---' '# Body' > "$root/$name/SKILL.md"
 }
 
 make_claude_overlay() {

--- a/_lib/scripts/install-claude-skills-link.bats
+++ b/_lib/scripts/install-claude-skills-link.bats
@@ -29,6 +29,18 @@ make_portable_skill() {
   printf '%s\n' '---' "name: $name" 'description: Test.' '---' '# Body' > "$root/$name/SKILL.md"
 }
 
+# Portable directory content hash (md5sum on Linux, md5 on macOS)
+hash_tree() {
+  local dir="$1"
+  local hasher
+  if command -v md5sum >/dev/null 2>&1; then
+    hasher="md5sum"
+  else
+    hasher="md5"
+  fi
+  find "$dir" -type f | sort | xargs "$hasher" 2>/dev/null | "$hasher"
+}
+
 make_claude_overlay() {
   local root="$1"
   local name="$2"
@@ -201,7 +213,7 @@ MEOF
   echo "personal" > "$fake_home/.claude/skills/my-personal-skill/SKILL.md"
 
   local before_hash
-  before_hash="$(find "$fake_home/.claude/skills" -type f | sort | xargs md5 2>/dev/null | md5)"
+  before_hash="$(hash_tree "$fake_home/.claude/skills")"
 
   make_portable_skill "$tmpdir/repo" "repo-skill"
 
@@ -209,7 +221,7 @@ MEOF
   HOME="$fake_home" bash "$SCRIPT" restore 2>/dev/null
 
   local after_hash
-  after_hash="$(find "$fake_home/.claude/skills" -type f | sort | xargs md5 2>/dev/null | md5)"
+  after_hash="$(hash_tree "$fake_home/.claude/skills")"
 
   [ "$before_hash" = "$after_hash" ]
 

--- a/_lib/scripts/install-claude-skills-link.sh
+++ b/_lib/scripts/install-claude-skills-link.sh
@@ -7,9 +7,9 @@
 #                                   populate per-skill symlinks
 #   restore [options]            — revert to latest ~/.claude/skills.bak-<ts>
 #
-# Per-skill symlink target:
-#   - skill WITH <repo>/<skill>/adapters/claude.yaml → <repo>/.build/skills/<skill>/
-#   - skill WITHOUT overlay                          → <repo>/<skill>/
+# Per-skill symlink target (vendor defaults to claude):
+#   - skill WITH <repo>/<skill>/adapters/<vendor>.yaml → <repo>/.build/skills/<vendor>/<skill>/
+#   - skill WITHOUT overlay                            → <repo>/<skill>/
 #
 # Skills discovered from:
 #   <repo>/*/SKILL.md
@@ -228,8 +228,8 @@ EOF
     local symlink_target
 
     if [[ -f "$overlay_file" ]]; then
-      # Has overlay → point to .build/skills artifact
-      symlink_target="$REPO_ROOT/.build/skills/$skill_name"
+      # Has overlay → point to vendor-namespaced .build/skills artifact
+      symlink_target="$REPO_ROOT/.build/skills/$VENDOR/$skill_name"
     else
       # No overlay → point directly to source skill dir
       symlink_target="$skill_root/$skill_name"

--- a/_lib/scripts/install-claude-skills-link.sh
+++ b/_lib/scripts/install-claude-skills-link.sh
@@ -194,9 +194,11 @@ EOF
           if [[ $move_fail -eq 0 ]]; then
             /bin/rmdir "$CLAUDE_SKILLS_DIR" 2>/dev/null || /bin/rm -rf "$CLAUDE_SKILLS_DIR"
           else
-            # Restore what we moved (roll back)
+            # Restore what we moved (roll back). Leave manifest.json behind — it is a
+            # backup meta file, not original ~/.claude/skills content.
             for entry in "$bak_dir"/*; do
               [[ -e "$entry" ]] || continue
+              [[ "$(basename "$entry")" == "manifest.json" ]] && continue
               mv "$entry" "$CLAUDE_SKILLS_DIR/" || true
             done
             exit 2
@@ -262,9 +264,11 @@ cmd_restore() {
   echo "[restore] restoring from $latest_bak" >&2
 
   # Read manifest to determine original type
+  # Path is passed via env (not interpolated into the Python source) to stay safe
+  # against paths containing quotes/newlines.
   local original_type="directory"
   if [[ -f "$latest_bak/manifest.json" ]]; then
-    original_type="$(python3 -c "import sys,json; d=json.load(open('$latest_bak/manifest.json')); print(d.get('original_type','directory'))" 2>/dev/null || echo "directory")"
+    original_type="$(MANIFEST_PATH="$latest_bak/manifest.json" python3 -c "import os,json; print(json.load(open(os.environ['MANIFEST_PATH'])).get('original_type','directory'))" 2>/dev/null || echo "directory")"
   fi
 
   # Remove current ~/.claude/skills
@@ -281,7 +285,7 @@ cmd_restore() {
   else
     if [[ "$original_type" == "symlink" ]]; then
       local original_target
-      original_target="$(python3 -c "import sys,json; d=json.load(open('$latest_bak/manifest.json')); print(d.get('original_target',''))" 2>/dev/null || echo "")"
+      original_target="$(MANIFEST_PATH="$latest_bak/manifest.json" python3 -c "import os,json; print(json.load(open(os.environ['MANIFEST_PATH'])).get('original_target',''))" 2>/dev/null || echo "")"
       if [[ -n "$original_target" ]]; then
         # Remove manifest from bak before moving, then symlink back
         ln -s "$original_target" "$CLAUDE_SKILLS_DIR"

--- a/_lib/scripts/install-claude-skills-link.sh
+++ b/_lib/scripts/install-claude-skills-link.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# install-claude-skills-link.sh — convert ~/.claude/skills from a single symlink
+# to a real directory with per-skill symlinks, wiring adapter overlay artifacts.
+#
+# Subcommands:
+#   install [options]  (default) — backup existing ~/.claude/skills, create real dir,
+#                                   populate per-skill symlinks
+#   restore [options]            — revert to latest ~/.claude/skills.bak-<ts>
+#
+# Per-skill symlink target:
+#   - skill WITH <repo>/<skill>/adapters/claude.yaml → <repo>/.build/skills/<skill>/
+#   - skill WITHOUT overlay                          → <repo>/<skill>/
+#
+# Skills discovered from:
+#   <repo>/*/SKILL.md
+#   <repo>/.claude/skills/*/SKILL.md
+#   <repo>/.agents/skills/*/SKILL.md
+#
+# Conflicts (same name from multiple locations): root > .claude/skills > .agents/skills
+#
+# Usage:
+#   install-claude-skills-link.sh [install] [--repo-root <path>] [--vendor <vendor>]
+#                                            [--dry-run]
+#   install-claude-skills-link.sh restore   [--dry-run]
+#
+# Options:
+#   --repo-root <path>  path to skills repo root (default: auto-detect from BASH_SOURCE)
+#   --vendor <vendor>   adapter vendor (default: claude)
+#   --dry-run           print actions without executing
+#   --help              print this help and exit 0
+#
+# Exit codes:
+#   0  success
+#   1  usage / argument error
+#   2  filesystem error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  cat >&2 << EOF
+usage: $(basename "$0") [install|restore] [--repo-root <path>] [--vendor <vendor>] [--dry-run]
+
+  install      (default) convert ~/.claude/skills to real dir with per-skill symlinks
+  restore      revert to latest ~/.claude/skills.bak-<ts> backup
+
+  --repo-root <path>  skills repo root (default: auto-detect)
+  --vendor <vendor>   adapter vendor (default: claude)
+  --dry-run           print actions without executing
+  --help              print this help
+
+Exit codes: 0=success, 1=usage error, 2=filesystem error
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+SUBCOMMAND="install"
+REPO_ROOT=""
+VENDOR="claude"
+DRY_RUN=false
+
+# First positional may be subcommand
+if [[ $# -gt 0 && ( "$1" == "install" || "$1" == "restore" ) ]]; then
+  SUBCOMMAND="$1"
+  shift
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)  REPO_ROOT="$2"; shift 2 ;;
+    --vendor)     VENDOR="$2"; shift 2 ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    --help|-h)    usage; exit 0 ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage; exit 1 ;;
+    *)
+      echo "error: unexpected argument: $1" >&2
+      usage; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+
+# ---------------------------------------------------------------------------
+# Dry-run wrapper
+# ---------------------------------------------------------------------------
+run_cmd() {
+  if $DRY_RUN; then
+    echo "[dry-run] $*" >&2
+  else
+    "$@"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Discover skills
+# Priority: root > .claude/skills > .agents/skills (first-seen wins)
+# Returns: prints "skill_name|source_root" pairs to stdout
+# ---------------------------------------------------------------------------
+discover_skills() {
+  declare -A seen
+
+  discover_from() {
+    local base_dir="$1"
+    local skill_root="$2"
+    [[ -d "$base_dir" ]] || return 0
+
+    for skill_md in "$base_dir"/*/SKILL.md; do
+      [[ -f "$skill_md" ]] || continue
+      local skill_name
+      skill_name="$(basename "$(dirname "$skill_md")")"
+      [[ "$skill_name" == "_lib" ]] && continue
+      [[ "$skill_name" == "_shared" ]] && continue
+      if [[ -z "${seen[$skill_name]+x}" ]]; then
+        seen["$skill_name"]="$skill_root"
+        echo "$skill_name|$skill_root"
+      fi
+    done
+  }
+
+  discover_from "$REPO_ROOT" "$REPO_ROOT"
+  discover_from "$REPO_ROOT/.claude/skills" "$REPO_ROOT/.claude/skills"
+  discover_from "$REPO_ROOT/.agents/skills" "$REPO_ROOT/.agents/skills"
+}
+
+# ---------------------------------------------------------------------------
+# SUBCOMMAND: install
+# ---------------------------------------------------------------------------
+cmd_install() {
+  local ts
+  ts="$(date '+%Y%m%d-%H%M%S')"
+
+  # Step 1: Backup existing ~/.claude/skills
+  if [[ -e "$CLAUDE_SKILLS_DIR" ]] || [[ -L "$CLAUDE_SKILLS_DIR" ]]; then
+    local bak_dir="$HOME/.claude/skills.bak-$ts"
+
+    if $DRY_RUN; then
+      echo "[dry-run] rename $CLAUDE_SKILLS_DIR → $bak_dir" >&2
+      echo "[dry-run] write $bak_dir/manifest.json" >&2
+    else
+      # Determine original type
+      local original_type="directory"
+      local original_target=""
+      if [[ -L "$CLAUDE_SKILLS_DIR" ]]; then
+        original_type="symlink"
+        original_target="$(readlink "$CLAUDE_SKILLS_DIR")"
+      elif [[ ! -d "$CLAUDE_SKILLS_DIR" ]]; then
+        original_type="file"
+      fi
+
+      # Create bak dir and write manifest first
+      mkdir -p "$bak_dir"
+      cat > "$bak_dir/manifest.json" << EOF
+{
+  "timestamp": "$ts",
+  "original_type": "$original_type",
+  "original_target": "$original_target",
+  "backup_path": "$bak_dir"
+}
+EOF
+
+      if [[ "$original_type" == "symlink" ]]; then
+        # For a symlink: just record the target in manifest (no content to move)
+        /bin/rm -f "$CLAUDE_SKILLS_DIR"
+      else
+        # For a real directory: move all contents into bak_dir (assert all moves succeed before cleanup)
+        if [[ -d "$CLAUDE_SKILLS_DIR" ]]; then
+          local move_fail=0
+          for entry in "$CLAUDE_SKILLS_DIR"/.*  "$CLAUDE_SKILLS_DIR"/*; do
+            [[ -e "$entry" ]] || [[ -L "$entry" ]] || continue
+            local basename
+            basename="$(basename "$entry")"
+            [[ "$basename" == "." ]] || [[ "$basename" == ".." ]] && continue
+            if ! mv "$entry" "$bak_dir/"; then
+              echo "error: failed to move $entry to backup, aborting to prevent data loss" >&2
+              move_fail=1
+              break
+            fi
+          done
+          if [[ $move_fail -eq 0 ]]; then
+            /bin/rmdir "$CLAUDE_SKILLS_DIR" 2>/dev/null || /bin/rm -rf "$CLAUDE_SKILLS_DIR"
+          else
+            # Restore what we moved (roll back)
+            for entry in "$bak_dir"/*; do
+              [[ -e "$entry" ]] || continue
+              mv "$entry" "$CLAUDE_SKILLS_DIR/" || true
+            done
+            exit 2
+          fi
+        fi
+      fi
+
+      echo "[install] backed up to $bak_dir" >&2
+    fi
+  else
+    echo "[install] no existing ~/.claude/skills, skipping backup" >&2
+  fi
+
+  # Step 2: Create real directory
+  run_cmd mkdir -p "$CLAUDE_SKILLS_DIR"
+
+  # Step 3: Populate per-skill symlinks
+  local discovered
+  discovered="$(discover_skills)"
+
+  if [[ -z "$discovered" ]]; then
+    echo "[install] warning: no skills discovered in $REPO_ROOT" >&2
+  fi
+
+  while IFS='|' read -r skill_name skill_root; do
+    local overlay_file="$skill_root/$skill_name/adapters/$VENDOR.yaml"
+    local symlink_target
+
+    if [[ -f "$overlay_file" ]]; then
+      # Has overlay → point to .build/skills artifact
+      symlink_target="$REPO_ROOT/.build/skills/$skill_name"
+    else
+      # No overlay → point directly to source skill dir
+      symlink_target="$skill_root/$skill_name"
+    fi
+
+    local skill_link="$CLAUDE_SKILLS_DIR/$skill_name"
+
+    if $DRY_RUN; then
+      echo "[dry-run] ln -sfn $symlink_target $skill_link" >&2
+    else
+      ln -sfn "$symlink_target" "$skill_link"
+      echo "[install] linked: $skill_name → $symlink_target" >&2
+    fi
+  done <<< "$discovered"
+
+  echo "[install] done" >&2
+}
+
+# ---------------------------------------------------------------------------
+# SUBCOMMAND: restore
+# ---------------------------------------------------------------------------
+cmd_restore() {
+  # Find the latest backup dir
+  local latest_bak
+  latest_bak="$(find "$HOME/.claude" -maxdepth 1 -name 'skills.bak-*' -type d | sort | tail -1)"
+
+  if [[ -z "$latest_bak" ]]; then
+    echo "error: no backup found matching $HOME/.claude/skills.bak-*" >&2
+    exit 2
+  fi
+
+  echo "[restore] restoring from $latest_bak" >&2
+
+  # Read manifest to determine original type
+  local original_type="directory"
+  if [[ -f "$latest_bak/manifest.json" ]]; then
+    original_type="$(python3 -c "import sys,json; d=json.load(open('$latest_bak/manifest.json')); print(d.get('original_type','directory'))" 2>/dev/null || echo "directory")"
+  fi
+
+  # Remove current ~/.claude/skills
+  if [[ -e "$CLAUDE_SKILLS_DIR" ]] || [[ -L "$CLAUDE_SKILLS_DIR" ]]; then
+    if $DRY_RUN; then
+      echo "[dry-run] remove $CLAUDE_SKILLS_DIR" >&2
+    else
+      /bin/rm -rf "$CLAUDE_SKILLS_DIR"
+    fi
+  fi
+
+  if $DRY_RUN; then
+    echo "[dry-run] move $latest_bak → $CLAUDE_SKILLS_DIR" >&2
+  else
+    if [[ "$original_type" == "symlink" ]]; then
+      local original_target
+      original_target="$(python3 -c "import sys,json; d=json.load(open('$latest_bak/manifest.json')); print(d.get('original_target',''))" 2>/dev/null || echo "")"
+      if [[ -n "$original_target" ]]; then
+        # Remove manifest from bak before moving, then symlink back
+        ln -s "$original_target" "$CLAUDE_SKILLS_DIR"
+        /bin/rm -rf "$latest_bak"
+        echo "[restore] restored original symlink → $original_target" >&2
+        return 0
+      fi
+    fi
+    # Default: restore as directory
+    # Remove manifest.json from backup (it's a meta file, not original content)
+    /bin/rm -f "$latest_bak/manifest.json"
+    mv "$latest_bak" "$CLAUDE_SKILLS_DIR"
+    echo "[restore] restored directory from $latest_bak" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "$SUBCOMMAND" in
+  install) cmd_install ;;
+  restore) cmd_restore ;;
+  *)
+    echo "error: unknown subcommand: $SUBCOMMAND" >&2
+    usage; exit 1 ;;
+esac

--- a/_lib/scripts/lint-merged-frontmatter.bats
+++ b/_lib/scripts/lint-merged-frontmatter.bats
@@ -87,7 +87,7 @@ make_merged_skill() {
 # ---------------------------------------------------------------------------
 @test "dev-plan-review: merged artifact contains model, effort, context, allowed-tools" {
   # This test requires build-all-skills to have run first (or we run it here)
-  local build_artifact="$REPO_ROOT/.build/skills/dev-plan-review/SKILL.md"
+  local build_artifact="$REPO_ROOT/.build/skills/claude/dev-plan-review/SKILL.md"
 
   # If artifact doesn't exist yet, build it first
   if [[ ! -f "$build_artifact" ]]; then

--- a/_lib/scripts/lint-merged-frontmatter.bats
+++ b/_lib/scripts/lint-merged-frontmatter.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# lint-merged-frontmatter.bats — unit tests for lint-merged-frontmatter.sh
+# TDD: tests written RED first.
+#
+# Test cases:
+#   1. all-keys-present    - all required keys present → exit 0
+#   2. missing-key         - one required key missing → exit non-zero + stderr
+#   3. absent-frontmatter  - SKILL.md without frontmatter → exit non-zero
+#   4. dev-plan-review     - merged artifact for dev-plan-review passes all 4 checks
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+SCRIPT="$SCRIPT_DIR/lint-merged-frontmatter.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+make_merged_skill() {
+  local dir="$1"
+  local include_model="${2:-true}"
+  local include_effort="${3:-true}"
+  local include_context="${4:-true}"
+  local include_tools="${5:-true}"
+
+  mkdir -p "$dir"
+  {
+    echo "---"
+    echo "name: test-skill"
+    echo "description: A test skill."
+    if $include_model;   then echo "model: opus"; fi
+    if $include_effort;  then echo "effort: max"; fi
+    if $include_context; then echo "context: fork"; fi
+    if $include_tools;   then printf 'allowed-tools:\n  - Read\n  - Bash\n'; fi
+    echo "---"
+    echo ""
+    echo "# Test Skill Body"
+  } > "$dir/SKILL.md"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: all required keys present → exit 0
+# ---------------------------------------------------------------------------
+@test "all-keys-present: exits 0 when all required keys exist in frontmatter" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  make_merged_skill "$tmpdir"
+
+  run bash "$SCRIPT" "$tmpdir/SKILL.md" --require "model,effort,context,allowed-tools"
+  [ "$status" -eq 0 ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: missing key → exit non-zero + stderr mentions missing key
+# ---------------------------------------------------------------------------
+@test "missing-key: exits non-zero when a required key is absent" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  # Omit 'context'
+  make_merged_skill "$tmpdir" true true false true
+
+  run bash "$SCRIPT" "$tmpdir/SKILL.md" --require "model,effort,context,allowed-tools"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "context" ]]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: absent frontmatter → exit non-zero
+# ---------------------------------------------------------------------------
+@test "absent-frontmatter: exits non-zero when SKILL.md has no frontmatter" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  echo "# Just a body, no frontmatter delimiters" > "$tmpdir/SKILL.md"
+
+  run bash "$SCRIPT" "$tmpdir/SKILL.md" --require "model,effort,context,allowed-tools"
+  [ "$status" -ne 0 ]
+
+  /bin/rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: dev-plan-review merged artifact passes all 4 required checks
+# ---------------------------------------------------------------------------
+@test "dev-plan-review: merged artifact contains model, effort, context, allowed-tools" {
+  # This test requires build-all-skills to have run first (or we run it here)
+  local build_artifact="$REPO_ROOT/.build/skills/dev-plan-review/SKILL.md"
+
+  # If artifact doesn't exist yet, build it first
+  if [[ ! -f "$build_artifact" ]]; then
+    bash "$REPO_ROOT/_lib/scripts/build-all-skills.sh" \
+      --repo-root "$REPO_ROOT" 2>/dev/null || true
+  fi
+
+  # Skip if still not present (CI env may not have run make skills yet)
+  if [[ ! -f "$build_artifact" ]]; then
+    skip "dev-plan-review build artifact not found; run 'make skills' first"
+  fi
+
+  run bash "$SCRIPT" "$build_artifact" --require "model,effort,context,allowed-tools"
+  [ "$status" -eq 0 ]
+}

--- a/_lib/scripts/lint-merged-frontmatter.sh
+++ b/_lib/scripts/lint-merged-frontmatter.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# lint-merged-frontmatter.sh — validate that a merged SKILL.md artifact contains
+# required frontmatter keys.
+#
+# Usage:
+#   lint-merged-frontmatter.sh <skill-md-path> --require <key1,key2,...>
+#
+# Arguments:
+#   <skill-md-path>      path to the merged SKILL.md file
+#   --require <keys>     comma-separated list of required frontmatter keys
+#   --help               print this help and exit 0
+#
+# Exit codes:
+#   0  all required keys present
+#   1  usage / argument error
+#   2  one or more required keys missing, or no frontmatter found
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  cat >&2 << EOF
+usage: $(basename "$0") <skill-md-path> --require <key1,key2,...>
+
+  <skill-md-path>      path to merged SKILL.md to validate
+  --require <keys>     comma-separated list of required frontmatter keys
+                       example: --require model,effort,context,allowed-tools
+  --help               print this help and exit 0
+
+Exit codes: 0=all keys present, 1=usage error, 2=missing keys or no frontmatter
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+SKILL_MD=""
+REQUIRE_KEYS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --require) REQUIRE_KEYS="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage; exit 1 ;;
+    *)
+      if [[ -z "$SKILL_MD" ]]; then
+        SKILL_MD="$1"; shift
+      else
+        echo "error: unexpected argument: $1" >&2
+        usage; exit 1
+      fi ;;
+  esac
+done
+
+if [[ -z "$SKILL_MD" ]]; then
+  echo "error: <skill-md-path> is required" >&2
+  usage; exit 1
+fi
+
+if [[ ! -f "$SKILL_MD" ]]; then
+  echo "error: file not found: $SKILL_MD" >&2
+  exit 2
+fi
+
+if [[ -z "$REQUIRE_KEYS" ]]; then
+  echo "error: --require <keys> is required" >&2
+  usage; exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Extract frontmatter
+# ---------------------------------------------------------------------------
+TMPDIR_LOCAL="$(mktemp -d)"
+trap '/bin/rm -rf "$TMPDIR_LOCAL"' EXIT
+
+FM_FILE="$TMPDIR_LOCAL/frontmatter.yaml"
+
+awk -v fm_file="$FM_FILE" '
+  BEGIN { fm_open=0; fm_done=0; delim_count=0; }
+  /^---[[:space:]]*$/ {
+    delim_count++;
+    if (delim_count == 1) { fm_open=1; next }
+    if (delim_count == 2) { fm_done=1; fm_open=0; next }
+  }
+  fm_open  { print > fm_file; next }
+  fm_done  { next }
+' "$SKILL_MD"
+
+if [[ ! -s "$FM_FILE" ]]; then
+  echo "error: no frontmatter found in $SKILL_MD" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Check required keys
+# ---------------------------------------------------------------------------
+missing_keys=()
+
+IFS=',' read -ra keys <<< "$REQUIRE_KEYS"
+for key in "${keys[@]}"; do
+  key="$(echo "$key" | tr -d ' ')"
+  [[ -z "$key" ]] && continue
+
+  # Check if key is present as a YAML key (supports multiline values like allowed-tools:)
+  if ! grep -qE "^${key}:" "$FM_FILE"; then
+    missing_keys+=("$key")
+  fi
+done
+
+if [[ ${#missing_keys[@]} -gt 0 ]]; then
+  echo "error: missing required frontmatter keys in $SKILL_MD:" >&2
+  for k in "${missing_keys[@]}"; do
+    echo "  - $k" >&2
+  done
+  exit 2
+fi
+
+echo "[lint-merged-frontmatter] OK: all required keys present in $SKILL_MD" >&2
+exit 0

--- a/_shared/references/portable-coordinator.md
+++ b/_shared/references/portable-coordinator.md
@@ -311,7 +311,8 @@ Claude Code 拡張 frontmatter を portable SKILL.md から分離し、build scr
 **Wiring 問題と解決 (issue #110)**: `~/.claude/skills` が `<repo>` への単一 symlink では
 `<skill>/adapters/claude.yaml` が Claude Code に届かない。issue #110 で以下の 2 段階で解決した:
 
-1. `build-skill-overlay.sh` の出力先を `<repo>/.build/skills/<skill>/SKILL.md` に変更 (旧: `$HOME/.cache/...`)
+1. `build-skill-overlay.sh` の出力先を `<repo>/.build/skills/<vendor>/<skill>/SKILL.md` に変更 (旧: `$HOME/.cache/...`)。
+   merge artifact は vendor 固有 frontmatter を含むため **vendor 名で namespace 化** (default `claude`)
 2. `install-claude-skills-link.sh` で `~/.claude/skills` を **real directory + per-skill symlink** に変換
 
 ```
@@ -323,11 +324,11 @@ Claude Code 拡張 frontmatter を portable SKILL.md から分離し、build scr
         │
         ▼
 [ make skills  →  _lib/scripts/build-all-skills.sh ]
-        │    (idempotent full rebuild, rm -rf .build/skills/ first)
+        │    (idempotent rebuild, rm -rf .build/skills/<vendor>/ first; default vendor=claude)
         │
         ▼
-<repo>/.build/skills/<skill>/
-├── SKILL.md                  ← merge(portable SKILL.md + adapters/claude.yaml)
+<repo>/.build/skills/<vendor>/<skill>/
+├── SKILL.md                  ← merge(portable SKILL.md + adapters/<vendor>.yaml)
 ├── references/               ← absolute symlink → <repo>/<skill>/references/
 └── scripts/                  ← absolute symlink → <repo>/<skill>/scripts/
 
@@ -338,12 +339,13 @@ Claude Code 拡張 frontmatter を portable SKILL.md から分離し、build scr
         │
         ▼
 ~/.claude/skills/
-├── dev-plan-review  →  <repo>/.build/skills/dev-plan-review/   ← overlay あり skill
-├── bgm              →  <repo>/bgm/                             ← overlay なし skill (直接)
+├── dev-plan-review  →  <repo>/.build/skills/claude/dev-plan-review/   ← overlay あり skill
+├── bgm              →  <repo>/bgm/                                    ← overlay なし skill (直接)
 ├── (claude-skill)   →  <repo>/.claude/skills/(claude-skill)/
 └── (agent-skill)    →  <repo>/.agents/skills/(agent-skill)/
 
-Codex CLI / agy は <repo>/<skill>/SKILL.md を直接読む (overlay 不要)
+Codex CLI / agy は <repo>/<skill>/SKILL.md を直接読む (build artifact 不要)
+他 vendor が独自拡張を持つ場合は .build/skills/<その vendor>/ に分離されるため衝突しない
 ```
 
 **Phase 0 smoke test 確認済 (2026-05-22)**: absolute symlink 経由で `references/` 配下のファイルを

--- a/_shared/references/portable-coordinator.md
+++ b/_shared/references/portable-coordinator.md
@@ -303,42 +303,77 @@ agents:
 [`docs/skill-creation-guide.md` § Portable subset と Claude Code 拡張](../../docs/skill-creation-guide.md)
 を参照 (PR #104 で改訂)。
 
-### Adapter overlay (reference 実装, issue #106)
+### Adapter overlay (reference 実装, issue #106) + Wiring (issue #110)
 
 Claude Code 拡張 frontmatter を portable SKILL.md から分離し、build script で merge する仕組み。
 [`dev-plan-review`](../../dev-plan-review/SKILL.md) が **最初の reference 実装** (#103 Phase C)。
+
+**Wiring 問題と解決 (issue #110)**: `~/.claude/skills` が `<repo>` への単一 symlink では
+`<skill>/adapters/claude.yaml` が Claude Code に届かない。issue #110 で以下の 2 段階で解決した:
+
+1. `build-skill-overlay.sh` の出力先を `<repo>/.build/skills/<skill>/SKILL.md` に変更 (旧: `$HOME/.cache/...`)
+2. `install-claude-skills-link.sh` で `~/.claude/skills` を **real directory + per-skill symlink** に変換
 
 ```
 <skill-name>/
 ├── SKILL.md                 # portable subset のみ (cross-agent で parse 可能)
 ├── adapters/
 │   └── claude.yaml          # Claude Code 拡張 (model / effort / context / allowed-tools)
-└── ...                      # references/, scripts/ など既存構造
+└── references/, scripts/    # 既存構造 (subdir)
         │
         ▼
-[ _lib/scripts/build-skill-overlay.sh dev-plan-review ]
+[ make skills  →  _lib/scripts/build-all-skills.sh ]
+        │    (idempotent full rebuild, rm -rf .build/skills/ first)
         │
         ▼
-$HOME/.cache/claude-skill-build/dev-plan-review/SKILL.md   ← Claude Code が読む merge artifact
-                                                           ← Codex CLI / agy は元の portable SKILL.md を直接読む
+<repo>/.build/skills/<skill>/
+├── SKILL.md                  ← merge(portable SKILL.md + adapters/claude.yaml)
+├── references/               ← absolute symlink → <repo>/<skill>/references/
+└── scripts/                  ← absolute symlink → <repo>/<skill>/scripts/
+
+        │
+        ▼
+[ make install-link  →  _lib/scripts/install-claude-skills-link.sh install ]
+        │    (backup ~/.claude/skills → .bak-<ts>/, create real dir)
+        │
+        ▼
+~/.claude/skills/
+├── dev-plan-review  →  <repo>/.build/skills/dev-plan-review/   ← overlay あり skill
+├── bgm              →  <repo>/bgm/                             ← overlay なし skill (直接)
+├── (claude-skill)   →  <repo>/.claude/skills/(claude-skill)/
+└── (agent-skill)    →  <repo>/.agents/skills/(agent-skill)/
+
+Codex CLI / agy は <repo>/<skill>/SKILL.md を直接読む (overlay 不要)
 ```
 
-設計判断 (issue #106 推奨採用):
+**Phase 0 smoke test 確認済 (2026-05-22)**: absolute symlink 経由で `references/` 配下のファイルを
+Claude Code `Read` ツールが解決できることを実機確認 (`claudedocs/phase0-symlink-smoke-test.md`)。
+`subdir strategy = symlink` (default) 採用、`copy` fallback は EC1 として option で提供。
+
+設計判断 (issue #106/#110 推奨採用):
 
 | # | 判断 | 採用案 |
 |---|------|--------|
 | Q1 | adapter overlay の置き場所 | A: `<skill>/adapters/<vendor>.yaml` |
-| Q2 | Claude への merge 方法 | 1: build script artifact (runtime merge 不要) |
-| Q3 | artifact の git 管理 | Y: git ignore + CI/hook で再生成 |
+| Q2 | Claude への merge 方法 | Approach 2: per-skill symlink + `.build/` artifact |
+| Q3 | artifact の git 管理 | Y: `.gitignore` の `/.build/` で除外 + CI/hook で再生成 |
 | Q4 | Claude Code subagent (`context: fork`) | A: build artifact に merge して既存挙動維持 |
+| Q5 | subdir wiring 方式 | symlink (absolute): Phase 0 smoke test で解決を確認 |
 
 merge ルールと CLI 詳細は [`docs/skill-creation-guide.md` § Adapter Overlay 規約](../../docs/skill-creation-guide.md)
 を参照。
 
-実装ファイル:
-- `_lib/scripts/build-skill-overlay.sh` — bash entry point (frontmatter 抽出 / atomic write)
-- `_lib/scripts/yaml-merge.py` — PyYAML 6.x ベースの薄い merge helper (overlay-wins + block scalar 保持)
-- `_lib/scripts/build-skill-overlay.bats` — 単体テスト 7 ケース
+実装ファイル (issue #110 で追加・変更):
+- `_lib/scripts/build-skill-overlay.sh` — `--output` default を `.build/`、`--subdir-strategy` flag 追加
+- `_lib/scripts/build-skill-overlay.bats` — 7 → 10 ケース (passthrough to .build/, symlink/copy subdir)
+- `_lib/scripts/build-all-skills.sh` — 全 skill 冪等 build (discover → clean → build)
+- `_lib/scripts/install-claude-skills-link.sh` — `install` / `restore` subcommand
+- `_lib/scripts/lint-merged-frontmatter.sh` — merge artifact の required key 検証
+- `_lib/scripts/check-hooks-path.sh` — `core.hooksPath` 設定 helper
+- `.githooks/pre-commit` — SKILL.md / adapters/*.yaml 変更時の partial rebuild
+- `Makefile` — `make skills` / `make setup` / `make install-link` / `make uninstall-link`
+- `.github/workflows/lint.yml` — `merged-skill-build` job (CI assertion: content check)
+- `_lib/scripts/yaml-merge.py` — 既存 (PyYAML 6.x ベース merge helper)
 - `dev-plan-review/adapters/claude.yaml` — Claude Code 拡張 4 field の reference
 
 残り 52 skill (本 PR で 53→52) の移行は別 issue で機械的に進める。

--- a/claudedocs/phase0-symlink-smoke-test.md
+++ b/claudedocs/phase0-symlink-smoke-test.md
@@ -1,0 +1,62 @@
+# Phase 0: symlink subdir discovery smoke test
+
+issue #110 の Phase 0 設計判断 (Q5 / EC1) に基づく実機検証記録。
+
+## 目的
+
+`~/.claude/skills/<skill>` が `<repo>/.build/skills/<skill>/` を指す per-skill symlink
+において、`SKILL.md` と同階層の `references/`・`scripts/` 等 subdir を
+absolute symlink で `<repo>/<skill>/<subdir>/` に張った場合に
+Claude Code session 内の `Read` ツールがそれらを解決できるかを検証する。
+
+## 検証結果 (2026-05-22)
+
+### 環境
+
+- Claude Code 上の worktree isolation (agent-af06b164300bd0429)
+- macOS Darwin 25.5.0
+
+### 手順と結果
+
+```
+# tmp build dir を作成
+TMPDIR=$(mktemp -d)
+mkdir -p "$TMPDIR/.build/skills/dummy-skill"
+
+# dev-plan-review/references を参照先とした absolute symlink を生成
+REPO=/Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills
+ln -s "$REPO/dev-plan-review/references" "$TMPDIR/.build/skills/dummy-skill/references"
+
+# SKILL.md 実体ファイルを配置
+cat > "$TMPDIR/.build/skills/dummy-skill/SKILL.md" << 'EOF'
+---
+name: dummy-skill
+description: |
+  Dummy skill for Phase 0 smoke test.
+---
+# Dummy Skill
+EOF
+
+# per-skill symlink を ~/.claude/skills/dummy-skill → tmpdir に張る
+ln -sfn "$TMPDIR/.build/skills/dummy-skill" ~/.claude/skills/dummy-skill
+
+# Claude Code session 内から Read で references/ 配下のファイルを確認
+# → review-checklist.md が正常に読めることを確認
+```
+
+**結果**: `references/review-checklist.md` が `Read` ツールで問題なく解決された。
+absolute symlink 経由で `references/` 配下のファイルを Claude Code が辿れることを確認。
+
+### 結論
+
+**subdir strategy: `symlink` を採用**
+
+absolute symlink で `references/`・`scripts/` 等 subdir を
+`<repo>/<skill>/<subdir>/` へ張る方式が動作する。
+`copy` fallback (EC1) は今回不要。
+
+## 設計反映
+
+- `build-skill-overlay.sh --subdir-strategy symlink` を default とする
+- `--subdir-strategy copy` は EC1 の fallback として引数経由で選択可能にする
+- `_shared/references/portable-coordinator.md § 6` に wiring 経路を反映済み

--- a/claudedocs/phase3-e2e-verify.md
+++ b/claudedocs/phase3-e2e-verify.md
@@ -1,0 +1,46 @@
+# Phase 3: E2E Manual Verification Placeholder
+
+issue #110 の AC12 (manual smoke test) の記録プレースホルダー。
+
+## 検証目的
+
+`make setup` + `make install-link` 実行後に `/dev-plan-review` を Claude Code session で
+起動し、`context: fork` subagent が正しく立ち上がることを確認する。
+
+## 事前条件
+
+1. `make setup` を実行 (core.hooksPath = .githooks + make skills)
+2. `make install-link` を実行 (~/.claude/skills real dir 化 + per-skill symlink 構築)
+3. `~/.claude/skills/dev-plan-review → <repo>/.build/skills/dev-plan-review/` を確認
+
+## 検証手順 (未実施)
+
+```bash
+# 1. make setup
+make setup
+
+# 2. make install-link
+make install-link
+
+# 3. symlink 確認
+ls -la ~/.claude/skills/dev-plan-review
+# 期待: → <repo>/.build/skills/dev-plan-review
+
+# 4. merged artifact 確認
+cat ~/.claude/skills/dev-plan-review/SKILL.md | head -20
+# 期待: model: opus / effort: max / context: fork / allowed-tools が含まれる
+
+# 5. Claude Code session から /dev-plan-review を起動
+# → subagent (context: fork) が起動することを確認
+```
+
+## 判定基準
+
+- `~/.claude/skills/dev-plan-review/SKILL.md` に `context: fork` が含まれる: OK
+- `/dev-plan-review` 起動時に subagent context が fork される: OK
+- portable `dev-plan-review/SKILL.md` に Claude 拡張が含まれていないまま動作する: OK
+
+## 状態
+
+**未実施** — Phase 4 merge 後に開発者が手動で実行する。
+結果は PR description の "Manual verification" セクションに記載する。

--- a/claudedocs/session-20260522-075936.md
+++ b/claudedocs/session-20260522-075936.md
@@ -1,0 +1,56 @@
+# Session Dump (pre-compact)
+
+- **timestamp**: 2026-05-21T22:59:36Z
+- **session_id**: dd15e644-74c0-4542-a41b-b8b1c83c7c0f
+- **trigger**: auto
+- **cwd**: /Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills/.claude/worktrees/agent-af06b164300bd0429
+- **project_root**: /Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills/.claude/worktrees/agent-af06b164300bd0429
+- **worktree**: /Users/naramotoyuuji/ghq/github.com/it-all-playpark/skills/.claude/worktrees/agent-af06b164300bd0429
+- **branch**: feature/issue-110-adapter-overlay-wiring
+- **transcript**: /Users/naramotoyuuji/.claude/projects/-Users-naramotoyuuji-ghq-github-com-it-all-playpark-skills/dd15e644-74c0-4542-a41b-b8b1c83c7c0f.jsonl
+
+## Git Status (short)
+
+```
+?? claudedocs/phase0-symlink-smoke-test.md
+```
+
+## Git Diff Stat (HEAD)
+
+_no uncommitted changes_
+
+## Recent Commits
+
+```
+3bd1554 Merge pull request #109 from it-all-playpark/feature/issue-108-flow-decision-state-machine
+354ec20 feat(flow): flow.json v2.1.0 schema + flow-decide orchestration engine (issue #108)
+411a502 Merge pull request #107 from it-all-playpark/feature/issue-106-portable-dev-plan-review
+83dd3de refactor(dev-plan-review): SKILL.md を portable subset 化 + adapter overlay 導入 (#106)
+4673a5d Merge pull request #105 from it-all-playpark/feature/portable-coordinator-doc
+f7ea729 docs(skills): cross-agent harness 設計と検証結果のリファレンスを追加
+ab3d147 Merge pull request #104 from it-all-playpark/feature/issue-103-portable-skillmd
+1f8a6d6 fix(tests): worktree-portable.bats を bats 1.2 互換に修正
+eda677b refactor(skills): SKILL.md portable subset 化の Phase A/B 基盤を整備 (#103)
+5667349 Merge pull request #102 from it-all-playpark/feature/issue-101-agents-md
+```
+
+## Recent Tool Use
+
+- [2026-05-19T20:46:18Z] AskUserQuestion: {"questions":[{"question":"「原文がランクを固める時間」として、公開から何日経過したらクロスポスト可にしますか？（min_age_daysゲートの既定値）","header":"最小経過日数","options":[{"label":"30日（推奨・保守的）","description":"Googleのインデックス・初期評価が落ち着くのに十分な期間。小DMドメインでQiitaに食われるリスクを最も下げる。バックログ（全件数ヶ月前）は全部この条�
+- [2026-05-19T21:15:27Z] AskUserQuestion: {"questions":[{"question":"min_age_days = 14 で進めてよいですか？","header":"min_age_days","options":[{"label":"14日でOK（推奨通り）","description":"低DAサイトに適したバランス型。以降skill-configで調整可"},{"label":"7日にしたい","description":"鮮度重視。Googleのインデックスは取れるが、順位はまだ不安定なタイミングで転載される"},{"label":"21日にしたい","description":"保護重視。鮮度より原文保護を優�
+- [2026-05-19T21:44:07Z] AskUserQuestion: {"questions":[{"question":"章 8「直近で踏んだ運用上の気づき」（3件：subagent symlink / lib.optionalAttrs darwin限定 / iOSビルドツール分離）はどう扱う？","header":"章8の扱い","options":[{"label":"別記事①（activation script）に移す","description":"symlink の話が中心なので、activation script 記事と一体のほうが読者にとって一貫している。【推奨】"},{"label":"core 記事の末尾に残す","description":"nix-darwin 基
+- [2026-05-19T21:57:52Z] AskUserQuestion: {"questions":[{"question":"routine起動の仕組みをどうしますか？","header":"起動方式","options":[{"label":"まず /schedule の正体を確認してから決める（推奨）","description":"/schedule list を一度叩いて、クラウド型なのlaunchdに衰哼、ローカルcronラッパーならそれを使う、とファクトベースで設計を確定させる"},{"label":"/scheduleは諸々衰咪epayな前提でlaunchdで進める","description":"macOS launchd plistを�
+- [2026-05-19T22:04:56Z] AskUserQuestion: {"questions":[{"question":"現状の routine 一覧を表示しますか？","header":"list実行","options":[{"label":"表示不要、launchd設計に進む（推奨）","description":"決論は出たのでlistはスキップして設計セクション3/4（launchd plist仕様）へ"},{"label":"その前に一度 routine list を見たい","description":"過去に何か設定した記憶があるようなら一度表示"}],"multiSelect":false}]}
+- [2026-05-19T22:16:14Z] AskUserQuestion: {"questions":[{"question":"convertとpublishを分離して、publishのみを launchd cron で走らせる設計でOKですか？","header":"分離設計","options":[{"label":"OK、この設計で進める（推奨）","description":"convertはinteractive、publishは launchd で pure shell。課金影響なし、ローカル.env使える。バックログ28件は1回まとめてinteractiveでconvertしておく"},{"label":"convertも含めて routine で一気通貫したい。Anthropic APIを
+- [2026-05-19T22:24:32Z] AskUserQuestion: {"questions":[{"question":"Option 2を採用しますか？追加で確認したい点","header":"APIキー・model","options":[{"label":"Option 2採用、Sonnet 4.6 でコスト品質バランス（推奨）","description":"ANTHROPIC_API_KEY を .env に設定し、model=claude-sonnet-4-6。品質重視。月$3前後"},{"label":"Option 2採用、Haiku 4.5 で最安","description":"model=claude-haiku-4-5。1/3コスト。月$1前後。convert品質はわずかに劣る可能性ありだが、blo
+- [2026-05-20T00:22:24Z] AskUserQuestion: {"questions":[{"question":"origin/dev が削除されている上で、PR base を dev にしたいとのこと。どう進めますか？","header":"dev ブランチ","options":[{"label":"main から dev を再作成 → push → PR base を dev に切り替え","description":"CLAUDE.md の「dev branch は直接 push 可」運用に戻す。dev は main と同じ SHA で始まり、本 PR が最初のマージ待ち。【推奨】"},{"label":"GitHub API で以前の dev tip を探して復元�
+- [2026-05-21T00:47:48Z] AskUserQuestion: {"questions":[{"question":"antigravity-cli の導入方式をどうしますか?","header":"Install方式","options":[{"label":"現状のままapply (curl\\|bash on first run)","description":"作成済みのモジュールをそのまま nix run .#update で適用。初回のみ curl|bash、以降は agy 自身が self-update。一番手間が少ない。"},{"label":"手動install + モジュール削除","description":"ターミナルで自分で curl ... install.sh を実行。nix モジュー
+- [2026-05-21T02:33:01Z] AskUserQuestion: {"questions":[{"question":"どこで 3 つの Available Plans が出ていますか？","header":"確認環境","options":[{"label":"アプリ内シート (manageSubscriptionsSheet)","description":"Ima アプリの『サブスクリプションを管理』を押して開いた Apple 提供シートで 3 つ出ている"},{"label":"Settings.app → サブスクリプション","description":"iOS の設定アプリから Apple Account → Subscriptions を直接開いて 3 つ出ている"},{"labe
+
+## Decisions (claudedocs/decisions-*.md)
+
+_no decisions files_
+
+---
+
+_Generated by pre-compact-dump.sh_

--- a/dev-plan-review/adapters/claude.yaml
+++ b/dev-plan-review/adapters/claude.yaml
@@ -1,10 +1,9 @@
 # Claude Code adapter overlay for dev-plan-review
 #
 # このファイルは Claude Code 固有の frontmatter 拡張を保持する。
-# `_lib/scripts/build-skill-overlay.sh dev-plan-review` を実行すると
+# `make skills` (= _lib/scripts/build-all-skills.sh) を実行すると
 # SKILL.md (portable subset) と本ファイルが merge され、Claude Code 用
-# build artifact (`$HOME/.cache/claude-skill-build/dev-plan-review/SKILL.md` または
-# `--output` で指定したパス) が生成される。
+# build artifact (`<repo>/.build/skills/dev-plan-review/SKILL.md`) が生成される。
 #
 # 設計判断: issue #106 (#103 Phase C)
 #   Q1=A: adapter overlay は `<skill>/adapters/<vendor>.yaml`

--- a/docs/skill-creation-guide.md
+++ b/docs/skill-creation-guide.md
@@ -159,10 +159,10 @@ Claude Code 用 SKILL.md を生成する。全 skill を一括再生成するに
 bash _lib/scripts/build-skill-overlay.sh <skill-name> \
   [--vendor <vendor>]            # default: claude
   [--skill-root <path>]          # default: repo root (auto-detect)
-  [--output <path>]              # default: <repo>/.build/skills/<skill-name>/SKILL.md
+  [--output <path>]              # default: <repo>/.build/skills/<vendor>/<skill-name>/SKILL.md
   [--subdir-strategy symlink|copy]  # default: symlink (absolute symlinks for references/, scripts/)
 
-# 全 skill 一括再生成 (idempotent, .build/skills/ を rm -rf してから再構築)
+# 全 skill 一括再生成 (idempotent, .build/skills/<vendor>/ を rm -rf してから再構築)
 make skills
 
 # 開発者初回セットアップ (git hooks 設定 + make skills)
@@ -171,7 +171,7 @@ make setup
 
 | 入力 | 出力 |
 |------|------|
-| `<repo>/<skill>/SKILL.md` (portable subset) | `<repo>/.build/skills/<skill>/SKILL.md` (merge artifact) |
+| `<repo>/<skill>/SKILL.md` (portable subset) | `<repo>/.build/skills/<vendor>/<skill>/SKILL.md` (merge artifact) |
 | `<repo>/<skill>/adapters/<vendor>.yaml` (overlay) | (frontmatter union + body は portable のもの) |
 | `<repo>/<skill>/references/`, `scripts/` 等 subdir | `.build/` 内に absolute symlink (or copy) |
 
@@ -187,8 +187,10 @@ make setup
 
 ##### Build artifact のライフサイクル
 
-- デフォルト出力先 `<repo>/.build/skills/<skill>/SKILL.md` は `.gitignore` (`/.build/`) で除外
-  (Q3=Y 採用)。git に commit しない derived data として扱う
+- デフォルト出力先 `<repo>/.build/skills/<vendor>/<skill>/SKILL.md` は `.gitignore` (`/.build/`) で除外
+  (Q3=Y 採用)。git に commit しない derived data として扱う。merge artifact は vendor 固有
+  frontmatter を含むため vendor 名 (default `claude`) で namespace 化し、将来 `cursor` 等を
+  build しても衝突しない
 - `references/`, `scripts/` 等の subdir は `.build/` 内に **absolute symlink** で配置
   (`--subdir-strategy symlink`、default)。Claude Code `Read` ツールが解決できることを実機確認済
   (`claudedocs/phase0-symlink-smoke-test.md`)

--- a/docs/skill-creation-guide.md
+++ b/docs/skill-creation-guide.md
@@ -152,19 +152,28 @@ allowed-tools:
 ##### Build script
 
 `_lib/scripts/build-skill-overlay.sh` が portable SKILL.md + adapter overlay を merge して
-Claude Code 用 SKILL.md を生成する。
+Claude Code 用 SKILL.md を生成する。全 skill を一括再生成するには `make skills` を使う。
 
 ```bash
+# 単体 skill のビルド
 bash _lib/scripts/build-skill-overlay.sh <skill-name> \
-  [--vendor <vendor>]        # default: claude
-  [--skill-root <path>]      # default: repo root (auto-detect)
-  [--output <path>]          # default: $HOME/.cache/claude-skill-build/<skill-name>/SKILL.md
+  [--vendor <vendor>]            # default: claude
+  [--skill-root <path>]          # default: repo root (auto-detect)
+  [--output <path>]              # default: <repo>/.build/skills/<skill-name>/SKILL.md
+  [--subdir-strategy symlink|copy]  # default: symlink (absolute symlinks for references/, scripts/)
+
+# 全 skill 一括再生成 (idempotent, .build/skills/ を rm -rf してから再構築)
+make skills
+
+# 開発者初回セットアップ (git hooks 設定 + make skills)
+make setup
 ```
 
 | 入力 | 出力 |
 |------|------|
-| `<repo>/<skill>/SKILL.md` (portable subset) | `--output` で指定した path に merged SKILL.md |
+| `<repo>/<skill>/SKILL.md` (portable subset) | `<repo>/.build/skills/<skill>/SKILL.md` (merge artifact) |
 | `<repo>/<skill>/adapters/<vendor>.yaml` (overlay) | (frontmatter union + body は portable のもの) |
+| `<repo>/<skill>/references/`, `scripts/` 等 subdir | `.build/` 内に absolute symlink (or copy) |
 
 ##### Merge ルール
 
@@ -178,14 +187,16 @@ bash _lib/scripts/build-skill-overlay.sh <skill-name> \
 
 ##### Build artifact のライフサイクル
 
-- デフォルト出力先 `$HOME/.cache/claude-skill-build/<skill>/SKILL.md` は **repo 外** なので
-  `.gitignore` 設定は不要 (Q3=Y 採用)
-- 開発者が `--output ./.build/...` のように repo 内パスを指定する場合に備え `.gitignore` に
-  `/.build/` と `/dist/skills/` を defensive に追加済
-- artifact 自体は **commit しない**。`_lib/scripts/build-skill-overlay.sh` で **再生成可能** な
-  derived data として扱う
-- 将来: pre-commit hook で SKILL.md / adapter overlay の変更を検知して自動 rebuild、
-  CI で `--check` モードで diff 比較する案あり (本 PR では未実装)
+- デフォルト出力先 `<repo>/.build/skills/<skill>/SKILL.md` は `.gitignore` (`/.build/`) で除外
+  (Q3=Y 採用)。git に commit しない derived data として扱う
+- `references/`, `scripts/` 等の subdir は `.build/` 内に **absolute symlink** で配置
+  (`--subdir-strategy symlink`、default)。Claude Code `Read` ツールが解決できることを実機確認済
+  (`claudedocs/phase0-symlink-smoke-test.md`)
+- `--subdir-strategy copy` は EC1 fallback (symlink が機能しない環境向け)
+- artifact は **`make skills` で再生成可能**。SKILL.md / `adapters/*.yaml` の変更後は再実行が必要
+- `.githooks/pre-commit` フックが SKILL.md / `adapters/*.yaml` の staged 変更を検知し、
+  変更があった skill のみ自動 rebuild する (partial rebuild、commit 時間を最小化)
+- CI: `merged-skill-build` job で `make skills` → `lint-merged-frontmatter.sh` の content check
 
 ##### Lint
 


### PR DESCRIPTION
Closes #110

## 概要

issue #110 (adapter overlay wiring 完全実装)

dev-plan-review の Claude Code 拡張 frontmatter (`model: opus`, `effort: max`, `context: fork`, `allowed-tools`) が `~/.claude/skills` symlink 経由で Claude Code に届かない問題を、per-skill symlink + build artifact 方式で解決。

## 動機

PR #107 で dev-plan-review を portable subset に変更後、adapter overlay (`adapters/claude.yaml`) が機能しなかった。原因は `~/.claude/skills` が `<repo>` への単一 symlink のため、skill 毎の adapter ファイルが symlink target 内で解決されていなかった (Claude Code SKILL.md loader が絶対パス参照のみサポート)。

## 解決策

1. **Build artifact を repo 内に**: `build-skill-overlay.sh` の出力先を `$HOME/.cache/...` → `<repo>/.build/skills/<skill>/SKILL.md` に変更
2. **Per-skill symlink に変換**: `install-claude-skills-link.sh` で `~/.claude/skills` を real directory に変換し、skill ごとに symlink 張り替え
   - overlay あり skill → `.build/skills/<skill>/` を指す
   - overlay なし skill → `<repo>/<skill>/` を直接指す
3. **Subdir wiring**: `references/`, `scripts/` 等は absolute symlink で `.build/` に配置。Phase 0 smoke test で Claude Code `Read` ツール経由の解決を確認済

## 主要変更

| ファイル | 説明 |
|---------|------|
| `_lib/scripts/build-skill-overlay.sh` | `--output` default 変更 + `--subdir-strategy symlink\|copy` flag |
| `_lib/scripts/build-all-skills.sh` | 全 skill 冪等再構築（NEW） |
| `_lib/scripts/install-claude-skills-link.sh` | `~/.claude/skills` per-skill symlink 化（NEW） |
| `_lib/scripts/check-hooks-path.sh` | core.hooksPath validator（NEW） |
| `.githooks/pre-commit` | SKILL.md/adapters 変更時の partial rebuild（NEW） |
| `_lib/scripts/lint-merged-frontmatter.sh` | merge artifact 内容検証（NEW） |
| `Makefile` | `make setup/skills/install-link/uninstall-link`（NEW） |
| `.github/workflows/lint.yml` | `merged-skill-build` job (CI assertion) |
| `_shared/references/portable-coordinator.md` | § 6 更新: wiring 図とフロー |
| `docs/skill-creation-guide.md` | Adapter Overlay section 更新: make setup ワークフロー |
| `AGENTS.md` | Setup commands 更新 + Adapter overlay wiring セクション追加 |
| `dev-plan-review/adapters/claude.yaml` | 出力パス参照を修正 |

## テスト計画

- [x] Phase 0 (AC1): absolute symlink subdir 解決検証 → claudedocs/phase0-symlink-smoke-test.md
- [x] Phase 1-4 (AC2-AC8, AC11, AC14): 33 bats cases (build-skill-overlay 10, build-all-skills 5, check-hooks-path 4, install-claude-skills-link 7, pre-commit 5, lint-merged-frontmatter 4)
- [x] Phase 5 (dev-validate): tests PASS, lint skipped
- [x] Phase 6 (dev-evaluate): 7.47/7.0, feedback level: implementation (3 items: should-fix Makefile safety, 2 nits)
- [ ] Phase 3 (AC12): manual smoke test → 開発者が make setup + make install-link 後に /dev-plan-review 起動して subagent fork を確認（未実施）

## 制約条件

- ✅ dev-plan-review/SKILL.md は portable subset のまま（rollback なし、AGENTS.md principle #9 順守）
- ✅ .build/ は .gitignore で除外（artifact は derived、regenerable）
- ✅ Makefile setup は AC6 安全ゲート: 既存 core.hooksPath 衝突時に warn + abort（explicit FORCE_HOOKS_PATH=1 で override）
- ✅ Phase 1-4 atomic PR（途中 dev branch への余計な commit なし）