### PR TITLE
fix(dev-env-setup): Setup phase に依存インストール（ensure-worktree-deps.sh）を非ブロッキング再統合

### DIFF
--- a/_lib/issue-120-patch.test.mjs
+++ b/_lib/issue-120-patch.test.mjs
@@ -1,0 +1,99 @@
+// issue-120-patch.test.mjs
+//
+// docs/issue-120-dev-flow-setup-install.patch が正しい内容であることを保証する。
+// F4 の patch 作成前は赤（readFileSync fail）、F4 後に緑。
+//
+// assertions:
+//   (1) diff ヘッダに .claude/workflows/dev-flow.js を含む
+//   (2) 追加行(行頭 +)に ensure-worktree-deps.sh と --path ${WT} を含む
+//   (3) 追加行に dev-runner を含む
+//   (4) env-setup 呼び出し行近傍 300 文字に need( が無い（非ブロッキング）
+//   (5) コンテキスト行に WT = setup.worktree と phase Analyze が現れ、
+//       ensure-worktree-deps.sh 追加行の indexOf が
+//         WT = setup.worktree 行より後・phase Analyze 行より前（順序検証）
+//   (6) 追加行に ENVSETUP と required を含む
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+
+const patchPath = join(repoRoot, 'docs/issue-120-dev-flow-setup-install.patch');
+const patch = readFileSync(patchPath, 'utf8');
+
+// 行頭が + で始まる（diff ヘッダの +++ は除く）追加行を抽出
+const addedLines = patch.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++'));
+
+test('(1) diff ヘッダに .claude/workflows/dev-flow.js を含む', () => {
+  assert.ok(
+    patch.includes('.claude/workflows/dev-flow.js'),
+    'patch に .claude/workflows/dev-flow.js が見つからない',
+  );
+});
+
+test('(2) 追加行に ensure-worktree-deps.sh と --path ${WT} を含む', () => {
+  const ensureLine = addedLines.find(l => l.includes('ensure-worktree-deps.sh'));
+  assert.ok(ensureLine, '追加行に ensure-worktree-deps.sh が見つからない');
+  assert.ok(
+    ensureLine.includes('--path') && ensureLine.includes('WT'),
+    `追加行に --path WT が含まれていない: ${ensureLine}`,
+  );
+});
+
+test('(3) 追加行に dev-runner を含む', () => {
+  const devRunnerLine = addedLines.find(l => l.includes('dev-runner'));
+  assert.ok(devRunnerLine, '追加行に dev-runner が見つからない');
+});
+
+test('(4) env-setup 呼び出し行近傍 300 文字に need( が無い（非ブロッキング）', () => {
+  const envSetupIdx = patch.indexOf('env-setup');
+  assert.ok(envSetupIdx !== -1, 'patch に env-setup が見つからない');
+  const start = Math.max(0, envSetupIdx - 150);
+  const end = Math.min(patch.length, envSetupIdx + 150);
+  const vicinity = patch.slice(start, end);
+  assert.ok(
+    !vicinity.includes('need('),
+    `env-setup 近傍 300 文字に need( が含まれている（ブロッキング呼び出し）: ...${vicinity}...`,
+  );
+});
+
+test('(5) ensure-worktree-deps.sh 挿入位置が WT = setup.worktree より後・Phase Analyze より前', () => {
+  // patch ファイルの先頭はコメントヘッダ（# で始まる説明行）。
+  // 比較は "diff --git" 以降の実 diff 部分のみで行う。
+  const diffStart = patch.indexOf('diff --git');
+  assert.ok(diffStart !== -1, 'patch に diff --git が見つからない（正しい unified diff 形式でない）');
+  const diffBody = patch.slice(diffStart);
+
+  // コンテキスト行: " WT = setup.worktree"（行頭スペースは patch フォーマットで変更なし行）
+  const wtIdx = diffBody.indexOf('WT = setup.worktree');
+  assert.ok(wtIdx !== -1, 'diff 本文に WT = setup.worktree が見つからない');
+
+  // Analyze フェーズの区切りコメント: "// Phase Analyze:"
+  const analyzeIdx = diffBody.indexOf('// Phase Analyze:');
+  assert.ok(analyzeIdx !== -1, 'diff 本文に // Phase Analyze: が見つからない');
+
+  // 追加行内の ensure-worktree-deps.sh（"+" 行に含まれる）
+  const ensureIdx = diffBody.indexOf('ensure-worktree-deps.sh');
+  assert.ok(ensureIdx !== -1, 'diff 本文に ensure-worktree-deps.sh が見つからない');
+
+  assert.ok(
+    ensureIdx > wtIdx,
+    `ensure-worktree-deps.sh (idx=${ensureIdx}) が WT = setup.worktree (idx=${wtIdx}) より前にある`,
+  );
+  assert.ok(
+    ensureIdx < analyzeIdx,
+    `ensure-worktree-deps.sh (idx=${ensureIdx}) が // Phase Analyze: (idx=${analyzeIdx}) より後にある`,
+  );
+});
+
+test('(6) 追加行に ENVSETUP と required を含む', () => {
+  const envsetupLine = addedLines.find(l => l.includes('ENVSETUP'));
+  assert.ok(envsetupLine, '追加行に ENVSETUP が見つからない');
+
+  const requiredLine = addedLines.find(l => l.includes('required'));
+  assert.ok(requiredLine, '追加行に required が見つからない');
+});

