### PR TITLE
fix(pr-iterate): review ⇄ fix ループの結果を PR コメントへ自動投稿

### DIFF
--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -268,13 +268,17 @@ for (i = 1; i <= MAX; i++) {
   // per-round 投稿: request-changes または comment
   const roundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking })
   const roundBodyFile = writeTempBody(roundBody, `review-${PR}-${i}-${review.decision}`)
-  const ghCmd = review.decision === 'request-changes'
-    ? `gh pr review ${PR} --request-changes --body-file ${roundBodyFile}`
-    : `gh pr review ${PR} --comment --body-file ${roundBodyFile}`
   const roundPost = await agent(
     `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: ${review.decision}）。\n`
     + `\n## Instructions\n`
-    + `以下のコマンドをそのまま実行せよ: \`${ghCmd}\`\n`
+    + (review.decision === 'request-changes'
+      ? `以下の手順で投稿せよ：\n`
+        + `1. self-PR 検出: \`gh pr view ${PR} --json author -q .author.login\` の出力と \`gh api user -q .login\` の出力を比較する。\n`
+        + `2. 自分自身の PR である場合（または --request-changes が "Can not request changes on your own pull request" エラーになる場合）は、\n`
+        + `   \`gh pr comment ${PR} --body-file ${roundBodyFile}\` でコメント投稿にフォールバックする。\n`
+        + `3. 自分自身の PR でない場合は \`gh pr review ${PR} --request-changes --body-file ${roundBodyFile}\` を試みる。\n`
+        + `   失敗した場合（"Can not request changes on your own pull request" 等）は \`gh pr comment ${PR} --body-file ${roundBodyFile}\` にフォールバックする。\n`
+      : `以下のコマンドをそのまま実行せよ: \`gh pr review ${PR} --comment --body-file ${roundBodyFile}\`\n`)
     + `投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
     + `投稿失敗時でも posted:false を返し throw しないこと。\n`
     + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -45,6 +45,103 @@ function issueTopic(x) {
   return `${file}::${desc}`
 }
 
+// ---- PR コメント生成関数 inline コピー（_lib/pr-comment-format.mjs から export 除去）-----------
+// loader 制約（ESM import 不可）のため関数本体を inline コピーしている。
+// _lib/pr-comment-format.sync.test.mjs がこの inline コピーの byte 一致を CI で保証する。
+// この関数を修正する際は、必ず _lib/pr-comment-format.mjs の元も同期すること。
+
+const DECISION_LABEL = {
+  'approve': '承認 (LGTM)',
+  'request-changes': '変更要求',
+  'comment': 'コメント',
+};
+
+function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
+  const label = DECISION_LABEL[decision] ?? decision;
+  const lines = [];
+
+  lines.push(`## PR #${pr} — レビュー結果 (iteration ${iteration})`);
+  lines.push('');
+  lines.push(`**判定**: ${label}`);
+  lines.push('');
+  lines.push('### Blocking 指摘');
+
+  if (!blocking || blocking.length === 0) {
+    lines.push('blocking 指摘なし');
+  } else {
+    for (const f of blocking) {
+      const loc = f.file != null
+        ? `${f.file}${f.line != null ? ':' + f.line : ''} `
+        : '';
+      const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
+      lines.push(`- [${f.severity}] ${loc}${f.description}${sug}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const STATUS_HEADLINE = {
+  'lgtm': '🎉 LGTM',
+  'stuck': '⚠️ STUCK — 人間レビューへエスカレーション',
+  'fix_failed': '⚠️ 自動修正失敗 — 人間へエスカレーション',
+  'max_reached': '⚠️ 反復上限到達',
+};
+
+function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, history }) {
+  const headline = STATUS_HEADLINE[status] ?? status;
+  const lines = [];
+
+  lines.push(`## PR #${pr} — pr-iterate 終了レポート`);
+  lines.push('');
+  lines.push(`### ${headline}`);
+  lines.push('');
+  lines.push(`- **総反復回数**: ${iterations}`);
+  lines.push(`- **最終判定**: ${DECISION_LABEL[lastDecision] ?? lastDecision}`);
+  lines.push(`- **最終判定理由**: ${lastSummary}`);
+
+  if (history && history.length > 0) {
+    lines.push('');
+    lines.push('### 反復履歴');
+    for (const round of history) {
+      const roundLabel = DECISION_LABEL[round.decision] ?? round.decision;
+      lines.push('');
+      lines.push(`#### Iteration ${round.iteration}: ${roundLabel}`);
+      lines.push(`${round.summary}`);
+      if (round.blocking && round.blocking.length > 0) {
+        lines.push(`- blocking 指摘数: ${round.blocking.length}`);
+        for (const f of round.blocking) {
+          const loc = f.file != null
+            ? `${f.file}${f.line != null ? ':' + f.line : ''} `
+            : '';
+          const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
+          lines.push(`  - [${f.severity}] ${loc}${f.description}${sug}`);
+        }
+      } else {
+        lines.push('- blocking 指摘なし');
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push('*このコメントは pr-iterate により自動生成されました。*');
+  lines.push(`<!-- pr-iterate:${status}:${iterations} -->`);
+
+  return lines.join('\n');
+}
+
+// ---- POST_RESULT schema（dev-runner 経由の PR 投稿結果）-----------------------------------
+const POST_RESULT = {
+  type: 'object',
+  required: ['posted'],
+  properties: {
+    posted: { type: 'boolean' },
+    method: { type: 'string' },
+    url: { type: 'string' },
+  },
+}
+
 const REVIEW = {
   type: 'object',
   required: ['decision', 'issues', 'summary'],
@@ -88,6 +185,7 @@ let lgtm = false
 let i = 0
 let terminal = null              // 早期終端理由（stuck / fix_failed）。null なら lgtm / max_reached で判定
 const reviewSeen = {}            // topic → { issue, count }（findings 累積 & stuck 検出。issue #126）
+const history = []               // ラウンド履歴 [{iteration, decision, summary, blocking}]
 
 for (i = 1; i <= MAX; i++) {
   const prior = Object.values(reviewSeen).map((s) => s.issue)   // 前 iteration までの累積 findings
@@ -107,6 +205,35 @@ for (i = 1; i <= MAX; i++) {
   if (review.decision === 'approve') {
     lgtm = true
     log(`iteration ${i}: LGTM`)
+
+    // approve ラウンドの history を記録（blocking なし）
+    history.push({ iteration: i, decision: review.decision, summary: review.summary, blocking: [] })
+
+    // per-round 投稿: approve（self-PR 検出 → --approve 失敗時 gh pr comment へフォールバック）
+    const approveBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking: [] })
+    const approvePost = await agent(
+      `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: approve）。\n`
+      + `\n## Instructions\n`
+      + `以下の手順で投稿せよ：\n`
+      + `1. self-PR 検出: \`gh pr view ${PR} --json author -q .author.login\` の出力と \`gh api user -q .login\` の出力を比較する。\n`
+      + `2. 自分自身の PR である場合（または --approve が "Cannot approve your own pull request" エラーになる場合）は、\n`
+      + `   \`gh pr comment ${PR} --body-file -\` でコメント投稿にフォールバックする。\n`
+      + `3. 自分自身の PR でない場合は \`gh pr review ${PR} --approve --body-file -\` を試みる。\n`
+      + `   失敗した場合（"Cannot approve your own pull request" 等）は \`gh pr comment ${PR} --body-file -\` にフォールバックする。\n`
+      + `4. 投稿本文は以下の BODY を stdin（ヒアドキュメント）で渡すこと（シェルクォート問題を避けるため）:\n`
+      + `   \`\`\`\n${approveBody}\n\`\`\`\n`
+      + `5. 投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
+      + `6. 投稿失敗時でも posted:false を返し throw しないこと。\n`
+      + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`
+      + `\n## Tools\n使用可: Bash\n`
+      + `\n## Boundary\nファイル変更禁止。git commit 禁止。\n`
+      + `\n## Token cap\n200 語以内で完結すること。`,
+      { agentType: 'dev-runner', schema: POST_RESULT, label: `post-review#${i}`, phase: 'Iterate' },
+    )
+    if (!approvePost?.posted) {
+      log(`⚠️ post-review#${i} (approve) の投稿に失敗しました（posted=${approvePost?.posted ?? 'null'}）。ワークフローは継続します。`)
+    }
+
     break
   }
 
@@ -121,6 +248,32 @@ for (i = 1; i <= MAX; i++) {
   const stuckTopics = Object.entries(reviewSeen).filter(([, s]) => s.count >= REVIEW_STUCK).map(([t]) => t)
   log(`iteration ${i}: ${review.decision} — blocking ${blocking.length} 件`
     + `${stuckTopics.length ? ` [REVIEW_STUCK: ${stuckTopics.join(' / ')}]` : ''}`)
+
+  // history に記録（blocking findings を含む）
+  history.push({ iteration: i, decision: review.decision, summary: review.summary, blocking })
+
+  // per-round 投稿: request-changes または comment
+  const roundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking })
+  const ghCmd = review.decision === 'request-changes'
+    ? `gh pr review ${PR} --request-changes --body-file -`
+    : `gh pr review ${PR} --comment --body-file -`
+  const roundPost = await agent(
+    `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: ${review.decision}）。\n`
+    + `\n## Instructions\n`
+    + `以下のコマンドを実行せよ: \`${ghCmd}\`\n`
+    + `投稿本文は以下の BODY を stdin（ヒアドキュメント）で渡すこと（シェルクォート問題を避けるため）:\n`
+    + `\`\`\`\n${roundBody}\n\`\`\`\n`
+    + `投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
+    + `投稿失敗時でも posted:false を返し throw しないこと。\n`
+    + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`
+    + `\n## Tools\n使用可: Bash\n`
+    + `\n## Boundary\nファイル変更禁止。git commit 禁止。\n`
+    + `\n## Token cap\n200 語以内で完結すること。`,
+    { agentType: 'dev-runner', schema: POST_RESULT, label: `post-review#${i}`, phase: 'Iterate' },
+  )
+  if (!roundPost?.posted) {
+    log(`⚠️ post-review#${i} (${review.decision}) の投稿に失敗しました（posted=${roundPost?.posted ?? 'null'}）。ワークフローは継続します。`)
+  }
 
   // stuck: 同一 topic が REVIEW_STUCK 回繰り返した = fix が刺さっていない。relax せず人間へエスカレーション。
   if (stuckTopics.length) {
@@ -153,6 +306,33 @@ for (i = 1; i <= MAX; i++) {
 
 const status = lgtm ? 'lgtm' : (terminal ?? 'max_reached')
 log(`pr-iterate 終端: status=${status}（iterations=${Math.min(i, MAX)}）`)
+
+// 終端サマリーを PR に 1 回だけ投稿する
+const summaryBody = buildTerminalSummaryBody({
+  pr: PR,
+  status,
+  iterations: Math.min(i, MAX),
+  lastDecision: lastReview?.decision ?? null,
+  lastSummary: lastReview?.summary ?? null,
+  history,
+})
+const summaryPost = await agent(
+  `## Objective\nPR #${PR} に pr-iterate の終端サマリーコメントを投稿する（status: ${status}）。\n`
+  + `\n## Instructions\n`
+  + `以下のコマンドを実行せよ: \`gh pr comment ${PR} --body-file -\`\n`
+  + `投稿本文は以下の BODY を stdin（ヒアドキュメント）で渡すこと（シェルクォート問題を避けるため）:\n`
+  + `\`\`\`\n${summaryBody}\n\`\`\`\n`
+  + `投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
+  + `投稿失敗時でも posted:false を返し throw しないこと。\n`
+  + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`
+  + `\n## Tools\n使用可: Bash\n`
+  + `\n## Boundary\nファイル変更禁止。git commit 禁止。\n`
+  + `\n## Token cap\n200 語以内で完結すること。`,
+  { agentType: 'dev-runner', schema: POST_RESULT, label: `post-summary`, phase: 'Iterate' },
+)
+if (!summaryPost?.posted) {
+  log(`⚠️ post-summary の投稿に失敗しました（posted=${summaryPost?.posted ?? 'null'}）。ワークフローは継続します。`)
+}
 
 return {
   pr: PR,

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -131,6 +131,20 @@ function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSu
   return lines.join('\n');
 }
 
+// ---- 投稿本文を一時ファイルに書き出すヘルパー ------------------------------------------
+// body をプロンプトに inline で埋め込むと triple-backtick フェンスやバッククォートを含む
+// コードレビュー本文でフェンス境界が衝突し LLM が本文を truncate / 誤解釈する危険がある。
+// 一時ファイルに書き出して agent にはパスのみ渡すことでこの問題を構造的に排除する。
+const _fs = require('fs')
+const _os = require('os')
+const _path = require('path')
+
+function writeTempBody(body, label) {
+  const file = _path.join(_os.tmpdir(), `pr-iterate-${label}-${Date.now()}.md`)
+  _fs.writeFileSync(file, body, 'utf8')
+  return file
+}
+
 // ---- POST_RESULT schema（dev-runner 経由の PR 投稿結果）-----------------------------------
 const POST_RESULT = {
   type: 'object',
@@ -211,19 +225,18 @@ for (i = 1; i <= MAX; i++) {
 
     // per-round 投稿: approve（self-PR 検出 → --approve 失敗時 gh pr comment へフォールバック）
     const approveBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking: [] })
+    const approveBodyFile = writeTempBody(approveBody, `review-${PR}-${i}-approve`)
     const approvePost = await agent(
       `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: approve）。\n`
       + `\n## Instructions\n`
       + `以下の手順で投稿せよ：\n`
       + `1. self-PR 検出: \`gh pr view ${PR} --json author -q .author.login\` の出力と \`gh api user -q .login\` の出力を比較する。\n`
       + `2. 自分自身の PR である場合（または --approve が "Cannot approve your own pull request" エラーになる場合）は、\n`
-      + `   \`gh pr comment ${PR} --body-file -\` でコメント投稿にフォールバックする。\n`
-      + `3. 自分自身の PR でない場合は \`gh pr review ${PR} --approve --body-file -\` を試みる。\n`
-      + `   失敗した場合（"Cannot approve your own pull request" 等）は \`gh pr comment ${PR} --body-file -\` にフォールバックする。\n`
-      + `4. 投稿本文は以下の BODY を stdin（ヒアドキュメント）で渡すこと（シェルクォート問題を避けるため）:\n`
-      + `   \`\`\`\n${approveBody}\n\`\`\`\n`
-      + `5. 投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
-      + `6. 投稿失敗時でも posted:false を返し throw しないこと。\n`
+      + `   \`gh pr comment ${PR} --body-file ${approveBodyFile}\` でコメント投稿にフォールバックする。\n`
+      + `3. 自分自身の PR でない場合は \`gh pr review ${PR} --approve --body-file ${approveBodyFile}\` を試みる。\n`
+      + `   失敗した場合（"Cannot approve your own pull request" 等）は \`gh pr comment ${PR} --body-file ${approveBodyFile}\` にフォールバックする。\n`
+      + `4. 投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
+      + `5. 投稿失敗時でも posted:false を返し throw しないこと。\n`
       + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`
       + `\n## Tools\n使用可: Bash\n`
       + `\n## Boundary\nファイル変更禁止。git commit 禁止。\n`
@@ -254,15 +267,14 @@ for (i = 1; i <= MAX; i++) {
 
   // per-round 投稿: request-changes または comment
   const roundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking })
+  const roundBodyFile = writeTempBody(roundBody, `review-${PR}-${i}-${review.decision}`)
   const ghCmd = review.decision === 'request-changes'
-    ? `gh pr review ${PR} --request-changes --body-file -`
-    : `gh pr review ${PR} --comment --body-file -`
+    ? `gh pr review ${PR} --request-changes --body-file ${roundBodyFile}`
+    : `gh pr review ${PR} --comment --body-file ${roundBodyFile}`
   const roundPost = await agent(
     `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: ${review.decision}）。\n`
     + `\n## Instructions\n`
-    + `以下のコマンドを実行せよ: \`${ghCmd}\`\n`
-    + `投稿本文は以下の BODY を stdin（ヒアドキュメント）で渡すこと（シェルクォート問題を避けるため）:\n`
-    + `\`\`\`\n${roundBody}\n\`\`\`\n`
+    + `以下のコマンドをそのまま実行せよ: \`${ghCmd}\`\n`
     + `投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
     + `投稿失敗時でも posted:false を返し throw しないこと。\n`
     + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`
@@ -316,12 +328,11 @@ const summaryBody = buildTerminalSummaryBody({
   lastSummary: lastReview?.summary ?? null,
   history,
 })
+const summaryBodyFile = writeTempBody(summaryBody, `summary-${PR}-${status}`)
 const summaryPost = await agent(
   `## Objective\nPR #${PR} に pr-iterate の終端サマリーコメントを投稿する（status: ${status}）。\n`
   + `\n## Instructions\n`
-  + `以下のコマンドを実行せよ: \`gh pr comment ${PR} --body-file -\`\n`
-  + `投稿本文は以下の BODY を stdin（ヒアドキュメント）で渡すこと（シェルクォート問題を避けるため）:\n`
-  + `\`\`\`\n${summaryBody}\n\`\`\`\n`
+  + `以下のコマンドをそのまま実行せよ: \`gh pr comment ${PR} --body-file ${summaryBodyFile}\`\n`
   + `投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
   + `投稿失敗時でも posted:false を返し throw しないこと。\n`
   + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`

--- a/_lib/pr-comment-format.mjs
+++ b/_lib/pr-comment-format.mjs
@@ -1,0 +1,111 @@
+// buildReviewCommentBody / buildTerminalSummaryBody: pr-iterate の per-round
+// レビューコメントおよび終端サマリー markdown を生成する純粋関数。
+// I/O なし、gh なし、Date.now() 非決定性なし。
+//
+// INLINE COPY POLICY: .claude/workflows/pr-iterate.js は Claude Code の
+// dynamic workflow ローダーが独自の VM コンテキストで評価するため、ESM の
+// import 文（`import { buildReviewCommentBody } from '../../_lib/pr-comment-format.mjs'` 等）
+// は使用できない。そのため pr-iterate.js に両関数の本体を inline コピーしており、
+// _lib/pr-comment-format.sync.test.mjs がその byte 一致を CI で保証する。
+// この関数を修正する際は、必ず pr-iterate.js の inline コピーも同期すること。
+
+const DECISION_LABEL = {
+  'approve': '承認 (LGTM)',
+  'request-changes': '変更要求',
+  'comment': 'コメント',
+};
+
+/**
+ * per-round レビューコメント markdown を生成する。
+ * @param {object} opts
+ * @param {number|string} opts.pr - PR 番号
+ * @param {number} opts.iteration - 反復回数
+ * @param {string} opts.decision - 'approve' | 'request-changes' | 'comment'
+ * @param {Array} opts.blocking - blocking finding の配列
+ * @returns {string}
+ */
+export function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
+  const label = DECISION_LABEL[decision] ?? decision;
+  const lines = [];
+
+  lines.push(`## PR #${pr} — レビュー結果 (iteration ${iteration})`);
+  lines.push('');
+  lines.push(`**判定**: ${label}`);
+  lines.push('');
+  lines.push('### Blocking 指摘');
+
+  if (!blocking || blocking.length === 0) {
+    lines.push('blocking 指摘なし');
+  } else {
+    for (const f of blocking) {
+      const loc = f.file != null
+        ? `${f.file}${f.line != null ? ':' + f.line : ''} `
+        : '';
+      const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
+      lines.push(`- [${f.severity}] ${loc}${f.description}${sug}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const STATUS_HEADLINE = {
+  'lgtm': '🎉 LGTM',
+  'stuck': '⚠️ STUCK — 人間レビューへエスカレーション',
+  'fix_failed': '⚠️ 自動修正失敗 — 人間へエスカレーション',
+  'max_reached': '⚠️ 反復上限到達',
+};
+
+/**
+ * 終端サマリー markdown を生成する。
+ * @param {object} opts
+ * @param {number|string} opts.pr - PR 番号
+ * @param {string} opts.status - 'lgtm' | 'stuck' | 'fix_failed' | 'max_reached'
+ * @param {number} opts.iterations - 総反復回数
+ * @param {string} opts.lastDecision - 最終判定
+ * @param {string} opts.lastSummary - 最終サマリーテキスト
+ * @param {Array} opts.history - ラウンド履歴 [{iteration, decision, summary, blocking}]
+ * @returns {string}
+ */
+export function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, history }) {
+  const headline = STATUS_HEADLINE[status] ?? status;
+  const lines = [];
+
+  lines.push(`## PR #${pr} — pr-iterate 終了レポート`);
+  lines.push('');
+  lines.push(`### ${headline}`);
+  lines.push('');
+  lines.push(`- **総反復回数**: ${iterations}`);
+  lines.push(`- **最終判定**: ${DECISION_LABEL[lastDecision] ?? lastDecision}`);
+  lines.push(`- **最終判定理由**: ${lastSummary}`);
+
+  if (history && history.length > 0) {
+    lines.push('');
+    lines.push('### 反復履歴');
+    for (const round of history) {
+      const roundLabel = DECISION_LABEL[round.decision] ?? round.decision;
+      lines.push('');
+      lines.push(`#### Iteration ${round.iteration}: ${roundLabel}`);
+      lines.push(`${round.summary}`);
+      if (round.blocking && round.blocking.length > 0) {
+        lines.push(`- blocking 指摘数: ${round.blocking.length}`);
+        for (const f of round.blocking) {
+          const loc = f.file != null
+            ? `${f.file}${f.line != null ? ':' + f.line : ''} `
+            : '';
+          const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
+          lines.push(`  - [${f.severity}] ${loc}${f.description}${sug}`);
+        }
+      } else {
+        lines.push('- blocking 指摘なし');
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push('*このコメントは pr-iterate により自動生成されました。*');
+  lines.push(`<!-- pr-iterate:${status}:${iterations} -->`);
+
+  return lines.join('\n');
+}

--- a/_lib/pr-comment-format.sync.test.mjs
+++ b/_lib/pr-comment-format.sync.test.mjs
@@ -1,0 +1,37 @@
+// Sync test: workflow inline コピーが canonical と byte 一致することを保証する。
+//
+// 背景: .claude/workflows/pr-iterate.js は Claude Code の dynamic workflow ローダーが
+// 独自の VM コンテキストで評価する。ESM の import 文はそのコンテキストで使用できないため、
+// buildReviewCommentBody / buildTerminalSummaryBody の関数本体を pr-iterate.js に inline
+// コピーしている。このテストはその手動同期の漏れを CI で検出するための安全網である。
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+
+// canonical ソースまたは inline コピーから指定関数の `function fnName ... }` ブロックを抽出する。
+// export キーワードは除いて比較するため、先頭の `export ` を strip する。
+function extractFn(src, fnName) {
+  const m = src.match(new RegExp(`function ${fnName}\\([\\s\\S]*?\\n}`));
+  if (!m) throw new Error(`${fnName} が見つからない`);
+  return m[0].trim();
+}
+
+for (const fnName of ['buildReviewCommentBody', 'buildTerminalSummaryBody']) {
+  const canonicalSrc = readFileSync(join(repoRoot, '_lib/pr-comment-format.mjs'), 'utf8');
+  const canonical = extractFn(canonicalSrc, fnName);
+
+  test(`.claude/workflows/pr-iterate.js の inline ${fnName} が canonical と byte 一致`, () => {
+    const inlinedSrc = readFileSync(join(repoRoot, '.claude/workflows/pr-iterate.js'), 'utf8');
+    const inlined = extractFn(inlinedSrc, fnName);
+    assert.equal(
+      inlined,
+      canonical,
+      `.claude/workflows/pr-iterate.js の inline コピー ${fnName} が _lib/pr-comment-format.mjs と乖離している`,
+    );
+  });
+}

--- a/_lib/pr-comment-format.test.mjs
+++ b/_lib/pr-comment-format.test.mjs
@@ -1,0 +1,281 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReviewCommentBody, buildTerminalSummaryBody } from './pr-comment-format.mjs';
+
+// ─── buildReviewCommentBody ───────────────────────────────────────────────────
+
+test('buildReviewCommentBody: approve -> 承認/LGTM ラベルを含む見出し', () => {
+  const body = buildReviewCommentBody({
+    pr: 42,
+    iteration: 1,
+    decision: 'approve',
+    blocking: [],
+  });
+  assert.ok(typeof body === 'string', 'string を返す');
+  assert.ok(body.includes('1'), 'iteration 番号を含む');
+  assert.ok(body.includes('承認') || body.includes('LGTM'), 'approve ラベルを含む');
+});
+
+test('buildReviewCommentBody: request-changes -> 変更要求 ラベルを含む見出し', () => {
+  const body = buildReviewCommentBody({
+    pr: 10,
+    iteration: 2,
+    decision: 'request-changes',
+    blocking: [],
+  });
+  assert.ok(body.includes('変更要求'), 'request-changes ラベルを含む');
+  assert.ok(body.includes('2'), 'iteration 番号を含む');
+});
+
+test('buildReviewCommentBody: comment -> コメント ラベルを含む見出し', () => {
+  const body = buildReviewCommentBody({
+    pr: 7,
+    iteration: 3,
+    decision: 'comment',
+    blocking: [],
+  });
+  assert.ok(body.includes('コメント'), 'comment ラベルを含む');
+  assert.ok(body.includes('3'), 'iteration 番号を含む');
+});
+
+test('buildReviewCommentBody: blocking 空の場合は "blocking 指摘なし" を表示', () => {
+  const body = buildReviewCommentBody({
+    pr: 5,
+    iteration: 1,
+    decision: 'approve',
+    blocking: [],
+  });
+  assert.ok(body.includes('blocking 指摘なし'), 'blocking 空時の表示');
+});
+
+test('buildReviewCommentBody: finding に file/line/suggestion すべて有り', () => {
+  const body = buildReviewCommentBody({
+    pr: 5,
+    iteration: 1,
+    decision: 'request-changes',
+    blocking: [
+      {
+        severity: 'error',
+        file: 'src/foo.ts',
+        line: 42,
+        description: 'null check missing',
+        suggestion: 'add null guard',
+      },
+    ],
+  });
+  assert.ok(body.includes('error'), 'severity を含む');
+  assert.ok(body.includes('src/foo.ts'), 'file を含む');
+  assert.ok(body.includes('42'), 'line を含む');
+  assert.ok(body.includes('null check missing'), 'description を含む');
+  assert.ok(body.includes('add null guard'), 'suggestion を含む');
+  // bullet format: `- [severity] file:line description → suggestion`
+  assert.ok(body.includes('- [error]'), 'bullet 形式を含む');
+  assert.ok(body.includes('src/foo.ts:42'), 'file:line 形式を含む');
+  assert.ok(body.includes('→'), '矢印区切り');
+});
+
+test('buildReviewCommentBody: finding に file/line なし', () => {
+  const body = buildReviewCommentBody({
+    pr: 5,
+    iteration: 1,
+    decision: 'request-changes',
+    blocking: [
+      {
+        severity: 'warning',
+        description: 'unused variable',
+      },
+    ],
+  });
+  assert.ok(body.includes('warning'), 'severity を含む');
+  assert.ok(body.includes('unused variable'), 'description を含む');
+  // file:line は含まない
+  assert.ok(!body.match(/undefined:undefined/), 'file:line が undefined にならない');
+});
+
+test('buildReviewCommentBody: finding に suggestion なし', () => {
+  const body = buildReviewCommentBody({
+    pr: 5,
+    iteration: 1,
+    decision: 'request-changes',
+    blocking: [
+      {
+        severity: 'error',
+        file: 'src/bar.ts',
+        line: 10,
+        description: 'type error',
+      },
+    ],
+  });
+  assert.ok(body.includes('type error'), 'description を含む');
+  // suggestion の矢印が出ない
+  assert.ok(!body.includes('→ undefined'), 'undefined suggestion を出力しない');
+});
+
+test('buildReviewCommentBody: 複数 finding をすべてリスト', () => {
+  const body = buildReviewCommentBody({
+    pr: 3,
+    iteration: 2,
+    decision: 'request-changes',
+    blocking: [
+      { severity: 'error', description: 'first error' },
+      { severity: 'warning', description: 'second warning' },
+    ],
+  });
+  assert.ok(body.includes('first error'), '1件目を含む');
+  assert.ok(body.includes('second warning'), '2件目を含む');
+});
+
+test('buildReviewCommentBody: 決定性（同入力 -> 同出力）', () => {
+  const input = {
+    pr: 99,
+    iteration: 5,
+    decision: 'request-changes',
+    blocking: [
+      { severity: 'error', file: 'a.ts', line: 1, description: 'desc', suggestion: 'fix' },
+    ],
+  };
+  const first = buildReviewCommentBody(input);
+  const second = buildReviewCommentBody(input);
+  assert.equal(first, second, '同入力 -> バイト完全一致');
+});
+
+// ─── buildTerminalSummaryBody ─────────────────────────────────────────────────
+
+test('buildTerminalSummaryBody: lgtm -> LGTM/承認 見出し', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 42,
+    status: 'lgtm',
+    iterations: 2,
+    lastDecision: 'approve',
+    lastSummary: 'looks good',
+    history: [],
+  });
+  assert.ok(typeof body === 'string', 'string を返す');
+  assert.ok(body.includes('42'), 'PR 番号を含む');
+  assert.ok(body.includes('LGTM') || body.includes('承認'), 'lgtm 見出しを含む');
+});
+
+test('buildTerminalSummaryBody: stuck -> 人間レビューへエスカレーション(stuck)', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 10,
+    status: 'stuck',
+    iterations: 3,
+    lastDecision: 'request-changes',
+    lastSummary: 'not improving',
+    history: [],
+  });
+  assert.ok(body.includes('stuck') || body.includes('エスカレーション'), 'stuck 見出しを含む');
+  assert.ok(body.includes('人間レビュー') || body.includes('エスカレーション'), '人間レビューへの言及');
+});
+
+test('buildTerminalSummaryBody: fix_failed -> 自動修正失敗', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 5,
+    status: 'fix_failed',
+    iterations: 1,
+    lastDecision: 'request-changes',
+    lastSummary: 'fix failed',
+    history: [],
+  });
+  assert.ok(body.includes('自動修正失敗') || body.includes('fix_failed'), 'fix_failed 見出しを含む');
+});
+
+test('buildTerminalSummaryBody: max_reached -> 上限到達', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 8,
+    status: 'max_reached',
+    iterations: 10,
+    lastDecision: 'request-changes',
+    lastSummary: 'max iterations hit',
+    history: [],
+  });
+  assert.ok(body.includes('上限到達') || body.includes('max_reached'), 'max_reached 見出しを含む');
+});
+
+test('buildTerminalSummaryBody: iterations と lastDecision/lastSummary を含む', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 20,
+    status: 'lgtm',
+    iterations: 4,
+    lastDecision: 'approve',
+    lastSummary: 'all checks pass',
+    history: [],
+  });
+  assert.ok(body.includes('4'), 'iteration 数を含む');
+  assert.ok(body.includes('all checks pass'), 'lastSummary を含む');
+});
+
+test('buildTerminalSummaryBody: history セクションをレンダリング', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 1,
+    status: 'lgtm',
+    iterations: 2,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    history: [
+      {
+        iteration: 1,
+        decision: 'request-changes',
+        summary: 'needs work',
+        blocking: [
+          { severity: 'error', description: 'something wrong' },
+        ],
+      },
+      {
+        iteration: 2,
+        decision: 'approve',
+        summary: 'looks good now',
+        blocking: [],
+      },
+    ],
+  });
+  // 各ラウンドの decision が含まれる
+  assert.ok(body.includes('request-changes') || body.includes('変更要求'), 'iteration 1 decision');
+  assert.ok(body.includes('approve') || body.includes('承認'), 'iteration 2 decision');
+  // summary が含まれる
+  assert.ok(body.includes('needs work'), 'iteration 1 summary');
+  assert.ok(body.includes('looks good now'), 'iteration 2 summary');
+  // blocking count/list
+  assert.ok(body.includes('something wrong') || body.includes('1'), 'blocking finding');
+});
+
+test('buildTerminalSummaryBody: idempotency marker を埋め込む', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 55,
+    status: 'stuck',
+    iterations: 3,
+    lastDecision: 'request-changes',
+    lastSummary: 'still stuck',
+    history: [],
+  });
+  // status と iterations を含む安定マーカー行
+  assert.ok(body.includes('stuck'), 'status をマーカーに含む');
+  assert.ok(body.includes('3'), 'iterations をマーカーに含む');
+});
+
+test('buildTerminalSummaryBody: 決定性（同入力 -> 同出力）', () => {
+  const input = {
+    pr: 77,
+    status: 'lgtm',
+    iterations: 2,
+    lastDecision: 'approve',
+    lastSummary: 'perfect',
+    history: [
+      {
+        iteration: 1,
+        decision: 'request-changes',
+        summary: 'minor issues',
+        blocking: [{ severity: 'warning', description: 'style' }],
+      },
+      {
+        iteration: 2,
+        decision: 'approve',
+        summary: 'fixed',
+        blocking: [],
+      },
+    ],
+  };
+  const first = buildTerminalSummaryBody(input);
+  const second = buildTerminalSummaryBody(input);
+  assert.equal(first, second, '同入力 -> バイト完全一致');
+});


