### PR TITLE
feat(dev-flow): child-split orchestration を flow-decide 駆動の bash decision loop に薄化 (Stage 3, #112)

### DIFF
--- a/_lib/scripts/validate-decomposition.sh
+++ b/_lib/scripts/validate-decomposition.sh
@@ -2,7 +2,7 @@
 # validate-decomposition.sh - Validate v2 child-split flow.json
 #
 # Checks:
-#   - schema version == 2.0.0 (no v1 fallback — no-backcompat)
+#   - schema version == 2.1.0 (no v2.0 / v1 fallback — no-backcompat)
 #   - parent issue is positive integer
 #   - integration_branch.name matches required pattern
 #   - children list non-empty and unique by issue number

--- a/_shared/references/portable-coordinator.md
+++ b/_shared/references/portable-coordinator.md
@@ -486,15 +486,55 @@ bash coordinator 経由なら **どの agent でも nesting 制限なし** (別 
   - `flow.json.phases[]` = top-level orchestration (decompose / batch_loop / integrate / final_pr / pr_iterate)
   - `kickoff.json.current_phase` = single mode の child 内 phase (1b → 8、`dev-kickoff/scripts/next-action.sh` の管轄、本 PR では変更しない)
 
-### Stage 3: Orchestrator skill の薄化
+### Stage 3: child-split orchestration の bash decision loop 化 (Issue #112 で実装)
 
-- [ ] `dev-flow/SKILL.md` を「bash decision script + invoke-skill-poc.sh のループ」に書き換え
-- [ ] `dev-kickoff/SKILL.md` 同様
-- [ ] 既存 `dev-kickoff-worker` (`isolation: worktree`) は **Claude Code 用 adapter として残す** (後方互換)
-- [ ] 他 agent (Codex/agy) 用に `_lib/runners/codex-runner.sh`, `agy-runner.sh` を追加
+**スコープを「child-split mode top-level の orchestration 薄化」に限定** (dev-kickoff 薄化 /
+runner script は Stage 4+ に移動)。
 
-### Stage 4: 検証
+- [x] `dev-flow/scripts/build-envelope.sh` 新規 — **skill 実行結果 → decision-input envelope の
+  純変換 builder 層** (副作用なし、invoke-skill-poc.sh の raw text は parse しない)。
+- [x] `dev-flow/scripts/orchestrate.sh` 新規 — `flow-decide.sh` (decision engine) を駆動する
+  bash decision loop。各 phase で skill 実行 → build-envelope → flow-decide → flow-update を
+  繰り返す。**起点は batch_loop** (decompose は dev-decompose が内包)。
+- [x] dev-decompose 改修 — Step 8 validate 成功直後に `flow-update phase decompose done`
+  (decompose done 化の責務を dev-decompose が内包、Q3)。
+- [x] `dev-flow/SKILL.md` child-split Step 3-6 を `orchestrate.sh` 呼び出しに薄化。single mode
+  (dev-kickoff) は現状維持。
+- [x] schema version 全整合 (Q10) — `verify-children-merged.sh` の version gate を
+  `2.0.0 → 2.1.0` に修正 (Stage 2 の version bump 漏れ吸収)。`tests/flow-v2-version-bump.sh`
+  の target に追加。
+- [x] bats — `build-envelope.bats` (4 phase 変換 + skipped 整合性 + ci polling) /
+  `orchestrate.bats` (phase 遷移 + retry + abort + allow-partial)。
 
+#### envelope builder pattern (変換表)
+
+builder 層は「決定論的ソース (skill JSON 出力 / state ファイル) → decision-input envelope
+(`_lib/schemas/decision-input.schema.json`)」の **純変換関数**。LLM の raw text を一切 parse
+しないことで、orchestrate の decision 分岐を決定論的かつ test 可能にする。
+
+| phase | 入力ソース (決定論的) | envelope 構築規則 |
+|---|---|---|
+| batch_loop | run-batch-loop.sh JSON + flow.json `children[]` | `completed_children = issues_succeeded`、`failed_children = issues_failed + (results[]\|select(.status=="skipped")\|length)`。skipped は results[] から集約 (`completed+failed == children\|length` 保証) |
+| integrate | dev-integrate `{type_check, validation}` | `tests_pass = (type_check ∈ {passed,skipped}) && (validation==passed)`、`merge_conflicts = []` (merge は batch_loop の auto-merge-child で完結済) |
+| final_pr | git-pr `{pr_url}` + orchestrate の `gh pr checks` polling | `{pr_url, ci_status}` (ci_status は polling 解決の純粋引数。最大 30×20s=10 分、timeout→failed) |
+| pr_iterate | iterate.json `{status, current_iteration}` | `decision = status` (in_progress は abort)、`iterations = current_iteration` |
+
+> **Note**: `flow-decide.sh` の **decompose** ケースは現状 reserved。child-split では
+> dev-decompose が decompose done 化を内包するため orchestrate は batch_loop 起点で開始し、
+> decompose case を呼ばない。将来 single mode を flow-decide に統合する際 (Stage 5) に再利用する
+> ための予約分岐として残す (Round3-d)。
+
+#### Stage 3 で対象外 (別 issue)
+
+- single mode (dev-kickoff) の flow-decide 統合 → Stage 5
+- dev-kickoff 薄化 + runner script (`codex-runner.sh` / `agy-runner.sh`) → Stage 4+
+- 他 agent (Codex/agy) E2E → Stage 4
+- Phase 3b/6 verdict 分岐の bash 化
+
+### Stage 4: 検証 + dev-kickoff 薄化 / runner
+
+- [ ] dev-kickoff 薄化 + runner script (`_lib/runners/codex-runner.sh`, `agy-runner.sh`)
+- [ ] 既存 `dev-kickoff-worker` (`isolation: worktree`) は **Claude Code 用 adapter として残す**
 - [ ] 1 issue を 3 agent で完走 (single mode)
 - [ ] child-split mode で 1 親 issue を 3 child に分解 → 3 agent で個別完走
 - [ ] dev-flow-doctor で前後比較 (turns, duration, retry count)
@@ -556,4 +596,4 @@ bash coordinator 経由なら **どの agent でも nesting 制限なし** (別 
 
 ---
 
-_Last updated: 2026-05-22 (Stage 2 実装完了 — issue #108)_
+_Last updated: 2026-05-22 (Stage 3 実装完了 — issue #112: child-split orchestration の bash decision loop 化 + envelope builder)_

--- a/dev-decompose/SKILL.md
+++ b/dev-decompose/SKILL.md
@@ -43,6 +43,7 @@ Used by `dev-flow --child-split` to drive multi-PR coordination through `run-bat
 6. Compose batches (run-batch-loop friendly format)
 7. Write flow.json v2 (init-flow-v2.sh --children-json --batches-json)
 8. Validate (validate-decomposition.sh)
+9. Mark decompose phase done (flow-update.sh phase decompose done)
 ```
 
 ### Step 1-3: Plan Generation
@@ -114,11 +115,21 @@ $SKILLS_DIR/_lib/scripts/validate-decomposition.sh --flow-state "$FLOW_STATE"
 ```
 
 Validation enforces:
-- schema version `2.0.0` (v1 schema rejected — no-backcompat)
+- schema version `2.1.0` (v2.0 / v1 schema rejected — no-backcompat)
 - batches 1-indexed and contiguous
 - children unique per batch
 - max_child_issues_hard
 - `integration_branch.name` pattern
+
+### Step 9: Mark decompose phase done (child-split orchestration)
+
+`init-flow-v2.sh` が seed した top-level `phases[]` のうち `decompose` を `done` に遷移させる。
+これにより `dev-flow --child-split` の `orchestrate.sh` は **batch_loop 起点**で開始できる
+(issue #112 Q3: decompose done 化の責務は dev-decompose が内包する)。validate (Step 8) 成功直後にのみ実行する。
+
+```bash
+$SKILLS_DIR/_lib/scripts/flow-update.sh --flow-state "$FLOW_STATE" phase decompose done
+```
 
 ## Dry-Run Mode (`--dry-run`)
 

--- a/dev-flow/SKILL.md
+++ b/dev-flow/SKILL.md
@@ -72,11 +72,13 @@ Details: [Single Mode](references/single-mode.md)
 | Step | Action | Complete When |
 |------|--------|---------------|
 | 1 | `Skill: dev-issue-analyze` | Parent requirements understood |
-| 2 | `Skill: dev-decompose --child-split` | children + integration branch + flow.json |
-| 3 | `run-batch-loop.sh` | All batches consumed, child PRs merged into integration branch |
-| 4 | `Skill: dev-integrate` | type check + dev-validate on integration branch |
-| 5 | `Skill: git-pr` | Final integration → dev/main PR created |
-| 6 | `Skill: pr-iterate` | LGTM or max iterations |
+| 2 | `Skill: dev-decompose --child-split` | children + integration branch + flow.json (decompose phase done) |
+| 3 | `bash dev-flow/scripts/orchestrate.sh` | batch_loop → integrate → final_pr → pr_iterate を flow-decide 駆動の decision loop で完走 |
+
+Step 3 は Stage 3 (issue #112) で `orchestrate.sh` に集約された。`run-batch-loop` /
+`dev-integrate` / `git-pr` / `pr-iterate` の各遷移は `flow-decide.sh` (decision engine) +
+`build-envelope.sh` (skill 出力 → decision-input envelope の純変換) + `flow-update.sh`
+(flow.json phase state 更新) の bash decision loop が制御する。
 
 Details: [Child-Split Mode](references/child-split-mode.md)
 
@@ -99,57 +101,43 @@ Skill: dev-decompose $ISSUE --child-split --base $BASE \
   --flow-state $WORKTREE_BASE/.claude/flow.json
 ```
 
-Output: integration branch + flow.json v2 (children[] + batches[]).
+Output: integration branch + flow.json v2.1 (children[] + batches[] + phases[])。
+dev-decompose は validate (Step 8) 成功直後に `flow-update phase decompose done` を呼ぶため、
+orchestrate.sh は `decompose == done` の flow.json を前提に **batch_loop 起点**で開始する
+(issue #112 Q3)。
 
-## Step 3 (Child-Split): Run Batch Loop
+## Step 3 (Child-Split): Orchestrate (decision loop)
 
-Each child issue is run through `dev-flow <child> --force-single --base $INTEGRATION_BRANCH`.
-Child PRs are auto-merged into the integration branch (auto-merge-guard permits it).
-
-```bash
-INTEGRATION_BRANCH=$(jq -r '.integration_branch.name' $FLOW_STATE)
-BATCHES_JSON=$(mktemp)
-jq '.batches' $FLOW_STATE > $BATCHES_JSON
-
-$SKILLS_DIR/_shared/scripts/run-batch-loop.sh \
-  --batches-json $BATCHES_JSON \
-  --issue-runner "Skill: dev-flow {issue} --force-single --base $INTEGRATION_BRANCH --lang ja" \
-  --on-success "$SKILLS_DIR/dev-flow/scripts/auto-merge-child.sh {issue} --base $INTEGRATION_BRANCH --flow-state $FLOW_STATE" \
-  --state-file $WORKTREE_BASE/.claude/batch-state.json \
-  --fail-fast
-```
-
-`--fail-fast` skips subsequent batches once any batch has a failed issue
-(recommended for layered dependencies like schema → API → E2E). Omit it when
-batches are loose-coupled.
-
-`auto-merge-child.sh` resolves the child's PR via flow.json `pr_number` or
-GitHub's authoritative Issue→PR link (`closedByPullRequestsReferences`), then
-runs `auto-merge-guard.sh`. Since base is `integration/issue-*`, the guard
-allows `gh pr merge --admin`.
-
-## Step 4 (Child-Split): Integration
+batch_loop → integrate → final_pr → pr_iterate の遷移は **`orchestrate.sh` の bash decision
+loop** に集約される。各 phase で skill を実行 → `build-envelope.sh` で決定論的ソース
+(run-batch-loop JSON / dev-integrate JSON / git-pr JSON / iterate.json) を decision-input
+envelope に純変換 → `flow-decide.sh` で next_action を決定 → `flow-update.sh` で phase state を
+更新、を繰り返す。
 
 ```bash
-Skill: dev-integrate --flow-state $FLOW_STATE --base $INTEGRATION_BRANCH
+$SKILLS_DIR/dev-flow/scripts/orchestrate.sh \
+  --flow-state $WORKTREE_BASE/.claude/flow.json \
+  --worktree $WORKTREE_BASE \
+  --base $BASE --lang ja \
+  [--allow-partial]
 ```
 
-`dev-integrate` (v2) verifies all children merged successfully and runs
-type check + dev-validate on the integration branch (linear, no Kahn sort).
+- **batch_loop**: 内部で `run-batch-loop.sh` を `--fail-fast` で回し、各 child PR を
+  `auto-merge-child.sh` で integration branch に auto-merge する (従来 Step 3 と同等)。
+  `build-envelope.sh batch_loop` が `issues_succeeded` → `completed_children`、
+  `issues_failed + (results[]|skipped)` → `failed_children` に集約する。
+- **integrate**: `dev-integrate` を実行し `{type_check, validation}` を tests_pass に変換。
+  merge は batch_loop で完結済のため `merge_conflicts = []`。
+- **final_pr**: `git-pr` で **non-draft** の integration → dev/main PR を作成。orchestrate が
+  `gh pr checks` を最大 10 分 polling して ci_status を解決 (Q12)。
+- **pr_iterate**: `pr-iterate` を実行し iterate.json `{status, current_iteration}` を
+  `{decision, iterations}` に変換。`lgtm` / `max_reached` で完了、`failed` で abort。
 
-## Step 5 (Child-Split): Final PR
+`--allow-partial` は default off。明示時のみ batch_loop で `failed_children > 0` でも
+integrate に進む (Q11)。retry が必要な phase は orchestrate が
+`flow-update phase <t> running --attempts +1` を呼んでから再実行する (Q5、max 3 attempts)。
 
-```bash
-Skill: git-pr $ISSUE --base $BASE --lang ja --worktree $INTEGRATION_WORKTREE
-```
-
-This creates the **non-draft** integration → dev/main PR (final review).
-
-## Step 6 (Child-Split): pr-iterate
-
-```bash
-Task: pr-iterate $FINAL_PR_URL --max-iterations $MAX
-```
+exit code: `0` = 完走 (next_action complete) / `2` = abort (手動介入要) / `3` = skill 起動エラー。
 
 ## Usage
 
@@ -213,6 +201,9 @@ Details: [Journal Logging](references/journal-logging.md)
 - [dev-decompose](../dev-decompose/SKILL.md) - Child-split planner
 - [dev-integrate](../dev-integrate/SKILL.md) - Integration verifier
 - [pr-iterate](../pr-iterate/SKILL.md) - PR iteration skill
+- [orchestrate.sh](scripts/orchestrate.sh) - Child-split decision loop (Stage 3)
+- [build-envelope.sh](scripts/build-envelope.sh) - skill 出力 → decision-input envelope 純変換
+- [flow-decide.sh](../_lib/scripts/flow-decide.sh) - Decision engine (read-only)
 - [run-batch-loop.sh](../_shared/scripts/run-batch-loop.sh) - Batch dispatcher
 - [auto-merge-guard.sh](../_lib/scripts/auto-merge-guard.sh) - --admin merge guard
 - [integration-branch.sh](../_lib/scripts/integration-branch.sh) - Integration branch helper

--- a/dev-flow/references/child-split-mode.md
+++ b/dev-flow/references/child-split-mode.md
@@ -11,11 +11,17 @@ linear DAG dependencies).
 | Step | Action | Complete When |
 |------|--------|---------------|
 | 1 | `Skill: dev-issue-analyze` | parent requirements captured |
-| 2 | `Skill: dev-decompose --child-split` | flow.json v2 + integration branch + child issues |
-| 3 | `run-batch-loop.sh` | all child PRs merged into integration branch |
-| 4 | `Skill: dev-integrate` (v2) | type check + dev-validate pass |
-| 5 | `Skill: git-pr` | final non-draft integration PR created |
-| 6 | `Skill: pr-iterate` | LGTM or max iterations |
+| 2 | `Skill: dev-decompose --child-split` | flow.json v2.1 + integration branch + child issues (decompose phase done) |
+| 3 | `bash orchestrate.sh` | batch_loop → integrate → final_pr → pr_iterate decision loop 完走 |
+
+**Stage 3 (issue #112) 以降**、旧 Step 3-6 (run-batch-loop / dev-integrate / git-pr /
+pr-iterate) は `dev-flow/scripts/orchestrate.sh` の **bash decision loop** に集約された。
+orchestrate は `flow-decide.sh` (decision engine, read-only) を駆動し、各 phase の決定論的
+ソースを `build-envelope.sh` で decision-input envelope に純変換し、`flow-update.sh` で
+flow.json の phase state を更新する。下記 § orchestrate decision loop を参照。
+
+decompose phase の done 化責務は **dev-decompose が内包する** (Step 8 validate 成功直後に
+`flow-update phase decompose done` を呼ぶ)。そのため orchestrate は **batch_loop 起点**で開始する。
 
 ## Step 1: Issue Analysis
 
@@ -40,21 +46,47 @@ Output checks:
 - `children[]` count <= `max_child_issues_hard` (12)
 - All children are real GitHub issues (`gh issue view`)
 
-## Step 3: Batch Loop
+## Step 3: Orchestrate decision loop
 
 ```bash
-INTEGRATION_BRANCH=$(jq -r '.integration_branch.name' $FLOW_STATE)
-BATCHES_JSON=$(mktemp)
-jq '.batches' $FLOW_STATE > $BATCHES_JSON
-
-$SKILLS_DIR/_shared/scripts/run-batch-loop.sh \
-  --batches-json $BATCHES_JSON \
-  --issue-runner "Skill: dev-flow {issue} --force-single --base $INTEGRATION_BRANCH --lang ja" \
-  --on-success "$SKILLS_DIR/dev-flow/scripts/auto-merge-child.sh {issue} --base $INTEGRATION_BRANCH --flow-state $FLOW_STATE" \
-  --state-file $WORKTREE_BASE/.claude/batch-state.json
+$SKILLS_DIR/dev-flow/scripts/orchestrate.sh \
+  --flow-state $FLOW_STATE \
+  --worktree $WORKTREE_BASE \
+  --base $BASE --lang ja \
+  [--allow-partial]
 ```
 
-### Per-child execution flow
+orchestrate は次の decision loop を回す (batch_loop 起点):
+
+```
+phase ∈ {batch_loop, integrate, final_pr, pr_iterate}:
+  1. flow-update phase <p> running
+  2. <p> の決定論的ソースを取得 (skill 実行 or run-batch-loop)
+  3. build-envelope.sh <p> ... → decision-input envelope
+  4. flow-decide.sh --phase <p> --result <envelope> → {next_action}
+  5. next_action:
+       skill    → flow-update phase <p> done; 次 phase へ
+       retry    → flow-update phase <target> running --attempts +1; 再実行 (Q5)
+       complete → flow-update phase <p> done; status integrated; exit 0
+       abort    → flow-update phase <p> failed; status failed; exit 2
+```
+
+各 phase の envelope 変換規則 (issue #112 Q2):
+
+| phase | 入力ソース | envelope |
+|---|---|---|
+| batch_loop | run-batch-loop.sh JSON + flow.json children[] | `completed_children = issues_succeeded`、`failed_children = issues_failed + (results[]\|skipped\|length)` (skipped は results[] から集約、`completed+failed == children\|length` 保証) |
+| integrate | dev-integrate `{type_check, validation}` | `tests_pass = (type_check ∈ {passed,skipped}) && (validation==passed)`、`merge_conflicts = []` |
+| final_pr | git-pr `{pr_url}` + orchestrate の `gh pr checks` polling | `{pr_url, ci_status}` (ci_status は polling 解決、最大 30×20s=10 分、timeout→failed) |
+| pr_iterate | iterate.json `{status, current_iteration}` | `decision = status` (in_progress は abort)、`iterations = current_iteration` |
+
+`--allow-partial` は default off。明示時のみ batch_loop で `failed_children > 0` でも
+integrate へ進む (Q11)。
+
+### Per-child execution flow (orchestrate batch_loop phase 内部)
+
+orchestrate の **batch_loop** phase は内部で `run-batch-loop.sh` を `--fail-fast` で実行し、
+各 child の `--on-success` で `auto-merge-child.sh` を呼ぶ。フローは従来と同じ:
 
 For each child issue:
 
@@ -89,9 +121,10 @@ $SKILLS_DIR/_shared/scripts/run-batch-loop.sh \
 
 For loose-coupled batches (independent endpoints all in one parallel batch), omit `--fail-fast` so that one bad endpoint doesn't block the rest.
 
-## Step 4: Integration Validation
+## orchestrate integrate phase (旧 Step 4): Integration Validation
 
-After all children are merged into the integration branch, run dev-integrate:
+batch_loop で全 children が integration branch に merge された後、orchestrate は
+`dev-integrate` を実行する (手動相当コマンド):
 
 ```bash
 Skill: dev-integrate --flow-state $FLOW_STATE
@@ -106,7 +139,7 @@ dev-integrate (v2) does:
 
 No Kahn-sort, no merge-subtask logic — children are already merged.
 
-## Step 5: Final Integration PR
+## orchestrate final_pr phase (旧 Step 5): Final Integration PR
 
 ```bash
 Skill: git-pr $PARENT --base $BASE --lang ja --worktree $INTEGRATION_WORKTREE
@@ -114,13 +147,17 @@ Skill: git-pr $PARENT --base $BASE --lang ja --worktree $INTEGRATION_WORKTREE
 
 This is a **non-draft** PR (final review by humans). All the child PR
 diffs are already on the integration branch, so this final PR's diff
-equals the cumulative child changes.
+equals the cumulative child changes. orchestrate はこの後 `gh pr checks` を polling して
+ci_status を解決し、`passed` のときのみ pr_iterate へ進む (Q12)。
 
-## Step 6: pr-iterate
+## orchestrate pr_iterate phase (旧 Step 6): pr-iterate
 
 ```bash
-Task: pr-iterate $FINAL_PR_URL --max-iterations $MAX
+Skill: pr-iterate $FINAL_PR_URL
 ```
+
+orchestrate は pr-iterate 完了後に iterate.json `{status, current_iteration}` を読み、
+`decision = status` (lgtm / max_reached で完了、failed で abort) に変換する。
 
 ## Child PR draft flag
 

--- a/dev-flow/scripts/build-envelope.bats
+++ b/dev-flow/scripts/build-envelope.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# Tests for dev-flow/scripts/build-envelope.sh
+#
+# Run with: bats dev-flow/scripts/build-envelope.bats
+# Skipped if `bats` not installed; CI runs them via tests/run-all-bats.sh.
+
+setup() {
+    SKILLS_REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCRIPT="$SKILLS_REPO/dev-flow/scripts/build-envelope.sh"
+    DECIDE="$SKILLS_REPO/_lib/scripts/flow-decide.sh"
+    FLOW="$BATS_TMPDIR/flow.json"
+    cat > "$FLOW" << 'EOF'
+{
+  "version": "2.1.0",
+  "issue": 112,
+  "status": "running",
+  "children": [{"issue": 201}, {"issue": 202}, {"issue": 203}],
+  "batches": [],
+  "phases": [
+    {"name": "decompose",  "status": "done",    "attempts": 0, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "batch_loop", "status": "running", "attempts": 1, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "integrate",  "status": "pending", "attempts": 0, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "final_pr",   "status": "pending", "attempts": 0, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "pr_iterate", "status": "pending", "attempts": 0, "retry_target": null, "failed_at": null, "score": null}
+  ]
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# batch_loop
+# ---------------------------------------------------------------------------
+
+@test "batch_loop: maps issues_succeeded/failed to completed/failed_children" {
+    run "$SCRIPT" batch_loop --flow-state "$FLOW" \
+        --batch-result '{"issues_succeeded":2,"issues_failed":1,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"failed"},{"issue":203,"status":"success"}]}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.phase')" = "batch_loop" ]
+    [ "$(echo "$output" | jq -r '.completed_children')" = "2" ]
+    [ "$(echo "$output" | jq -r '.failed_children')" = "1" ]
+}
+
+@test "batch_loop: skipped is aggregated from results[] into failed_children (Round3-c)" {
+    run "$SCRIPT" batch_loop --flow-state "$FLOW" \
+        --batch-result '{"issues_succeeded":1,"issues_failed":1,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"failed"},{"issue":203,"status":"skipped"}]}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.completed_children')" = "1" ]
+    # failed = issues_failed(1) + skipped(1) = 2
+    [ "$(echo "$output" | jq -r '.failed_children')" = "2" ]
+}
+
+@test "batch_loop: invariant completed+failed == children fails when inconsistent" {
+    run "$SCRIPT" batch_loop --flow-state "$FLOW" \
+        --batch-result '{"issues_succeeded":1,"issues_failed":0,"results":[]}'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"inconsistent"* ]]
+}
+
+@test "batch_loop: requires --flow-state" {
+    run "$SCRIPT" batch_loop --batch-result '{"issues_succeeded":3,"issues_failed":0,"results":[]}'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--flow-state"* ]]
+}
+
+@test "batch_loop: missing required fields fails" {
+    run "$SCRIPT" batch_loop --flow-state "$FLOW" --batch-result '{"status":"ok"}'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"missing required fields"* ]]
+}
+
+@test "batch_loop: envelope feeds flow-decide -> dev-integrate" {
+    env=$("$SCRIPT" batch_loop --flow-state "$FLOW" \
+        --batch-result '{"issues_succeeded":3,"issues_failed":0,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"success"},{"issue":203,"status":"success"}]}')
+    echo "$env" | jq -c . > "$BATS_TMPDIR/env.json"
+    run "$DECIDE" --flow-state "$FLOW" --phase batch_loop --result "$BATS_TMPDIR/env.json"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next_action')" = "skill" ]
+    [ "$(echo "$output" | jq -r '.skill')" = "dev-integrate" ]
+}
+
+# ---------------------------------------------------------------------------
+# integrate
+# ---------------------------------------------------------------------------
+
+@test "integrate: type_check=passed + validation=passed -> tests_pass true" {
+    run "$SCRIPT" integrate --integrate-result '{"status":"integrated","type_check":"passed","validation":"passed"}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.phase')" = "integrate" ]
+    [ "$(echo "$output" | jq -r '.tests_pass')" = "true" ]
+    [ "$(echo "$output" | jq -c '.merge_conflicts')" = "[]" ]
+}
+
+@test "integrate: type_check=skipped + validation=passed -> tests_pass true" {
+    run "$SCRIPT" integrate --integrate-result '{"type_check":"skipped","validation":"passed"}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.tests_pass')" = "true" ]
+}
+
+@test "integrate: type_check=failed -> tests_pass false" {
+    run "$SCRIPT" integrate --integrate-result '{"type_check":"failed","validation":"passed"}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.tests_pass')" = "false" ]
+}
+
+@test "integrate: validation=failed -> tests_pass false" {
+    run "$SCRIPT" integrate --integrate-result '{"type_check":"passed","validation":"failed"}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.tests_pass')" = "false" ]
+}
+
+@test "integrate: merge_conflicts always empty (auto-merge-child completed merges)" {
+    env=$("$SCRIPT" integrate --integrate-result '{"type_check":"passed","validation":"passed"}')
+    echo "$env" | jq -c . > "$BATS_TMPDIR/env.json"
+    run "$DECIDE" --flow-state "$FLOW" --phase integrate --result "$BATS_TMPDIR/env.json"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next_action')" = "skill" ]
+    [ "$(echo "$output" | jq -r '.skill')" = "git-pr" ]
+}
+
+# ---------------------------------------------------------------------------
+# final_pr
+# ---------------------------------------------------------------------------
+
+@test "final_pr: maps git-pr pr_url + ci_status arg" {
+    run "$SCRIPT" final_pr --pr-result '{"pr_url":"https://github.com/x/y/pull/5","title":"t","branch":"b"}' --ci-status passed
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.phase')" = "final_pr" ]
+    [ "$(echo "$output" | jq -r '.pr_url')" = "https://github.com/x/y/pull/5" ]
+    [ "$(echo "$output" | jq -r '.ci_status')" = "passed" ]
+}
+
+@test "final_pr: ci pending then passed (polling mock)" {
+    # pending envelope -> flow-decide abort
+    env_pending=$("$SCRIPT" final_pr --pr-result '{"pr_url":"https://github.com/x/y/pull/5"}' --ci-status pending)
+    [ "$(echo "$env_pending" | jq -r '.ci_status')" = "pending" ]
+    # passed envelope -> flow-decide pr-iterate
+    env_passed=$("$SCRIPT" final_pr --pr-result '{"pr_url":"https://github.com/x/y/pull/5"}' --ci-status passed)
+    echo "$env_passed" | jq -c . > "$BATS_TMPDIR/env.json"
+    run "$DECIDE" --flow-state "$FLOW" --phase final_pr --result "$BATS_TMPDIR/env.json"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.skill')" = "pr-iterate" ]
+}
+
+@test "final_pr: invalid ci-status rejected" {
+    run "$SCRIPT" final_pr --pr-result '{"pr_url":"https://github.com/x/y/pull/5"}' --ci-status timeout
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ci-status"* ]]
+}
+
+@test "final_pr: requires --ci-status" {
+    run "$SCRIPT" final_pr --pr-result '{"pr_url":"https://github.com/x/y/pull/5"}'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--ci-status"* ]]
+}
+
+@test "final_pr: missing pr_url fails" {
+    run "$SCRIPT" final_pr --pr-result '{"title":"t"}' --ci-status passed
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"pr_url"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# pr_iterate
+# ---------------------------------------------------------------------------
+
+@test "pr_iterate: maps status->decision, current_iteration->iterations" {
+    run "$SCRIPT" pr_iterate --iterate-state '{"version":"1.0","status":"lgtm","current_iteration":3}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.phase')" = "pr_iterate" ]
+    [ "$(echo "$output" | jq -r '.decision')" = "lgtm" ]
+    [ "$(echo "$output" | jq -r '.iterations')" = "3" ]
+}
+
+@test "pr_iterate: max_reached decision" {
+    run "$SCRIPT" pr_iterate --iterate-state '{"status":"max_reached","current_iteration":10}'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.decision')" = "max_reached" ]
+}
+
+@test "pr_iterate: in_progress aborts (must not build until terminal)" {
+    run "$SCRIPT" pr_iterate --iterate-state '{"status":"in_progress","current_iteration":2}'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"in_progress"* ]]
+}
+
+@test "pr_iterate: envelope feeds flow-decide -> complete on lgtm" {
+    env=$("$SCRIPT" pr_iterate --iterate-state '{"status":"lgtm","current_iteration":2}')
+    echo "$env" | jq -c . > "$BATS_TMPDIR/env.json"
+    run "$DECIDE" --flow-state "$FLOW" --phase pr_iterate --result "$BATS_TMPDIR/env.json"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.next_action')" = "complete" ]
+}
+
+# ---------------------------------------------------------------------------
+# generic
+# ---------------------------------------------------------------------------
+
+@test "unknown phase fails" {
+    run "$SCRIPT" decompose --batch-result '{}'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown phase"* ]]
+}
+
+@test "no phase arg fails" {
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "accepts file path for result input" {
+    echo '{"issues_succeeded":3,"issues_failed":0,"results":[]}' > "$BATS_TMPDIR/br.json"
+    run "$SCRIPT" batch_loop --flow-state "$FLOW" --batch-result "$BATS_TMPDIR/br.json"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.completed_children')" = "3" ]
+}

--- a/dev-flow/scripts/build-envelope.sh
+++ b/dev-flow/scripts/build-envelope.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# build-envelope.sh - Pure conversion: skill 実行結果 → decision-input envelope.
+#
+# child-split mode の top-level orchestration で、各 phase の決定論的ソース
+# (run-batch-loop.sh JSON / dev-integrate JSON / git-pr JSON / iterate.json)
+# を _lib/scripts/flow-decide.sh が消費する decision-input envelope
+# (_lib/schemas/decision-input.schema.json) に変換する **副作用なしの純関数**。
+#
+# invoke-skill-poc.sh の raw text は parse しない。常に決定論的ソース
+# (JSON / state ファイル) のみを入力とする。
+#
+# Usage:
+#   build-envelope.sh batch_loop --batch-result JSON_OR_FILE --flow-state PATH
+#   build-envelope.sh integrate  --integrate-result JSON_OR_FILE
+#   build-envelope.sh final_pr   --pr-result JSON_OR_FILE --ci-status STATUS
+#   build-envelope.sh pr_iterate --iterate-state JSON_OR_FILE
+#
+# Output (stdout, single-line JSON): decision-input envelope (phase 別 oneOf branch)
+#
+# Exit codes:
+#   0 - envelope successfully produced
+#   1 - invalid input / missing field / inconsistent data / unknown phase
+#
+# Conversion table (issue #112 Q2):
+#   batch_loop : run-batch-loop.sh JSON + flow.json children[]
+#       completed_children = issues_succeeded
+#       failed_children    = issues_failed + (results[]|select(.status=="skipped")|length)
+#       invariant: completed_children + failed_children == (flow.json.children|length)
+#   integrate  : dev-integrate JSON {type_check, validation}
+#       tests_pass      = (type_check ∈ {passed,skipped}) && (validation == passed)
+#       merge_conflicts = []   (merge は batch_loop の auto-merge-child で完結済)
+#   final_pr   : git-pr JSON {pr_url} + ci_status (orchestrate の gh pr checks polling 解決)
+#       {pr_url, ci_status}   (純関数: ci_status は引数で受取る)
+#   pr_iterate : iterate.json {status, current_iteration}
+#       decision   = status   (in_progress は来ない前提、来たら abort)
+#       iterations = current_iteration
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+
+PHASE="${1:-}"
+shift || true
+
+[[ -n "$PHASE" ]] || die_json "phase argument required (batch_loop|integrate|final_pr|pr_iterate)" 1
+
+# Resolve a --opt value that may be inline JSON or a file path.
+resolve_json() {
+    local val="$1"
+    if [[ -f "$val" ]]; then
+        cat "$val"
+    else
+        printf '%s' "$val"
+    fi
+}
+
+BATCH_RESULT=""
+INTEGRATE_RESULT=""
+PR_RESULT=""
+CI_STATUS=""
+ITERATE_STATE=""
+FLOW_STATE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --batch-result) BATCH_RESULT="$2"; shift 2 ;;
+        --integrate-result) INTEGRATE_RESULT="$2"; shift 2 ;;
+        --pr-result) PR_RESULT="$2"; shift 2 ;;
+        --ci-status) CI_STATUS="$2"; shift 2 ;;
+        --iterate-state) ITERATE_STATE="$2"; shift 2 ;;
+        --flow-state) FLOW_STATE="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,46p' "$0"
+            exit 0
+            ;;
+        *) die_json "Unknown option: $1" 1 ;;
+    esac
+done
+
+case "$PHASE" in
+    batch_loop)
+        [[ -n "$BATCH_RESULT" ]] || die_json "batch_loop requires --batch-result" 1
+        [[ -n "$FLOW_STATE" ]] || die_json "batch_loop requires --flow-state" 1
+        [[ -f "$FLOW_STATE" ]] || die_json "flow.json not found: $FLOW_STATE" 1
+
+        RESULT="$(resolve_json "$BATCH_RESULT")"
+        if ! echo "$RESULT" | jq -e . >/dev/null 2>&1; then
+            die_json "--batch-result is not valid JSON" 1
+        fi
+        # run-batch-loop.sh emits issues_succeeded / issues_failed / results[].
+        if ! echo "$RESULT" | jq -e '.issues_succeeded != null and .issues_failed != null and (.results | type == "array")' >/dev/null 2>&1; then
+            die_json "batch_loop result missing required fields (issues_succeeded, issues_failed, results[])" 1
+        fi
+
+        COMPLETED=$(echo "$RESULT" | jq '.issues_succeeded')
+        # skipped は top-level キーでなく results[] から集約 (Round3-c)
+        SKIPPED=$(echo "$RESULT" | jq '[.results[] | select(.status == "skipped")] | length')
+        FAILED_RAW=$(echo "$RESULT" | jq '.issues_failed')
+        FAILED=$((FAILED_RAW + SKIPPED))
+
+        TOTAL_CHILDREN=$(jq '.children | length' "$FLOW_STATE")
+        if (( COMPLETED + FAILED != TOTAL_CHILDREN )); then
+            die_json "batch_loop envelope inconsistent: completed($COMPLETED) + failed($FAILED) [= issues_failed($FAILED_RAW) + skipped($SKIPPED)] != children($TOTAL_CHILDREN)" 1
+        fi
+
+        jq -n \
+            --argjson completed "$COMPLETED" \
+            --argjson failed "$FAILED" \
+            '{phase: "batch_loop", completed_children: $completed, failed_children: $failed}'
+        ;;
+
+    integrate)
+        [[ -n "$INTEGRATE_RESULT" ]] || die_json "integrate requires --integrate-result" 1
+        RESULT="$(resolve_json "$INTEGRATE_RESULT")"
+        if ! echo "$RESULT" | jq -e . >/dev/null 2>&1; then
+            die_json "--integrate-result is not valid JSON" 1
+        fi
+        if ! echo "$RESULT" | jq -e '.type_check != null and .validation != null' >/dev/null 2>&1; then
+            die_json "integrate result missing required fields (type_check, validation)" 1
+        fi
+
+        TYPE_CHECK=$(echo "$RESULT" | jq -r '.type_check')
+        VALIDATION=$(echo "$RESULT" | jq -r '.validation')
+
+        # tests_pass = (type_check ∈ {passed,skipped}) && (validation == passed)
+        TESTS_PASS="false"
+        if [[ "$TYPE_CHECK" == "passed" || "$TYPE_CHECK" == "skipped" ]] && [[ "$VALIDATION" == "passed" ]]; then
+            TESTS_PASS="true"
+        fi
+
+        # merge は batch_loop の auto-merge-child で完結済 → integrate では発生しない
+        jq -n \
+            --argjson tests_pass "$TESTS_PASS" \
+            '{phase: "integrate", merge_conflicts: [], tests_pass: $tests_pass}'
+        ;;
+
+    final_pr)
+        [[ -n "$PR_RESULT" ]] || die_json "final_pr requires --pr-result" 1
+        [[ -n "$CI_STATUS" ]] || die_json "final_pr requires --ci-status (resolved by orchestrate polling)" 1
+        RESULT="$(resolve_json "$PR_RESULT")"
+        if ! echo "$RESULT" | jq -e . >/dev/null 2>&1; then
+            die_json "--pr-result is not valid JSON" 1
+        fi
+        PR_URL=$(echo "$RESULT" | jq -r '.pr_url // empty')
+        [[ -n "$PR_URL" ]] || die_json "final_pr result missing pr_url" 1
+
+        # decision-input.schema.json enum: passed | failed | pending | unknown.
+        # polling timeout は orchestrate 側で ci_status=failed に正規化して渡す
+        # (timeout は schema enum 外。flow-decide は ci_status!=passed で abort するため等価)。
+        case "$CI_STATUS" in
+            passed|failed|pending|unknown) ;;
+            *) die_json "final_pr --ci-status must be one of: passed|failed|pending|unknown (got: $CI_STATUS)" 1 ;;
+        esac
+
+        jq -n \
+            --arg pr_url "$PR_URL" \
+            --arg ci_status "$CI_STATUS" \
+            '{phase: "final_pr", pr_url: $pr_url, ci_status: $ci_status}'
+        ;;
+
+    pr_iterate)
+        [[ -n "$ITERATE_STATE" ]] || die_json "pr_iterate requires --iterate-state" 1
+        RESULT="$(resolve_json "$ITERATE_STATE")"
+        if ! echo "$RESULT" | jq -e . >/dev/null 2>&1; then
+            die_json "--iterate-state is not valid JSON" 1
+        fi
+        if ! echo "$RESULT" | jq -e '.status != null and .current_iteration != null' >/dev/null 2>&1; then
+            die_json "pr_iterate state missing required fields (status, current_iteration)" 1
+        fi
+
+        STATUS=$(echo "$RESULT" | jq -r '.status')
+        ITERATIONS=$(echo "$RESULT" | jq -r '.current_iteration')
+
+        # decision = status. in_progress は来ない前提 (来たら abort)。
+        if [[ "$STATUS" == "in_progress" ]]; then
+            die_json "pr_iterate state still in_progress (current_iteration=$ITERATIONS); orchestrate must not build envelope until pr-iterate terminates." 1
+        fi
+        case "$STATUS" in
+            lgtm|max_reached|failed) ;;
+            *) die_json "pr_iterate state.status invalid: $STATUS (valid: lgtm|max_reached|failed; in_progress aborts)" 1 ;;
+        esac
+
+        jq -n \
+            --arg decision "$STATUS" \
+            --argjson iterations "$ITERATIONS" \
+            '{phase: "pr_iterate", decision: $decision, iterations: $iterations}'
+        ;;
+
+    *)
+        die_json "Unknown phase: $PHASE (valid: batch_loop|integrate|final_pr|pr_iterate; decompose は dev-decompose が内包)" 1
+        ;;
+esac