--- a/dev-env-setup/SKILL.md
+++ b/dev-env-setup/SKILL.md
@@ -75,11 +75,22 @@ This enables project-specific setup (DB migrations, env generation, etc.).
 
 ## Integration with worktree workflows
 
-After a worktree is created (e.g. dev-flow workflow の Setup phase), run dev-env-setup to install deps:
+dev-flow workflow の Setup phase は worktree 確定直後（WT 確定後・Analyze 前）に
+dev-runner 経由で非ブロッキングラッパーを自動実行する:
 
 ```bash
-$SKILLS_DIR/dev-env-setup/scripts/detect-and-install.sh --path $WORKTREE
+$SKILLS_DIR/dev-env-setup/scripts/ensure-worktree-deps.sh --path $WORKTREE
 ```
+
+`ensure-worktree-deps.sh` は内部で `detect-and-install.sh` を呼び出し、
+install が失敗しても **常に exit 0** を返す（呼び出し側向け非ブロッキング契約）。
+これにより dev-flow は install 失敗で abort せず、後段 Validate phase の
+test-green ループが第二段の保険として機能する二段構えとなる。
+
+> **dev-flow.js への 1 ステップ追加について**: dev-flow.js は Claude Code の
+> Self-Modification guard により agent が直接編集できない。そのため Setup phase への
+> `ensure-worktree-deps.sh` 呼び出し追加は `docs/issue-120-dev-flow-setup-install.patch`
+> として提供されており、human が `git apply` で適用する運用となっている（issue #120）。
 
 ## Error Handling
 
@@ -87,7 +98,7 @@ $SKILLS_DIR/dev-env-setup/scripts/detect-and-install.sh --path $WORKTREE
 |----------|--------|
 | No lockfile/config found | Report "no dependencies detected", exit 0 |
 | Package manager not installed | Warn and skip (don't fail the workflow) |
-| Install fails | Report error, exit 1 (caller decides to continue or abort) |
+| Install fails | Report error, exit 1 (caller decides to continue or abort); `ensure-worktree-deps.sh` ラッパー経由で呼ぶ場合は exit 0 へ正規化される |
 | Custom setup.sh fails | Warn but don't fail (non-blocking) |
 | Already installed | Report "dependencies up to date", skip install |
 

--- a/dev-env-setup/scripts/ensure-worktree-deps.bats
+++ b/dev-env-setup/scripts/ensure-worktree-deps.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# Tests for dev-env-setup/scripts/ensure-worktree-deps.sh
+#
+# Strategy: mktemp -d で一時ディレクトリを作成し、ファイルの有無で挙動を検証する。
+# NOTE: F2 でスクリプトが実装されるまでこれらのテストは fail (red) になる。
+
+setup() {
+    SKILLS_REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCRIPT="$SKILLS_REPO/dev-env-setup/scripts/ensure-worktree-deps.sh"
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "依存ファイル皆無のディレクトリで exit 0 かつ no_dependencies を含む JSON を stdout に出す" {
+    # TMP_DIR は空 — 依存ファイルなし
+    run "$SCRIPT" --path "$TMP_DIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no_dependencies"* ]]
+}
+
+@test "--path 未指定で非 0 exit (必須引数エラー)" {
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "package.json のみ (lock なし) のディレクトリでも exit 0 (pm_not_found 経由)" {
+    # lock ファイルなし、package.json のみ → npm-no-lock として検出
+    # テスト環境に npm がある場合でも install 失敗 / already_installed / installed いずれかで exit 0
+    echo '{"name":"test","version":"1.0.0"}' > "$TMP_DIR/package.json"
+    run "$SCRIPT" --path "$TMP_DIR"
+    [ "$status" -eq 0 ]
+}

--- a/dev-env-setup/scripts/ensure-worktree-deps.bats
+++ b/dev-env-setup/scripts/ensure-worktree-deps.bats
@@ -46,3 +46,10 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"path"'* ]]
 }