### PR DESCRIPTION
## 概要

Closes #132

- pr-iterate.js のループ内で各 iteration のレビュー判定を PR コメントとして投稿
- ループ終端（lgtm / stuck / fix_failed / max_reached）後にサマリを PR へ 1 回投稿
- self-PR で `gh pr review --approve` が失敗する場合は `gh pr comment` へフォールバック

## 動機

dev-flow を dynamic workflow へ移行した際（`eb8aa7e`）、旧 `submit-review.sh` と `post-summary.sh` が削除された。
これらの PR 投稿責務が workflow 側に引き継がれず、review ⇄ fix ループの結果が GitHub PR に届かなくなっていた。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/pr-iterate.js` | per-round 投稿（approve / request-changes / comment）と終端サマリー投稿を追加。`history[]` でラウンド履歴を蓄積 |
| `_lib/pr-comment-format.mjs` | `buildReviewCommentBody` / `buildTerminalSummaryBody` 整形関数を切り出し |
| `_lib/pr-comment-format.sync.test.mjs` | workflow inline コピーと `_lib` 側の byte 一致を CI で保証 |
| `_lib/pr-comment-format.test.mjs` | 整形関数のユニットテスト |

### 設計上の注意点

- workflow loader が ESM `import` を解決できないため、整形関数は `pr-iterate.js` に inline コピーを維持
- sync テストが inline コピーのドリフトを検出することで、保守コストを最小化
- 投稿失敗時は `posted:false` を返してワークフローを継続（握り潰しなし）

## テスト計画

- [x] `_lib/pr-comment-format.test.mjs` — 整形関数のユニットテスト
- [x] `_lib/pr-comment-format.sync.test.mjs` — inline コピーの byte 一致確認
- [ ] pr-iterate を実際に動かして PR コメントが投稿されることを確認