--- a/dev-flow/scripts/orchestrate.bats
+++ b/dev-flow/scripts/orchestrate.bats
@@ -17,6 +17,15 @@ setup() {
     write_flow
 }
 
+# bats 1.2's `run` merges stderr into $output. orchestrate.sh logs progress to
+# stderr, which corrupts `jq "$output"`. `orch` runs the script via bash -c with
+# stderr discarded, so $output holds only the clean JSON result emitted on stdout.
+# Tests that assert die_json diagnostics (written to stderr) use plain `run`
+# instead. ORCHESTRATE_DRY_* env vars are inherited, so export them before orch.
+orch() {
+    run bash -c '"$0" "$@" 2>/dev/null' "$SCRIPT" "$@"
+}
+
 # Write a fresh flow.json with N completed children, decompose done, rest pending.
 write_flow() {
     cat > "$FLOW" << 'EOF'
@@ -43,7 +52,7 @@ EOF
 }
 
 @test "dry-run completes all 4 phases (batch_loop->integrate->final_pr->pr_iterate)" {
-    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq -r '.status')" = "completed" ]
     # all phases done
@@ -59,6 +68,7 @@ EOF
 }
 
 @test "rejects flow.json version != 2.1.0 (no-backcompat)" {
+    # die_json writes to stderr; plain `run` (which merges) captures it.
     jq '.version = "2.0.0"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
     run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -ne 0 ]
