### PR TITLE
feat(ai-pulse): Tier A 4ソース横断の日次ダイジェスト skill

### DIFF
--- a/ai-pulse/SKILL.md
+++ b/ai-pulse/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: ai-pulse
+description: |
+  AI キャッチアップガイドが定める Tier A 固定ソース（Smol AI News, Simon Willison,
+  Latent Space, HuggingFace Daily Papers）を横断取得し、1 枚の Markdown に集約する
+  日次ダイジェスト。ai-news-digest がトピック駆動なのに対し、本 skill は claudedocs/
+  ai-catchup-guide.md が定める「読むべきソース」を起点とするソース駆動。
+  Use when: (1) 毎日の AI 情報キャッチアップを 1 ファイルで完結させたい,
+  (2) Smol AI News / Simon Willison / Latent Space / HF Daily Papers の最新を横断したい,
+  (3) ガイドの「毎朝 10 分」ルーティンを実行したい,
+  (4) keywords: AI 日次, daily brief, AI pulse, ソース横断, info diet,
+  毎朝のAI, Smol AI News, Simon Willison, Latent Space, HF Daily Papers
+  Accepts args: [--days N] [--output PATH] [--sources LIST]
+allowed-tools:
+  - WebFetch
+  - WebSearch
+  - Bash
+  - Read
+  - Write
+  - Agent
+---
+
+# AI Pulse (Daily Source Digest)
+
+AI キャッチアップガイドの Tier A 固定ソースを横断取得し、1 枚の Markdown に集約する日次ダイジェスト。
+
+**目的**: 「サイトを 4 つ巡回する」を「1 ファイルを読む」に置き換える。
+**非目的**: 検索ベースの広範な調査（→ `/ai-news-digest`）、特定領域の深掘り tips（→ `/claude-code-tips`, `/codex-tips`）。
+
+## Usage
+
+```
+/ai-pulse [--days 1] [--output ./claudedocs/pulse/] [--sources all]
+```
+
+## Args
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `--days` | `1` | 遡る日数。週次まとめなら `--days 7` |
+| `--output` | `./claudedocs/pulse/` | 出力先ディレクトリ。`pulse-YYYY-MM-DD.md` で保存 |
+| `--sources` | `all` | `smol,willison,latent,hfpapers` のカンマ区切り。`all` で 4 ソース全部 |
+
+### Source ID
+
+| ID | サイト | URL | 取得対象 |
+|----|--------|-----|---------|
+| `smol` | Smol AI News | `https://buttondown.com/ainews` | 最新エディション |
+| `willison` | Simon Willison's Weblog | `https://simonwillison.net/` | 直近 `--days` 日の記事 |
+| `latent` | Latent Space | `https://www.latent.space/` | 直近 `--days` 日の記事 |
+| `hfpapers` | HuggingFace Daily Papers | `https://huggingface.co/papers` | 当日分の TL;DR |
+
+## Workflow
+
+```
+Step 1: Parse args → 出力 path / 取得対象ソース確定
+Step 2: 4 ソースを Agent で並列 fetch + 各記事 3 行要約
+Step 3: カテゴリ分類 (Claude Code / 新モデル / Eval / プロンプティング / その他)
+Step 4: 「今日触るべき 1 つ」を 1 件ピック（ハンズオン誘導枠）
+Step 5: MD format → Save → ファイルパス表示
+```
+
+## Step 1: Parse Args
+
+`scripts/parse-args.sh` で引数を解釈し、以下を出力する:
+
+- 出力 file path: `<output_dir>/pulse-YYYY-MM-DD.md` (today base)
+- 取得対象 source ID リスト
+
+`--sources all` 指定時は 4 ソース全部、それ以外はカンマ区切りで指定された ID のみ。
+
+## Step 2: Parallel Fetch & Summarize（4 ソース × Agent）
+
+各ソースに対して 1 つの subagent を並列で dispatch する。
+
+各 agent は:
+1. ソースの URL を WebFetch（必要なら index → individual articles）
+2. `--days` 範囲内の記事を抽出
+3. 各記事を 3 行要約 に圧縮（1行目: 何が起きたか / 2行目: 開発者への影響 / 3行目: ソース URL）
+4. 結果を JSON 配列で返す
+
+詳細プロンプト: [references/agent-prompts.md](references/agent-prompts.md)
+
+## Step 3: Categorize
+
+Step 2 の全記事を以下のカテゴリにバケット分けする（重複可）:
+
+| カテゴリ | 含むもの |
+|---------|---------|
+| Claude Code / Anthropic | CC 更新、Claude API、Anthropic ブログ |
+| 新モデル / リリース | GPT/Gemini/Claude/オープンソース新モデル、新製品 |
+| Eval / LLMOps | 評価、observability、本番運用 |
+| プロンプティング / 技法 | プロンプトエンジニアリング、推論技法 |
+| 論文 / 研究 | HF Papers、arXiv 関連 |
+| その他 | 上記に当てはまらないもの |
+
+該当記事が 0 件のカテゴリは「特筆なし」と明記し、空セクションを残さない。
+
+## Step 4: 「今日触るべき 1 つ」をピック
+
+ガイド §0 の大原則「読む量より触る量」を守るため、出力に必ず以下のセクションを含める:
+
+```markdown
+## 今日触るべき 1 つ
+
+- 対象: <ツール名 / モデル名 / コードリポジトリ名>
+- 理由: <なぜ今日触る価値があるか 1 行>
+- 最初のコマンド: `<実行コマンドや URL>`
+```
+
+選定基準（優先順）:
+1. 試せるもの: 今日叩けるコマンドが存在する（CLI install、Playground、Colab notebook 等）
+2. 5–15 分で結果が出る: 環境構築だけで終わるものは選ばない
+3. 既存業務と接続できる: Claude Code / Mastra / Vercel 系ワークフローに乗りそうなもの
+
+該当なしの日は「今日は『触る』より『読む』日。気になった記事を 1 本だけ精読する」と明記。
+
+## Step 5: Format & Save
+
+出力テンプレ: [references/output-template.md](references/output-template.md)
+
+- ファイル名: `pulse-YYYY-MM-DD.md`
+- 出力先: `--output` で指定（デフォルト `./claudedocs/pulse/`）
+- 既に同名ファイルがあれば末尾に `-2`, `-3` を付与
+- 保存後、絶対パスをユーザーに表示
+
+## Subagent Dispatch Rules
+
+この skill は Step 2 で 4 ソース × Agent を並列起動する。
+[Subagent Dispatch Rules](../_shared/references/subagent-dispatch.md) を遵守し、各呼び出しで以下 5 要素を明示する:
+
+1. **Objective** — `<source>` から直近 N 日の記事を 3 行要約に圧縮して JSON 配列で返す
+2. **Output format** — `[{title, url, published, summary_3lines, category_hint}]` の JSON のみ
+3. **Tools** — WebFetch のみ可。Write / Edit / Bash 禁止
+4. **Boundary** — リポジトリのファイル変更禁止、外部 POST 禁止、認証必要なサイトはスキップ
+5. **Token cap** — 1 ソースあたり最大 8 記事、要約は各 3 行・各行 80 字以内
+
+**Routing**: 探索 heavy なので `general-purpose` / Haiku で十分。Opus は不要。
+
+| タスク性質 | 推奨 subagent | model |
+|-----------|--------------|-------|
+| 各ソースの記事取得＋要約 | `general-purpose` | haiku |
+
+## Journal Logging
+
+```bash
+# On success
+$SKILLS_DIR/skill-retrospective/scripts/journal.sh log ai-pulse success \
+  --duration-turns $TURNS
+
+# On failure
+$SKILLS_DIR/skill-retrospective/scripts/journal.sh log ai-pulse failure \
+  --error-category <category> --error-msg "<message>"
+```
+
+## References
+
+- [output-template.md](references/output-template.md) - 出力 Markdown テンプレート
+- [agent-prompts.md](references/agent-prompts.md) - 各ソース fetch agent のプロンプト
+- [Skill Creation Guide](../docs/skill-creation-guide.md) - canonical source