+
+@test "委譲先失敗時のフォールバック JSON が jq で parse でき status が failed である" {
+    run "$SCRIPT" --path "/nonexistent/xyz_$$"
+    [ "$status" -eq 0 ]
+    # Validate JSON is well-formed and status field equals "failed"
+    echo "$output" | jq -e '.status == "failed"'
+}

--- a/dev-env-setup/scripts/ensure-worktree-deps.bats
+++ b/dev-env-setup/scripts/ensure-worktree-deps.bats
@@ -48,8 +48,12 @@ teardown() {
 }
 
 @test "委譲先失敗時のフォールバック JSON が jq で parse でき status が failed である" {
-    run "$SCRIPT" --path "/nonexistent/xyz_$$"
+    # JSON は stdout、診断 warning は stderr に出る。bats の run は両者を $output に
+    # 結合するため、jq parse には stdout のみを渡す (2>/dev/null で stderr を分離)。
+    run bash -c "'$SCRIPT' --path '/nonexistent/xyz_$$' 2>/dev/null"
     [ "$status" -eq 0 ]
-    # Validate JSON is well-formed and status field equals "failed"
-    echo "$output" | jq -e '.status == "failed"'
+    # Validate JSON is well-formed and status field equals "failed".
+    # printf '%s' (not echo) so literal "\n" inside the JSON string stays as data
+    # regardless of the shell's echo escape semantics (zsh / xpg_echo).
+    printf '%s\n' "$output" | jq -e '.status == "failed"'
 }

--- a/dev-env-setup/scripts/ensure-worktree-deps.bats
+++ b/dev-env-setup/scripts/ensure-worktree-deps.bats
@@ -33,3 +33,16 @@ teardown() {
     run "$SCRIPT" --path "$TMP_DIR"
     [ "$status" -eq 0 ]
 }
+
+@test "detect-and-install.sh が存在しないパスで呼ばれても exit 0 かつ status:failed の JSON を返す" {
+    # /nonexistent/xyz を渡すと detect-and-install.sh が die_json で exit 1 する
+    run "$SCRIPT" --path "/nonexistent/xyz_$$"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status":"failed"'* ]]
+}
+
+@test "委譲先失敗時の JSON に path フィールドが含まれる" {
+    run "$SCRIPT" --path "/nonexistent/xyz_$$"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"path"'* ]]
+}

--- a/dev-env-setup/scripts/ensure-worktree-deps.sh
+++ b/dev-env-setup/scripts/ensure-worktree-deps.sh
@@ -12,6 +12,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=../../_lib/common.sh
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
 # ============================================================================
 # Args
 # ============================================================================
@@ -70,9 +73,11 @@ fi
 # hard-crashed before it could write anything useful).
 if [[ -z "$output" ]] || [[ "${output:0:1}" != "{" ]]; then
     error_detail="${stderr_content:-exit code ${delegate_exit}}"
-    printf '{"status":"failed","path":"%s","error":"%s"}\n' \
-        "$TARGET_PATH" \
-        "$(printf '%s' "$error_detail" | tr '"' "'")"
+    # Use json_escape (jq -Rs . with fallback) to safely handle newlines,
+    # backslashes, and control characters that may appear in delegate stderr.
+    printf '{"status":"failed","path":%s,"error":%s}\n' \
+        "$(json_escape "$TARGET_PATH")" \
+        "$(json_escape "$error_detail")"
     exit 0
 fi
 

--- a/dev-env-setup/scripts/ensure-worktree-deps.sh
+++ b/dev-env-setup/scripts/ensure-worktree-deps.sh
@@ -33,9 +33,48 @@ fi
 # ============================================================================
 # Delegate to detect-and-install.sh (single source of truth for install logic)
 # Idempotency, pm detection, and already_installed checks are all in that script.