@@ -66,6 +76,7 @@ EOF
 }
 
 @test "aborts when decompose phase not done" {
+    # die_json writes to stderr; plain `run` (which merges) captures it.
     jq '(.phases[] | select(.name=="decompose")).status = "pending"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
     run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -ne 0 ]
@@ -74,22 +85,22 @@ EOF
 
 @test "resumes from integrate when batch_loop already done" {
     jq '(.phases[] | select(.name=="batch_loop")).status = "done"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
-    run env "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq -r '.status')" = "completed" ]
 }
 
 @test "all phases done -> completed no-op" {
     jq '.phases |= map(.status = "done")' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
-    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq -r '.status')" = "completed" ]
 }
 
 @test "abort when batch_loop has failed children and no --allow-partial" {
     echo '{"issues_succeeded":1,"issues_failed":1,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"failed"}]}' > "$BATS_TMPDIR/br.json"
-    run env ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json" \
-        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    export ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json"
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 2 ]
     [ "$(echo "$output" | jq -r '.status')" = "aborted" ]
     [ "$(echo "$output" | jq -r '.phase')" = "batch_loop" ]
@@ -99,16 +110,16 @@ EOF
 
 @test "continue past partial batch_loop with --allow-partial" {
     echo '{"issues_succeeded":1,"issues_failed":1,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"failed"}]}' > "$BATS_TMPDIR/br.json"
-    run env ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json" \
-        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --allow-partial --dry-run
+    export ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json"
+    orch --flow-state "$FLOW" --worktree "$WT" --allow-partial --dry-run
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq -r '.status')" = "completed" ]
 }
 
 @test "abort when final_pr CI status is not passed" {
     jq '(.phases[]|select(.name=="batch_loop")).status="done" | (.phases[]|select(.name=="integrate")).status="done"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
-    run env ORCHESTRATE_DRY_CI_STATUS="failed" \
-        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    export ORCHESTRATE_DRY_CI_STATUS="failed"
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 2 ]
     [ "$(echo "$output" | jq -r '.phase')" = "final_pr" ]
     [[ "$(echo "$output" | jq -r '.reason')" == *"CI status=failed"* ]]