--- a/ai-pulse/references/agent-prompts.md
+++ b/ai-pulse/references/agent-prompts.md
@@ -1,0 +1,82 @@
+# Agent Prompts: ai-pulse Step 2
+
+各ソースに対する subagent dispatch 用プロンプト。
+[Subagent Dispatch Rules](../../_shared/references/subagent-dispatch.md) の 5 要素を必ず満たす。
+
+## 共通テンプレート
+
+```
+You are fetching the latest articles from <SOURCE_NAME> for an AI daily digest.
+
+## Objective
+Fetch articles published in the last {{DAYS}} day(s) from <SOURCE_URL>,
+summarize each in exactly 3 lines, and return as JSON array.
+
+## Output format
+JSON only, no prose. Schema:
+[
+  {
+    "title": "string",
+    "url": "string (absolute)",
+    "published": "YYYY-MM-DD",
+    "summary_3lines": ["line1: what happened", "line2: dev impact", "line3: source URL"],
+    "category_hint": "claude-code | new-model | eval-llmops | prompting | paper | other"
+  }
+]
+
+## Tools
+- WebFetch: ALLOWED
+- WebSearch: ALLOWED only as fallback if WebFetch fails
+- Write / Edit / Bash / Agent: FORBIDDEN
+
+## Boundary
+- DO NOT modify any local files
+- DO NOT POST to external services
+- DO NOT follow paywalls or auth-gated content (skip and note in summary)
+- If WebFetch returns nothing usable, return empty array []
+
+## Token cap
+- Max 8 articles per source
+- Each summary line: 80 chars max
+- Total response: 2000 tokens max
+
+Begin fetching now.
+```
+
+## ソース別プロンプト差分
+
+### smol (Smol AI News)
+
+- `<SOURCE_NAME>` = `Smol AI News`
+- `<SOURCE_URL>` = `https://buttondown.com/ainews`
+- 補足: 最新エディションのみ取得（過去エディションは追わない）。1 エディション内のセクションを 1 記事として扱う
+
+### willison (Simon Willison's Weblog)
+
+- `<SOURCE_NAME>` = `Simon Willison's Weblog`
+- `<SOURCE_URL>` = `https://simonwillison.net/`
+- 補足: アンカー記事（短いリンク投稿）と通常記事を区別。通常記事を優先
+
+### latent (Latent Space)
+
+- `<SOURCE_NAME>` = `Latent Space`
+- `<SOURCE_URL>` = `https://www.latent.space/`
+- 補足: Newsletter 形式。1 エディション内の話題を 1 記事として分解
+
+### hfpapers (HuggingFace Daily Papers)
+
+- `<SOURCE_NAME>` = `HuggingFace Daily Papers`
+- `<SOURCE_URL>` = `https://huggingface.co/papers`
+- 補足: 当日分の論文リストから上位 5–8 件。abstract を 3 行要約に圧縮
+- `category_hint` は必ず `paper` を返す
+
+## 並列実行ルール
+
+Step 2 では 4 ソースを 1 メッセージで並列 dispatch する（Agent tool call を 1 メッセージに 4 つ並べる）。
+順次実行すると合計 4 倍の時間がかかるため、必ず並列化する。
+
+並列実行の失敗時の扱い:
+
+- 1 ソース失敗 → 該当ソースは empty array として扱い、他 3 ソースの結果でダイジェスト生成を続行
+- 2 ソース以上失敗 → ユーザーに「N 件のソース取得失敗」を明記して途中結果を出力
+- 全ソース失敗 → 失敗を明記して終了。ファイル保存はスキップ