+#
+# Error handling:
+#   - Temporarily disable set -e to prevent this wrapper from aborting on
+#     a non-zero exit from the delegate (non-blocking contract).
+#   - Capture stdout, stderr, and exit code separately via temp files.
+#   - If the delegate hard-crashes (nonexistent path, missing jq, etc.) and
+#     emits empty or non-JSON output, emit a structured fallback JSON so
+#     dev-runner always receives a valid ENVSETUP schema payload.
+#   - Re-emit stderr as a diagnostic warning (never silently swallowed).
 # ============================================================================
 
-output="$("$SCRIPT_DIR/detect-and-install.sh" --path "$TARGET_PATH" 2>/dev/null || true)"
+stdout_tmp="$(mktemp)"
+stderr_tmp="$(mktemp)"
+exit_tmp="$(mktemp)"
+
+# set +e so a non-zero exit from detect-and-install.sh does not propagate to us.
+set +e
+"$SCRIPT_DIR/detect-and-install.sh" --path "$TARGET_PATH" >"$stdout_tmp" 2>"$stderr_tmp"
+printf '%d' $? >"$exit_tmp"
+set -e
+
+output="$(cat "$stdout_tmp")"
+delegate_exit="$(cat "$exit_tmp")"
+stderr_content="$(cat "$stderr_tmp")"
+rm -f "$stdout_tmp" "$stderr_tmp" "$exit_tmp"
+
+# Re-emit stderr as a diagnostic warn on fd2 so it is visible in logs.
+if [[ -n "$stderr_content" ]]; then
+    printf '[ensure-worktree-deps] detect-and-install stderr: %s\n' "$stderr_content" >&2
+fi
+
+# Validate that output looks like JSON (starts with '{'), regardless of exit code.
+# The delegate may exit non-zero but still emit structured error JSON — pass it through.
+# Only synthesize a fallback when output is empty or non-JSON (i.e., the delegate
+# hard-crashed before it could write anything useful).
+if [[ -z "$output" ]] || [[ "${output:0:1}" != "{" ]]; then
+    error_detail="${stderr_content:-exit code ${delegate_exit}}"
+    printf '{"status":"failed","path":"%s","error":"%s"}\n' \
+        "$TARGET_PATH" \
+        "$(printf '%s' "$error_detail" | tr '"' "'")"
+    exit 0
+fi
 
 printf '%s\n' "$output"
 

--- a/dev-env-setup/scripts/ensure-worktree-deps.sh
+++ b/dev-env-setup/scripts/ensure-worktree-deps.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# ensure-worktree-deps.sh - Non-blocking install wrapper for worktree setup (issue #120)
+#
+# Purpose: Called after a worktree is confirmed (WT established), attempts dependency
+# installation without blocking the dev-flow Setup phase. Even if install fails, this
+# script exits 0 — the failure is visible in the JSON output (status partial/failed),
+# and the downstream Validate (test-green) loop acts as the second safety net.
+#
+# Usage: ensure-worktree-deps.sh --path <dir>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ============================================================================
+# Args
+# ============================================================================
+
+TARGET_PATH=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --path) TARGET_PATH="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$TARGET_PATH" ]]; then
+    echo "--path is required" >&2
+    exit 2
+fi
+
+# ============================================================================
+# Delegate to detect-and-install.sh (single source of truth for install logic)
+# Idempotency, pm detection, and already_installed checks are all in that script.
+# ============================================================================
+
+output="$("$SCRIPT_DIR/detect-and-install.sh" --path "$TARGET_PATH" 2>/dev/null || true)"
+
+printf '%s\n' "$output"
+
+exit 0