@@ -117,14 +128,14 @@ EOF
 @test "batch_loop skipped children counted as failed (consistency with build-envelope)" {
     # 1 success + 1 skipped: failed_children=1 -> abort without --allow-partial
     echo '{"issues_succeeded":1,"issues_failed":0,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"skipped"}]}' > "$BATS_TMPDIR/br.json"
-    run env ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json" \
-        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    export ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json"
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 2 ]
     [ "$(echo "$output" | jq -r '.phase')" = "batch_loop" ]
 }
 
 @test "marks phases done in order on success" {
-    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 0 ]
     [ "$(jq -r '.phases[]|select(.name=="batch_loop").status' "$FLOW")" = "done" ]
     [ "$(jq -r '.phases[]|select(.name=="integrate").status' "$FLOW")" = "done" ]
@@ -138,7 +149,7 @@ EOF
     # Seed a failed batch_loop carrying a non-abort retry_target (prior-run residue).
     jq '(.phases[]|select(.name=="batch_loop")) |= (.status="failed" | .retry_target="batch_loop" | .attempts=0)' \
         "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
-    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq -r '.status')" = "completed" ]
     # retry bumped attempts before re-running the phase
@@ -149,7 +160,7 @@ EOF
 @test "resume from failed phase at max attempts aborts (retry NOT fired)" {
     jq '(.phases[]|select(.name=="batch_loop")) |= (.status="failed" | .retry_target="batch_loop" | .attempts=3)' \
         "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
-    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 2 ]
     [ "$(echo "$output" | jq -r '.status')" = "aborted" ]
     [[ "$(echo "$output" | jq -r '.reason')" == *"max retry"* ]]