--- a/ai-pulse/references/output-template.md
+++ b/ai-pulse/references/output-template.md
@@ -1,0 +1,103 @@
+# Output Template: pulse-YYYY-MM-DD.md
+
+LLM はこのテンプレートに従って最終 Markdown を生成する。
+空セクションは残さず、該当なしのカテゴリは「特筆なし」と明記する。
+
+```markdown
+# AI Pulse — YYYY-MM-DD
+
+- 取得範囲: 直近 N 日
+- 取得ソース: smol, willison, latent, hfpapers
+- 記事総数: <件>
+- 生成: ai-pulse skill
+
+---
+
+## 今日触るべき 1 つ
+
+- **対象**: <ツール名 / モデル名 / コードリポジトリ名>
+- **理由**: <なぜ今日触る価値があるか 1 行>
+- **最初のコマンド**: `<実行コマンドや URL>`
+
+---
+
+## Claude Code / Anthropic
+
+### <記事タイトル>
+- <要約 1 行目: 何が起きたか>
+- <要約 2 行目: 開発者への影響>
+- ソース: [<サイト名>](<URL>)
+
+（記事ごとに上記を繰り返し。0 件なら「特筆なし」のみ）
+
+---
+
+## 新モデル / リリース
+
+（同上）
+
+---
+
+## Eval / LLMOps
+
+（同上）
+
+---
+
+## プロンプティング / 技法
+
+（同上）
+
+---
+
+## 論文 / 研究
+
+（同上。HF Daily Papers はここに集約。1 記事 = 1 論文）
+
+---
+
+## その他
+
+（同上）
+
+---
+
+## ソース別 raw 一覧
+
+<details>
+<summary>Smol AI News (N 件)</summary>
+
+- [<タイトル>](<URL>) — <1 行要約>
+- ...
+
+</details>
+
+<details>
+<summary>Simon Willison (N 件)</summary>
+
+（同上）
+
+</details>
+
+<details>
+<summary>Latent Space (N 件)</summary>
+
+（同上）
+
+</details>
+
+<details>
+<summary>HuggingFace Daily Papers (N 件)</summary>
+
+（同上）
+
+</details>
+```
+
+## 編集ルール
+
+- 「触るべき 1 つ」は必ず先頭に置く（ガイド §0 の「読む量より触る量」原則）
+- 各記事の要約は 3 行（タイトル除く）
+- カテゴリ内では「重要度の高い順」に並べる
+- 重複記事は最も信頼性の高いソースのみ残し、他は raw 一覧の `<details>` に格納
+- 引用ブロック・コードブロックは原文 URL を必ず併記