--- a/docs/issue-120-dev-flow-setup-install.patch
+++ b/docs/issue-120-dev-flow-setup-install.patch
@@ -1,0 +1,43 @@
+# NOTE: dev-flow.js は Claude Code の Self-Modification guard により agent が直接編集不能なため
+# 本変更は human が以下コマンドで手動適用すること:
+#
+#   git apply docs/issue-120-dev-flow-setup-install.patch
+#
+# 適用後の検証: Setup phase が WT 確定後・Analyze 前に ensure-worktree-deps.sh を
+# dev-runner 経由で非ブロッキング実行することを確認する。
+# （WT が確定した直後にインストールが走り、Analyze phase 開始前に完了する）
+#
+# 事前確認（実適用しない）:
+#   git apply --check docs/issue-120-dev-flow-setup-install.patch
+diff --git a/.claude/workflows/dev-flow.js b/.claude/workflows/dev-flow.js
+--- a/.claude/workflows/dev-flow.js
++++ b/.claude/workflows/dev-flow.js
+@@ -181,6 +181,15 @@
+     summary: { type: 'string' },
+   },
+ }
++const ENVSETUP = {
++  type: 'object', required: ['status'],
++  properties: {
++    status: { type: 'string' },
++    path: { type: 'string' },
++    results: { type: 'array' },
++    custom: { type: 'object' },
++  },
++}
+ const EVAL = {
+   type: 'object', required: ['verdict', 'total'],
+   properties: {
+@@ -250,6 +259,12 @@
+ WT = setup.worktree
+ log(`worktree: ${WT} (branch ${setup.branch})`)
+
++const envSetup = await agent(
++  `cd ${WT} で作業。\`bash dev-env-setup/scripts/ensure-worktree-deps.sh --path ${WT}\` を実行し、結果を返せ。`,
++  { agentType: 'dev-runner', schema: ENVSETUP, label: 'env-setup', phase: 'Setup' },
++)
++log(`env-setup status: ${envSetup?.status ?? 'skipped'}`)
++
+ // ============================================================
+ // Phase Analyze: issue 分析（dev-issue-analyze skill を dev-runner 経由で呼ぶ）
+ // ============================================================

--- a/docs/issue-120-dev-flow-setup-install.patch
+++ b/docs/issue-120-dev-flow-setup-install.patch
@@ -33,7 +33,7 @@ diff --git a/.claude/workflows/dev-flow.js b/.claude/workflows/dev-flow.js
  log(`worktree: ${WT} (branch ${setup.branch})`)
 
 +const envSetup = await agent(
-+  `cd ${WT} で作業。\`bash dev-env-setup/scripts/ensure-worktree-deps.sh --path ${WT}\` を実行し、結果を返せ。`,
++  `\`$SKILLS_DIR/dev-env-setup/scripts/ensure-worktree-deps.sh --path ${WT}\` を実行し、結果を返せ。`,
 +  { agentType: 'dev-runner', schema: ENVSETUP, label: 'env-setup', phase: 'Setup' },
 +)
 +log(`env-setup status: ${envSetup?.status ?? 'skipped'}`)


### PR DESCRIPTION
## 概要

Closes #120

- `dev-env-setup/scripts/ensure-worktree-deps.sh` を新規追加（非ブロッキングラッパー）
- `detect-and-install.sh` を委譲先として呼び出し、install 失敗でも常に exit 0 を返す
- `dev-env-setup/SKILL.md` の Integration 節を新 Setup フローと整合するよう更新
- `dev-flow.js` への変更は Self-Modification guard により agent 直接編集不可のため `docs/issue-120-dev-flow-setup-install.patch` として提供（human が `git apply` で適用）
- patch 内容を検証する `_lib/issue-120-patch.test.mjs`（node:test）と bats テスト `ensure-worktree-deps.bats` を追加

## 動機

dev-flow workflow 化（#118）で Setup phase が `git worktree add` するだけになり、旧 dev-kickoff-worker Phase 1 にあった依存インストール（dev-env-setup）が抜けた。依存未インストールの worktree で implementer / test が走るリグレッション懸念があるため、Setup phase 完了直後（WT 確定後・Analyze 前）に非ブロッキングで install を試みる仕組みを導入する。install 失敗時は後段の Validate（test-green）ループが保険として機能する二段構えを維持。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `dev-env-setup/scripts/ensure-worktree-deps.sh` | 新規追加。detect-and-install.sh を委譲先とし常に exit 0 を返す非ブロッキングラッパー |
| `dev-env-setup/scripts/ensure-worktree-deps.bats` | ensure-worktree-deps.sh の bats ユニットテスト |
| `docs/issue-120-dev-flow-setup-install.patch` | dev-flow.js Setup phase への 1 ステップ追加パッチ（human 手動適用用） |
| `_lib/issue-120-patch.test.mjs` | patch ファイルの内容を node:test で検証するスクリプト（6 アサーション） |
| `dev-env-setup/SKILL.md` | Integration 節を新フロー（ensure-worktree-deps.sh 経由）に合わせて更新 |

## テスト計画

- [x] `bats dev-env-setup/scripts/ensure-worktree-deps.bats` — 3 テストすべて green
- [x] `node --test _lib/issue-120-patch.test.mjs` — 6 アサーションすべて green
- [ ] `git apply docs/issue-120-dev-flow-setup-install.patch` — patch が clean に適用できることを確認（human 手動）
- [ ] dev-flow ワークフロー実行で Setup phase 完了直後に env-setup ログが出ることを目視確認