@@ -160,7 +171,7 @@ EOF
 @test "resume from failed phase with retry_target=abort aborts immediately" {
     jq '(.phases[]|select(.name=="batch_loop")) |= (.status="failed" | .retry_target="abort" | .attempts=0)' \
         "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
-    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    orch --flow-state "$FLOW" --worktree "$WT" --dry-run
     [ "$status" -eq 2 ]
     [ "$(echo "$output" | jq -r '.status')" = "aborted" ]
     # not re-run: still failed, attempts untouched

--- a/dev-flow/scripts/orchestrate.bats
+++ b/dev-flow/scripts/orchestrate.bats
@@ -131,3 +131,38 @@ EOF
     [ "$(jq -r '.phases[]|select(.name=="final_pr").status' "$FLOW")" = "done" ]
     [ "$(jq -r '.phases[]|select(.name=="pr_iterate").status' "$FLOW")" = "done" ]
 }
+
+# --- Resume-from-failed / retry (Q5) ---
+
+@test "resume from failed batch_loop with retry_target fires retry, bumps attempts, completes" {
+    # Seed a failed batch_loop carrying a non-abort retry_target (prior-run residue).
+    jq '(.phases[]|select(.name=="batch_loop")) |= (.status="failed" | .retry_target="batch_loop" | .attempts=0)' \
+        "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.status')" = "completed" ]
+    # retry bumped attempts before re-running the phase
+    [ "$(jq -r '.phases[]|select(.name=="batch_loop").attempts' "$FLOW")" = "1" ]
+    [ "$(jq -r '.phases[]|select(.name=="batch_loop").status' "$FLOW")" = "done" ]
+}
+
+@test "resume from failed phase at max attempts aborts (retry NOT fired)" {
+    jq '(.phases[]|select(.name=="batch_loop")) |= (.status="failed" | .retry_target="batch_loop" | .attempts=3)' \
+        "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 2 ]
+    [ "$(echo "$output" | jq -r '.status')" = "aborted" ]
+    [[ "$(echo "$output" | jq -r '.reason')" == *"max retry"* ]]
+    # attempts must NOT be bumped past the cap
+    [ "$(jq -r '.phases[]|select(.name=="batch_loop").attempts' "$FLOW")" = "3" ]
+}
+
+@test "resume from failed phase with retry_target=abort aborts immediately" {
+    jq '(.phases[]|select(.name=="batch_loop")) |= (.status="failed" | .retry_target="abort" | .attempts=0)' \
+        "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 2 ]
+    [ "$(echo "$output" | jq -r '.status')" = "aborted" ]
+    # not re-run: still failed, attempts untouched
+    [ "$(jq -r '.phases[]|select(.name=="batch_loop").attempts' "$FLOW")" = "0" ]
+}