--- a/ai-pulse/scripts/parse-args.sh
+++ b/ai-pulse/scripts/parse-args.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ai-pulse: parse CLI args and emit resolved values as KEY=VALUE lines.
+#
+# Usage:
+#   eval "$(./scripts/parse-args.sh --days 1 --output ./claudedocs/pulse/ --sources all)"
+#
+# Sets:
+#   AI_PULSE_DAYS, AI_PULSE_OUTPUT_DIR, AI_PULSE_OUTPUT_FILE, AI_PULSE_SOURCES
+
+set -euo pipefail
+
+DAYS=1
+OUTPUT_DIR="./claudedocs/pulse"
+SOURCES="all"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --days)
+      DAYS="$2"; shift 2 ;;
+    --output)
+      OUTPUT_DIR="$2"; shift 2 ;;
+    --sources)
+      SOURCES="$2"; shift 2 ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: parse-args.sh [--days N] [--output PATH] [--sources LIST]
+
+  --days N          Days to look back (default: 1)
+  --output PATH     Output directory (default: ./claudedocs/pulse/)
+  --sources LIST    Comma-separated source IDs or "all" (default: all)
+                    IDs: smol, willison, latent, hfpapers
+EOF
+      exit 0 ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2 ;;
+  esac
+done
+
+# Validate --days
+if ! [[ "$DAYS" =~ ^[0-9]+$ ]]; then
+  echo "invalid --days value: $DAYS (must be positive integer)" >&2
+  exit 2
+fi
+
+# Resolve sources
+if [[ "$SOURCES" == "all" ]]; then
+  RESOLVED="smol,willison,latent,hfpapers"
+else
+  # Validate each token
+  IFS=',' read -ra TOKENS <<< "$SOURCES"
+  for t in "${TOKENS[@]}"; do
+    case "$t" in
+      smol|willison|latent|hfpapers) ;;
+      *)
+        echo "invalid source id: $t (allowed: smol,willison,latent,hfpapers)" >&2
+        exit 2 ;;
+    esac
+  done
+  RESOLVED="$SOURCES"
+fi
+
+TODAY="$(date +%Y-%m-%d)"
+OUTPUT_FILE="${OUTPUT_DIR%/}/pulse-${TODAY}.md"
+
+# Conflict suffix
+if [[ -e "$OUTPUT_FILE" ]]; then
+  i=2
+  while [[ -e "${OUTPUT_DIR%/}/pulse-${TODAY}-${i}.md" ]]; do
+    i=$((i + 1))
+  done
+  OUTPUT_FILE="${OUTPUT_DIR%/}/pulse-${TODAY}-${i}.md"
+fi
+
+cat <<EOF
+AI_PULSE_DAYS=$DAYS
+AI_PULSE_OUTPUT_DIR=$OUTPUT_DIR
+AI_PULSE_OUTPUT_FILE=$OUTPUT_FILE
+AI_PULSE_SOURCES=$RESOLVED
+EOF


### PR DESCRIPTION
## Summary
- claudedocs/ai-catchup-guide.md (second-brain) の Tier A 固定ソースを横断取得し 1 ファイルに集約する skill
- 取得対象: Smol AI News / Simon Willison / Latent Space / HF Daily Papers
- 既存 ai-news-digest との違い: **ソース駆動** vs **トピック駆動**（補完関係）
- 出力に「今日触るべき 1 つ」セクションを必須化（ガイド §0「読む量より触る量」原則）

## Files
- `ai-pulse/SKILL.md` — frontmatter, workflow 5 steps, Subagent Dispatch Rules
- `ai-pulse/references/agent-prompts.md` — 4 ソース fetch agent プロンプト
- `ai-pulse/references/output-template.md` — 出力 MD テンプレ
- `ai-pulse/scripts/parse-args.sh` — 引数解釈 (--days / --output / --sources)

## Test plan
- [x] `tests/subagent-dispatch-lint.sh` → PASS 26 / FAIL 0
- [x] `scripts/parse-args.sh` happy/error path 動作確認
- [ ] 実運用: 後日 `/ai-pulse` を実行して出力品質を検証

## Notes
- dev branch がメイン worktree で占有されていたため feature/ai-pulse 経由でマージ
- このスキル雛形を残した可能性のある dev 直下 `ai-pulse/` ディレクトリは別途要削除