--- a/dev-flow/scripts/orchestrate.bats
+++ b/dev-flow/scripts/orchestrate.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# Tests for dev-flow/scripts/orchestrate.sh (child-split decision loop, Stage 3)
+#
+# Run with: bats dev-flow/scripts/orchestrate.bats
+# Skipped if `bats` not installed; CI runs them via tests/run-all-bats.sh.
+#
+# Uses --dry-run + ORCHESTRATE_DRY_* hooks so no real skills/network are invoked.
+# Phase transitions go through the real flow-decide.sh + build-envelope.sh +
+# flow-update.sh, exercising the full deterministic decision loop.
+
+setup() {
+    SKILLS_REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCRIPT="$SKILLS_REPO/dev-flow/scripts/orchestrate.sh"
+    WT="$BATS_TMPDIR/wt"
+    mkdir -p "$WT/.claude"
+    FLOW="$BATS_TMPDIR/flow.json"
+    write_flow
+}
+
+# Write a fresh flow.json with N completed children, decompose done, rest pending.
+write_flow() {
+    cat > "$FLOW" << 'EOF'
+{
+  "version": "2.1.0",
+  "issue": 112,
+  "status": "running",
+  "integration_branch": {"name": "integration/issue-112-x", "base": "dev"},
+  "children": [{"issue": 201, "status": "completed"}, {"issue": 202, "status": "completed"}],
+  "batches": [{"batch": 1, "mode": "serial", "children": [201, 202]}],
+  "phases": [
+    {"name": "decompose",  "status": "done",    "attempts": 0, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "batch_loop", "status": "pending", "attempts": 0, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "integrate",  "status": "pending", "attempts": 0, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "final_pr",   "status": "pending", "attempts": 0, "retry_target": null, "failed_at": null, "score": null},
+    {"name": "pr_iterate", "status": "pending", "attempts": 0, "retry_target": null, "failed_at": null, "score": null}
+  ],
+  "final_pr": null,
+  "config": {"strategy": "tdd", "depth": "standard", "lang": "ja", "base_branch": "dev", "env_mode": "hardlink"},
+  "created_at": "2026-05-22T00:00:00Z",
+  "updated_at": "2026-05-22T00:00:00Z"
+}
+EOF
+}
+
+@test "dry-run completes all 4 phases (batch_loop->integrate->final_pr->pr_iterate)" {
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.status')" = "completed" ]
+    # all phases done
+    [ "$(jq -r '[.phases[] | select(.status != "done")] | length' "$FLOW")" = "0" ]
+    [ "$(jq -r '.status' "$FLOW")" = "integrated" ]
+}
+
+@test "requires --flow-state and --worktree" {
+    run "$SCRIPT" --worktree "$WT" --dry-run
+    [ "$status" -ne 0 ]
+    run "$SCRIPT" --flow-state "$FLOW" --dry-run
+    [ "$status" -ne 0 ]
+}
+
+@test "rejects flow.json version != 2.1.0 (no-backcompat)" {
+    jq '.version = "2.0.0"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"2.1.0"* ]]
+}
+
+@test "aborts when decompose phase not done" {
+    jq '(.phases[] | select(.name=="decompose")).status = "pending"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"decompose"* ]]
+}
+
+@test "resumes from integrate when batch_loop already done" {
+    jq '(.phases[] | select(.name=="batch_loop")).status = "done"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run env "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.status')" = "completed" ]
+}
+
+@test "all phases done -> completed no-op" {
+    jq '.phases |= map(.status = "done")' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.status')" = "completed" ]
+}
+
+@test "abort when batch_loop has failed children and no --allow-partial" {
+    echo '{"issues_succeeded":1,"issues_failed":1,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"failed"}]}' > "$BATS_TMPDIR/br.json"
+    run env ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json" \
+        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 2 ]
+    [ "$(echo "$output" | jq -r '.status')" = "aborted" ]
+    [ "$(echo "$output" | jq -r '.phase')" = "batch_loop" ]
+    [ "$(jq -r '.status' "$FLOW")" = "failed" ]
+    [ "$(jq -r '.phases[]|select(.name=="batch_loop").status' "$FLOW")" = "failed" ]
+}
+
+@test "continue past partial batch_loop with --allow-partial" {
+    echo '{"issues_succeeded":1,"issues_failed":1,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"failed"}]}' > "$BATS_TMPDIR/br.json"
+    run env ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json" \
+        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --allow-partial --dry-run
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.status')" = "completed" ]
+}
+
+@test "abort when final_pr CI status is not passed" {
+    jq '(.phases[]|select(.name=="batch_loop")).status="done" | (.phases[]|select(.name=="integrate")).status="done"' "$FLOW" > "$FLOW.tmp" && mv "$FLOW.tmp" "$FLOW"
+    run env ORCHESTRATE_DRY_CI_STATUS="failed" \
+        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 2 ]
+    [ "$(echo "$output" | jq -r '.phase')" = "final_pr" ]
+    [[ "$(echo "$output" | jq -r '.reason')" == *"CI status=failed"* ]]
+}
+
+@test "batch_loop skipped children counted as failed (consistency with build-envelope)" {
+    # 1 success + 1 skipped: failed_children=1 -> abort without --allow-partial
+    echo '{"issues_succeeded":1,"issues_failed":0,"results":[{"issue":201,"status":"success"},{"issue":202,"status":"skipped"}]}' > "$BATS_TMPDIR/br.json"
+    run env ORCHESTRATE_DRY_BATCH_RESULT="$BATS_TMPDIR/br.json" \
+        "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 2 ]
+    [ "$(echo "$output" | jq -r '.phase')" = "batch_loop" ]
+}
+
+@test "marks phases done in order on success" {
+    run "$SCRIPT" --flow-state "$FLOW" --worktree "$WT" --dry-run
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.phases[]|select(.name=="batch_loop").status' "$FLOW")" = "done" ]
+    [ "$(jq -r '.phases[]|select(.name=="integrate").status' "$FLOW")" = "done" ]
+    [ "$(jq -r '.phases[]|select(.name=="final_pr").status' "$FLOW")" = "done" ]
+    [ "$(jq -r '.phases[]|select(.name=="pr_iterate").status' "$FLOW")" = "done" ]
+}

--- a/dev-flow/scripts/orchestrate.sh
+++ b/dev-flow/scripts/orchestrate.sh
@@ -242,6 +242,42 @@ while (( iter < MAX_ITER )); do
     iter=$((iter + 1))
     log "iteration $iter: phase=$PHASE"
 
+    # Resume-from-failed guard (Q5): if this phase still carries a `failed`
+    # status from a prior orchestrate run, consult flow-decide BEFORE we
+    # overwrite the status to `running`. flow-decide's retry/abort shortcut is
+    # gated on `status == "failed"`, so marking running first would silently
+    # swallow the retry decision (and re-run / done-ify a failed phase).
+    if [[ "$(phase_status "$PHASE")" == "failed" ]]; then
+        # flow-decide validates result.phase == --phase; the retry/abort
+        # shortcut is gated on flow.json status, so a minimal phase-only
+        # envelope is sufficient here (the phase is not re-run yet).
+        RESUME_FILE=$(mktemp)
+        jq -n --arg p "$PHASE" '{phase:$p}' > "$RESUME_FILE"
+        RESUME_DECISION=$("$FLOW_DECIDE" --flow-state "$FLOW_STATE" --phase "$PHASE" --result "$RESUME_FILE" "${ALLOW_PARTIAL_ARG[@]}")
+        rm -f "$RESUME_FILE"
+        RESUME_ACTION=$(echo "$RESUME_DECISION" | jq -r '.next_action')
+        RESUME_PHASE=$(echo "$RESUME_DECISION" | jq -r '.phase // empty')
+        RESUME_REASON=$(echo "$RESUME_DECISION" | jq -r '.reason')
+        log "resume-from-failed decision: $RESUME_ACTION ${RESUME_PHASE:+→ $RESUME_PHASE} ($RESUME_REASON)"
+        case "$RESUME_ACTION" in
+            retry)
+                # Q5: bump attempts on the retry target before re-running.
+                "$FLOW_UPDATE" --flow-state "$FLOW_STATE" phase "$RESUME_PHASE" running --attempts +1 >/dev/null
+                PHASE="$RESUME_PHASE"
+                ;;
+            abort)
+                "$FLOW_UPDATE" --flow-state "$FLOW_STATE" status failed >/dev/null
+                log "flow aborted on resume: $RESUME_REASON"
+                jq -n --arg reason "$RESUME_REASON" --arg phase "$PHASE" \
+                    '{status:"aborted",phase:$phase,reason:$reason}'
+                exit 2
+                ;;
+            *)
+                die_json "Unexpected resume decision '$RESUME_ACTION' for failed phase '$PHASE'" 1
+                ;;
+        esac
+    fi
+
     # Mark phase running.
     "$FLOW_UPDATE" --flow-state "$FLOW_STATE" phase "$PHASE" running >/dev/null
 

--- a/dev-flow/scripts/orchestrate.sh
+++ b/dev-flow/scripts/orchestrate.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# orchestrate.sh - child-split mode top-level decision loop (Stage 3).
+#
+# flow-decide.sh (decision engine) を駆動する bash decision loop。各 phase で
+#   1. skill を実行 (invoke-skill-poc.sh sync / 委譲先 helper)
+#   2. 決定論的ソースを build-envelope.sh で decision-input envelope に純変換
+#   3. flow-decide.sh に渡して next_action を得る
+#   4. flow-update.sh で flow.json phase 状態を更新
+#   5. next_action に従って遷移 (skill 続行 / retry / complete / abort)
+# を繰り返す。
+#
+# **起点は batch_loop**。decompose phase は dev-decompose が内包し、Step 8 validate
+# 直後に `flow-update phase decompose done` を呼ぶ前提 (issue #112 Q3)。
+# orchestrate は decompose==done の flow.json を受け取り、batch_loop から開始する。
+#
+# Usage:
+#   orchestrate.sh --flow-state PATH --worktree PATH [--allow-partial]
+#                  [--base BRANCH] [--lang ja|en] [--max-iterations N]
+#                  [--poll-max N] [--poll-interval SEC] [--dry-run]
+#
+# Exit codes:
+#   0 - flow completed (next_action == complete)
+#   1 - invalid input / setup error
+#   2 - flow aborted (next_action == abort) — manual intervention required
+#   3 - skill invocation error (invoke-skill-poc exit 2/3/4 propagated)
+#
+# Design refs (issue #112):
+#   Q4  : invoke-skill-poc.sh sync; exit code 0=success / 2=agent_error / 3=timeout
+#         / 4=unsupported → 2/3/4 は abort
+#   Q5  : flow-decide が retry を返したら `flow-update phase <t> running --attempts +1`
+#         を必ず呼んでから同 skill 再実行 (attempts++ 忘れ → 無限ループ防止)
+#   Q6  : build-envelope.sh = 純変換。`gh pr checks` polling は orchestrate (本 script) 側
+#   Q11 : --allow-partial default off。明示時のみ flow-decide に伝播
+#   Q12 : gh pr checks polling は最大 poll-max(30) × poll-interval(20s) = 10 分上限。
+#         timeout → ci_status=failed (schema enum 外の "timeout" は failed に正規化、
+#         flow-decide は ci_status!=passed で abort するため等価)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SKILLS_REPO/_lib/common.sh"
+
+require_cmds jq
+
+BUILD_ENVELOPE="$SCRIPT_DIR/build-envelope.sh"
+FLOW_DECIDE="$SKILLS_REPO/_lib/scripts/flow-decide.sh"
+FLOW_UPDATE="$SKILLS_REPO/_lib/scripts/flow-update.sh"
+RUN_BATCH_LOOP="$SKILLS_REPO/_shared/scripts/run-batch-loop.sh"
+AUTO_MERGE_CHILD="$SCRIPT_DIR/auto-merge-child.sh"
+
+FLOW_STATE=""
+WORKTREE=""
+ALLOW_PARTIAL="false"
+BASE=""
+LANG_OPT="ja"
+MAX_ITER="20"
+POLL_MAX="${ORCHESTRATE_POLL_MAX:-30}"
+POLL_INTERVAL="${ORCHESTRATE_POLL_INTERVAL:-20}"
+DRY_RUN="false"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --flow-state) FLOW_STATE="$2"; shift 2 ;;
+        --worktree) WORKTREE="$2"; shift 2 ;;
+        --allow-partial) ALLOW_PARTIAL="true"; shift ;;
+        --base) BASE="$2"; shift 2 ;;
+        --lang) LANG_OPT="$2"; shift 2 ;;
+        --max-iterations) MAX_ITER="$2"; shift 2 ;;
+        --poll-max) POLL_MAX="$2"; shift 2 ;;
+        --poll-interval) POLL_INTERVAL="$2"; shift 2 ;;
+        --dry-run) DRY_RUN="true"; shift ;;
+        -h|--help)
+            sed -n '2,40p' "$0"
+            exit 0
+            ;;
+        *) die_json "Unknown option: $1" 1 ;;
+    esac
+done
+
+[[ -n "$FLOW_STATE" ]] || die_json "--flow-state required" 1
+[[ -f "$FLOW_STATE" ]] || die_json "flow.json not found: $FLOW_STATE" 1
+[[ -n "$WORKTREE" ]] || die_json "--worktree required" 1
+
+# Reject non-2.1.0 (no-backcompat). Mirror flow-decide / flow-update gate.
+VERSION=$(jq -r '.version // empty' "$FLOW_STATE")
+[[ "$VERSION" == "2.1.0" ]] || die_json "flow.json schema version must be 2.1.0 (got: \"$VERSION\")" 1
+
+# decompose must be done before orchestrate runs (Q3: dev-decompose 内包).
+DECOMPOSE_STATUS=$(jq -r '.phases[] | select(.name=="decompose") | .status' "$FLOW_STATE")
+[[ "$DECOMPOSE_STATUS" == "done" ]] || die_json "orchestrate requires decompose phase == done (got: \"$DECOMPOSE_STATUS\"). dev-decompose must finalize decompose before orchestrate." 1
+
+INTEGRATION_BRANCH=$(jq -r '.integration_branch.name' "$FLOW_STATE")
+[[ -z "$BASE" ]] && BASE=$(jq -r '.config.base_branch // .integration_branch.base' "$FLOW_STATE")
+
+log() { echo "[orchestrate] $*" >&2; }
+
+ALLOW_PARTIAL_ARG=()
+[[ "$ALLOW_PARTIAL" == "true" ]] && ALLOW_PARTIAL_ARG=(--allow-partial)
+
+# ---------------------------------------------------------------------------
+# gh pr checks polling helper (Q6 / Q12). Resolves CI status for a PR.
+# Echoes one of: passed | failed | pending | unknown (schema enum).
+# timeout → failed (flow-decide aborts on != passed; "timeout" is enum-external).
+# ---------------------------------------------------------------------------
+poll_ci_status() {
+    local pr_url="$1"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "${ORCHESTRATE_DRY_CI_STATUS:-passed}"
+        return 0
+    fi
+    require_cmd gh
+    local attempt=0
+    local raw rc
+    while (( attempt < POLL_MAX )); do
+        attempt=$((attempt + 1))
+        # `gh pr checks` exit: 0 all pass, 8 pending, !=0 some failed/none.
+        raw=$(gh pr checks "$pr_url" 2>/dev/null) && rc=0 || rc=$?
+        if (( rc == 0 )); then
+            echo "passed"; return 0
+        elif (( rc == 8 )); then
+            log "CI pending for $pr_url (attempt $attempt/$POLL_MAX); sleeping ${POLL_INTERVAL}s"
+            sleep "$POLL_INTERVAL"
+            continue
+        else
+            # Non-pending non-zero: failures present, or no checks configured.
+            if [[ -z "$raw" ]]; then
+                echo "unknown"; return 0
+            fi
+            echo "failed"; return 0
+        fi
+    done
+    log "CI polling timed out after $((POLL_MAX * POLL_INTERVAL))s for $pr_url → treating as failed"
+    echo "failed"
+}
+
+# ---------------------------------------------------------------------------
+# Phase runners. Each runs the deterministic source for the phase, returns the
+# raw result on stdout (caller converts via build-envelope.sh).
+# ---------------------------------------------------------------------------
+
+run_batch_loop_phase() {
+    local batches_json state_file
+    batches_json=$(mktemp)
+    jq '.batches' "$FLOW_STATE" > "$batches_json"
+    state_file="$WORKTREE/.claude/batch-state.json"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        # Dry-run: emit injected batch result if provided (test hook), else
+        # synthesize a fully-successful batch result from children[].
+        if [[ -n "${ORCHESTRATE_DRY_BATCH_RESULT:-}" ]]; then
+            cat "$ORCHESTRATE_DRY_BATCH_RESULT"
+        else
+            jq -n --argjson succ "$(jq '.children | length' "$FLOW_STATE")" \
+                '{status:"ok",batches_processed:1,batches_skipped:0,issues_succeeded:$succ,issues_failed:0,fail_fast_triggered:false,results:[]}'
+        fi
+        rm -f "$batches_json"
+        return 0
+    fi
+    "$RUN_BATCH_LOOP" \
+        --batches-json "$batches_json" \
+        --issue-runner "Skill: dev-flow {issue} --force-single --base $INTEGRATION_BRANCH --lang $LANG_OPT" \
+        --on-success "$AUTO_MERGE_CHILD {issue} --base $INTEGRATION_BRANCH --flow-state $FLOW_STATE" \
+        --state-file "$state_file" \
+        --fail-fast
+    rm -f "$batches_json"
+}
+
+run_integrate_phase() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        jq -n '{status:"integrated",type_check:"skipped",validation:"passed"}'
+        return 0
+    fi
+    # dev-integrate skill produces {status, type_check, validation}.
+    invoke_skill "Skill: dev-integrate --flow-state $FLOW_STATE --base $INTEGRATION_BRANCH"
+}
+
+run_final_pr_phase() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        jq -n '{pr_url:"https://github.com/dry/run/pull/1",title:"dry-run",branch:"b",base:"d"}'
+        return 0
+    fi
+    # git-pr skill produces {pr_url, title, branch, base, worktree}.
+    invoke_skill "Skill: git-pr $(jq -r '.issue' "$FLOW_STATE") --base $BASE --lang $LANG_OPT --worktree $WORKTREE"
+}
+
+run_pr_iterate_phase() {
+    local pr_url="$1"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        jq -n '{version:"1.0",status:"lgtm",current_iteration:1}'
+        return 0
+    fi
+    # pr-iterate skill persists iterate.json; we read it back as the source.
+    invoke_skill "Skill: pr-iterate $pr_url" >/dev/null
+    local iterate_json="$WORKTREE/.claude/iterate.json"
+    [[ -f "$iterate_json" ]] || die_json "pr-iterate did not produce iterate.json at $iterate_json" 3
+    cat "$iterate_json"
+}
+
+# invoke_skill: run a skill prompt synchronously via invoke-skill-poc.sh and
+# propagate its exit codes (Q4: 2=agent_error/3=timeout/4=unsupported → abort).
+invoke_skill() {
+    local prompt="$1"
+    local out rc
+    out=$(bash "$SKILLS_REPO/_lib/scripts/invoke-skill-poc.sh" "$prompt") && rc=0 || rc=$?
+    if (( rc != 0 )); then
+        log "skill invocation failed (exit $rc): $prompt"
+        exit 3
+    fi
+    printf '%s' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Decision loop
+# ---------------------------------------------------------------------------
+
+# Helper: read current phase status from flow.json.
+phase_status() { jq -r --arg n "$1" '.phases[] | select(.name==$n) | .status' "$FLOW_STATE"; }
+
+# Determine starting phase: first of [batch_loop..pr_iterate] not yet done.
+resolve_start_phase() {
+    local p
+    for p in batch_loop integrate final_pr pr_iterate; do
+        if [[ "$(phase_status "$p")" != "done" ]]; then
+            echo "$p"; return 0
+        fi
+    done
+    echo ""  # all done
+}
+
+PHASE="$(resolve_start_phase)"
+if [[ -z "$PHASE" ]]; then
+    log "all phases already done; nothing to orchestrate."
+    echo '{"status":"completed","reason":"all phases done"}'
+    exit 0
+fi
+
+# Carry the PR url discovered in final_pr through to pr_iterate.
+FINAL_PR_URL=""
+
+iter=0
+while (( iter < MAX_ITER )); do
+    iter=$((iter + 1))
+    log "iteration $iter: phase=$PHASE"
+
+    # Mark phase running.
+    "$FLOW_UPDATE" --flow-state "$FLOW_STATE" phase "$PHASE" running >/dev/null
+
+    # Run the phase + build envelope.
+    ENVELOPE=""
+    case "$PHASE" in
+        batch_loop)
+            RESULT=$(run_batch_loop_phase)
+            ENVELOPE=$("$BUILD_ENVELOPE" batch_loop --flow-state "$FLOW_STATE" --batch-result "$RESULT")
+            ;;
+        integrate)
+            RESULT=$(run_integrate_phase)
+            ENVELOPE=$("$BUILD_ENVELOPE" integrate --integrate-result "$RESULT")
+            ;;
+        final_pr)
+            RESULT=$(run_final_pr_phase)
+            FINAL_PR_URL=$(echo "$RESULT" | jq -r '.pr_url')
+            CI=$(poll_ci_status "$FINAL_PR_URL")
+            ENVELOPE=$("$BUILD_ENVELOPE" final_pr --pr-result "$RESULT" --ci-status "$CI")
+            ;;
+        pr_iterate)
+            RESULT=$(run_pr_iterate_phase "$FINAL_PR_URL")
+            ENVELOPE=$("$BUILD_ENVELOPE" pr_iterate --iterate-state "$RESULT")
+            ;;
+        *)
+            die_json "Unexpected phase in loop: $PHASE" 1
+            ;;
+    esac
+
+    # Decide next action.
+    ENV_FILE=$(mktemp)
+    echo "$ENVELOPE" | jq -c . > "$ENV_FILE"
+    DECISION=$("$FLOW_DECIDE" --flow-state "$FLOW_STATE" --phase "$PHASE" --result "$ENV_FILE" "${ALLOW_PARTIAL_ARG[@]}")
+    rm -f "$ENV_FILE"
+
+    NEXT_ACTION=$(echo "$DECISION" | jq -r '.next_action')
+    NEXT_PHASE=$(echo "$DECISION" | jq -r '.phase // empty')
+    REASON=$(echo "$DECISION" | jq -r '.reason')
+    log "decision: $NEXT_ACTION ${NEXT_PHASE:+→ $NEXT_PHASE} ($REASON)"
+
+    case "$NEXT_ACTION" in
+        skill)
+            # Current phase succeeded; mark done and advance.
+            "$FLOW_UPDATE" --flow-state "$FLOW_STATE" phase "$PHASE" done >/dev/null
+            PHASE="$NEXT_PHASE"
+            ;;
+        complete)
+            "$FLOW_UPDATE" --flow-state "$FLOW_STATE" phase "$PHASE" done >/dev/null
+            "$FLOW_UPDATE" --flow-state "$FLOW_STATE" status integrated >/dev/null
+            log "flow complete: $REASON"
+            jq -n --arg reason "$REASON" --arg pr "$FINAL_PR_URL" \
+                '{status:"completed",reason:$reason,final_pr_url:(if $pr=="" then null else $pr end)}'
+            exit 0
+            ;;
+        retry)
+            # Q5: increment attempts on the retry target BEFORE re-running.
+            "$FLOW_UPDATE" --flow-state "$FLOW_STATE" phase "$NEXT_PHASE" running --attempts +1 >/dev/null
+            PHASE="$NEXT_PHASE"
+            ;;
+        abort)
+            "$FLOW_UPDATE" --flow-state "$FLOW_STATE" phase "$PHASE" failed --retry-target abort >/dev/null
+            "$FLOW_UPDATE" --flow-state "$FLOW_STATE" status failed >/dev/null
+            log "flow aborted: $REASON"
+            jq -n --arg reason "$REASON" --arg phase "$PHASE" \
+                '{status:"aborted",phase:$phase,reason:$reason}'
+            exit 2
+            ;;
+        *)
+            die_json "Unknown next_action from flow-decide: $NEXT_ACTION" 1
+            ;;
+    esac
+done
+
+die_json "orchestrate exceeded max iterations ($MAX_ITER) without completing" 2

--- a/dev-integrate/SKILL.md
+++ b/dev-integrate/SKILL.md
@@ -50,7 +50,7 @@ branches) has been **removed** (no-backcompat).
 $SKILLS_DIR/_lib/scripts/flow-read.sh --flow-state $FLOW_STATE
 ```
 
-Rejects with schema error if version != `2.0.0`.
+Rejects with schema error if version != `2.1.0`.
 
 ## Step 2: Verify Children Completed
 

--- a/dev-integrate/scripts/verify-children-merged.sh
+++ b/dev-integrate/scripts/verify-children-merged.sh
@@ -32,8 +32,8 @@ done
 [[ -f "$FLOW_STATE" ]] || die_json "flow.json not found: $FLOW_STATE" 1
 
 VERSION=$(jq -r '.version // empty' "$FLOW_STATE")
-if [[ "$VERSION" != "2.0.0" ]]; then
-    die_json "flow.json schema version must be 2.0.0 (got: \"$VERSION\"). v1 is not supported (no-backcompat)." 1
+if [[ "$VERSION" != "2.1.0" ]]; then
+    die_json "flow.json schema version must be 2.1.0 (got: \"$VERSION\"). v2.0 / v1 は schema error (no-backcompat)." 1
 fi
 
 TOTAL=$(jq '.children | length' "$FLOW_STATE")

--- a/tests/flow-v2-version-bump.sh
+++ b/tests/flow-v2-version-bump.sh
@@ -29,6 +29,7 @@ TARGETS=(
     "_lib/scripts/validate-decomposition.sh"
     "dev-flow/scripts/flow-status.sh"
     "dev-decompose/scripts/init-flow-v2.sh"
+    "dev-integrate/scripts/verify-children-merged.sh"
     "tests/flow-schema-v2-validate.sh"
     "tests/validate-decomposition-v2-branch.sh"
 )


### PR DESCRIPTION
## 概要

`_shared/references/portable-coordinator.md` Migration Path **Stage 3**。child-split mode の top-level orchestration を、Stage 2 (PR #109) で実装した `flow-decide.sh` 決定エンジン駆動の **bash decision loop** に書き換えた。

中核は **「skill 実行結果を決定論的ソースから decision-input envelope に変換する builder 層」** の実装。`invoke-skill-poc.sh` の raw text は parse せず、常に決定論的ソース (JSON / state ファイル) のみを入力とする。

Closes #112

## 主な変更

### Phase 1: envelope builder + decompose done 化
- **`dev-flow/scripts/build-envelope.sh`** (新規) — 4 phase の純変換 (副作用なし):
  - `batch_loop`: run-batch-loop.sh JSON + flow.json `children[]` → `completed_children = issues_succeeded`、`failed_children = issues_failed + (results[]|skipped|length)`。**skipped は top-level キーでなく `results[]` から集約**し `completed+failed == children|length` を保証 (Round3-c)
  - `integrate`: dev-integrate `{type_check, validation}` → `tests_pass = (type_check ∈ {passed,skipped}) && (validation==passed)`、`merge_conflicts = []`
  - `final_pr`: git-pr `{pr_url}` + ci_status (polling 解決の純粋引数) → `{pr_url, ci_status}`
  - `pr_iterate`: iterate.json `{status, current_iteration}` → `{decision, iterations}` (in_progress は abort)
- **dev-decompose 改修** — Step 8 validate 直後に `flow-update phase decompose done` を呼ぶ (Q3: decompose done 化の責務を内包)

### Phase 2: orchestrate.sh decision loop
- **`dev-flow/scripts/orchestrate.sh`** (新規) — `flow-decide → build-envelope → flow-update` の decision loop、**batch_loop 起点**
  - retry 時に `flow-update phase <t> running --attempts +1` を必ず呼んでから再実行 (Q5、無限ループ防止)
  - invoke-skill-poc.sh の exit code 2/3/4 を abort に伝播 (Q4)
  - `gh pr checks` polling は最大 30×20s=10 分上限、timeout → ci_status=failed (Q12)
  - `--allow-partial` は default off、明示時のみ flow-decide に伝播 (Q11)
  - exit code: 0=完走 / 2=abort / 3=skill 起動エラー

### Phase 3: SKILL.md 薄化 + schema version 全整合 (Q10、必須)
- `dev-flow/SKILL.md` child-split Step 3-6 を `orchestrate.sh` 呼び出しに薄化 (single mode 維持)
- **schema version 全整合**: `verify-children-merged.sh` の version gate を `2.0.0 → 2.1.0` に修正 (Stage 2 の version bump 漏れ吸収。**修正前は integrate phase が確実に die していた**)。`validate-decomposition.sh` / `dev-integrate/SKILL.md` / `dev-decompose/SKILL.md` のコメント整合、`tests/flow-v2-version-bump.sh` の target に `verify-children-merged.sh` を追加

### Phase 5: docs
- `portable-coordinator.md` Stage 3 を実装完了に更新 (scope 縮小 + envelope builder pattern + 変換表)。dev-kickoff 薄化 / runner script を Stage 4+ に移動。flow-decide の decompose ケースが reserved である旨を追記 (Round3-d)

## テスト

- **bats**: `dev-flow/scripts/build-envelope.bats` (4 phase 変換 + skipped 整合性 + ci polling mock + flow-decide 連携)、`dev-flow/scripts/orchestrate.bats` (5 phase 完走 + 遷移 + retry + abort + allow-partial)
- **既存テスト regression**: `flow-v2-version-bump.sh` / `flow-decide-cases.sh` / `flow-update-phase-action.sh` / `validate-decomposition-v2-branch.sh` / `flow-schema-v2-validate.sh` 全て green
- **dry-run smoke**: orchestrate.sh が decompose(pre-done) → batch_loop → integrate → final_pr → pr_iterate を完走 (status=integrated)、abort パス (batch_loop 失敗 / CI failed) も検証済
- **Q10 検証**: verify-children-merged.sh が 2.1.0 flow.json を受理することを確認 (integrate phase が die しなくなった)

> bats はローカル環境に未インストールのため CI (`--strict`) で実行される。builder/orchestrate のロジックは実 `flow-decide.sh` に対する直接 smoke で検証済。

## 設計準拠

issue body の Q1-Q12 設計判断と Plan agent 3 round review (R3: approve with minor edits) に完全準拠。no-backcompat scaffolding 規約に従い新形式のみ受理 (version enum dual-path なし)。