### PR TITLE
fix(pr-iterate): CI ゲート欠落を修正 — approve 後に CI 状態を確認し pending/failure を区別

### DIFF
--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -83,18 +83,22 @@ const FIX = {
 
 // CI gate schema — restores the gate lost in eb8aa7e (issue #133).
 // dev-runner runs pr-iterate/scripts/check-ci.sh and returns its stdout JSON unchanged.
+// failed_checks items match script output: {name, bucket, state} (conclusion was removed in
+// the bucket-field migration; see issue #133 / ci::bats-fabricated-schema).
+// 'error' status means gh API failed (auth/network); escalate to human immediately.
 const CI_STATUS = {
   type: 'object',
   required: ['status'],
   properties: {
-    status: { type: 'string', enum: ['passed', 'failed', 'pending', 'no_checks'] },
+    status: { type: 'string', enum: ['passed', 'failed', 'pending', 'no_checks', 'error'] },
     failed_checks: {
       type: 'array',
       items: {
         type: 'object',
         properties: {
           name: { type: 'string' },
-          conclusion: { type: 'string' },
+          bucket: { type: 'string' },
+          state: { type: 'string' },
         },
       },
     },
@@ -144,7 +148,7 @@ for (i = 1; i <= MAX; i++) {
       + `\`\`\`\nbash pr-iterate/scripts/check-ci.sh ${PR}\n\`\`\`\n`
       + `スクリプトの stdout JSON（{status, failed_checks, ...}）をそのまま返せ。\n\n`
       + `## Output format\n`
-      + `{ "status": "passed"|"failed"|"pending"|"no_checks", "failed_checks": [{name, conclusion}, ...] }\n`
+      + `{ "status": "passed"|"failed"|"pending"|"no_checks"|"error", "failed_checks": [{name, bucket, state}, ...] }\n`
       + `prose 禁止。JSON のみ返せ。\n\n`
       + `## Token cap\n`
       + `JSON のみ。1 行以内。`,
@@ -157,68 +161,73 @@ for (i = 1; i <= MAX; i++) {
       lgtm = true
       log(`iteration ${i}: LGTM（CI status=${ci.status}）`)
       break
-    }
-
-    if (ci.status === 'pending') {
+    } else if (ci.status === 'error') {
+      // Real gh API error (auth failure, network error, etc.) — do not misinterpret as CI failure.
+      // Surface to human immediately; retrying pr-fix on a non-existent bug would waste cycles.
+      terminal = 'ci_error'
+      log(`⚠️ CI check returned error — gh API failed (auth/network). 人間へエスカレーション`)
+      break
+    } else if (ci.status === 'pending') {
       terminal = 'ci_pending'
       log(`⚠️ CI pending — checks incomplete, never auto-approve. 人間/CI 完了待ちへエスカレーション`)
       break
+    } else if (ci.status === 'failed') {
+      // ci.status === 'failed': convert failed_checks into synthetic blocking findings and route
+      // through the existing pr-fix path. Repeated identical ci::<name> topics hit REVIEW_STUCK
+      // automatically via the existing stuckTopics computation below.
+      // failed_checks items are {name, bucket, state} per check-ci.sh output (no conclusion field).
+      const ciFindings = (ci.failed_checks && ci.failed_checks.length > 0)
+        ? ci.failed_checks.map((c) => ({
+            severity: 'critical',
+            topic: `ci::${c.name}`,
+            description: `CI check failed: ${c.name} (${c.state ?? c.bucket})`,
+            suggestion: 'CI を green にする',
+          }))
+        : [{
+            severity: 'critical',
+            topic: 'ci::unknown',
+            description: 'CI failed (no specific check details available)',
+            suggestion: 'CI を green にする',
+          }]
+
+      // Register CI findings into reviewSeen exactly like the existing blocking loop so that
+      // repeated identical CI failures (same ci::<name> topic) trigger REVIEW_STUCK escalation.
+      for (const x of ciFindings) {
+        const t = issueTopic(x)
+        if (reviewSeen[t]) { reviewSeen[t].issue = x; reviewSeen[t].count += 1 }
+        else reviewSeen[t] = { issue: x, count: 1 }
+      }
+      const ciStuckTopics = Object.entries(reviewSeen).filter(([, s]) => s.count >= REVIEW_STUCK).map(([t]) => t)
+      log(`iteration ${i}: approve but CI failed — ${ciFindings.length} failing check(s)`
+        + `${ciStuckTopics.length ? ` [REVIEW_STUCK: ${ciStuckTopics.join(' / ')}]` : ''}`)
+
+      if (ciStuckTopics.length) {
+        terminal = 'stuck'
+        log(`⚠️ Review STUCK — 同一 CI failure topic が ${REVIEW_STUCK} 回反復（${ciStuckTopics.join(' / ')}）。`
+          + `relax せず人間レビューへエスカレーション（critical/major のゲートは後退させない）`)
+        break
+      }
+
+      const issuesText = ciFindings
+        .map((x) => `- [${x.severity}] ${x.description}${x.suggestion ? ' → ' + x.suggestion : ''}`)
+        .join('\n')
+
+      const fix = await agent(
+        `PR #${PR} の CI 失敗を修正する。次の CI 失敗を解消するため \`Skill: pr-fix ${PR}\` を実行し、`
+        + `修正を push まで行え。解消すべき CI 失敗:\n${issuesText}`,
+        { agentType: 'dev-runner', schema: FIX, label: `fix#${i}`, phase: 'Iterate' },
+      )
+
+      if (fix == null || fix.applied !== true) {
+        terminal = 'fix_failed'
+        log(`⚠️ fix#${i} が適用されず（applied=${fix?.applied ?? 'null'}）— ${fix?.summary ?? '理由不明'}。`
+          + `無言で再レビューを繰り返さず人間へエスカレーション`)
+        break
+      }
+
+      // CI fix applied — continue to next iteration for re-review + re-CI-check
+      continue
     }
-
-    // ci.status === 'failed': convert failed_checks into synthetic blocking findings and route
-    // through the existing pr-fix path. Repeated identical ci::<name> topics hit REVIEW_STUCK
-    // automatically via the existing stuckTopics computation below.
-    const ciFindings = (ci.failed_checks && ci.failed_checks.length > 0)
-      ? ci.failed_checks.map((c) => ({
-          severity: 'critical',
-          topic: `ci::${c.name}`,
-          description: `CI check failed: ${c.name} (${c.conclusion})`,
-          suggestion: 'CI を green にする',
-        }))
-      : [{
-          severity: 'critical',
-          topic: 'ci::unknown',
-          description: 'CI failed (no specific check details available)',
-          suggestion: 'CI を green にする',
-        }]
-
-    // Register CI findings into reviewSeen exactly like the existing blocking loop so that
-    // repeated identical CI failures (same ci::<name> topic) trigger REVIEW_STUCK escalation.
-    for (const x of ciFindings) {
-      const t = issueTopic(x)
-      if (reviewSeen[t]) { reviewSeen[t].issue = x; reviewSeen[t].count += 1 }
-      else reviewSeen[t] = { issue: x, count: 1 }
-    }
-    const ciStuckTopics = Object.entries(reviewSeen).filter(([, s]) => s.count >= REVIEW_STUCK).map(([t]) => t)
-    log(`iteration ${i}: approve but CI failed — ${ciFindings.length} failing check(s)`
-      + `${ciStuckTopics.length ? ` [REVIEW_STUCK: ${ciStuckTopics.join(' / ')}]` : ''}`)
-
-    if (ciStuckTopics.length) {
-      terminal = 'stuck'
-      log(`⚠️ Review STUCK — 同一 CI failure topic が ${REVIEW_STUCK} 回反復（${ciStuckTopics.join(' / ')}）。`
-        + `relax せず人間レビューへエスカレーション（critical/major のゲートは後退させない）`)
-      break
-    }
-
-    const issuesText = ciFindings
-      .map((x) => `- [${x.severity}] ${x.description}${x.suggestion ? ' → ' + x.suggestion : ''}`)
-      .join('\n')
-
-    const fix = await agent(
-      `PR #${PR} の CI 失敗を修正する。次の CI 失敗を解消するため \`Skill: pr-fix ${PR}\` を実行し、`
-      + `修正を push まで行え。解消すべき CI 失敗:\n${issuesText}`,
-      { agentType: 'dev-runner', schema: FIX, label: `fix#${i}`, phase: 'Iterate' },
-    )
-
-    if (fix == null || fix.applied !== true) {
-      terminal = 'fix_failed'
-      log(`⚠️ fix#${i} が適用されず（applied=${fix?.applied ?? 'null'}）— ${fix?.summary ?? '理由不明'}。`
-        + `無言で再レビューを繰り返さず人間へエスカレーション`)
-      break
-    }
-
-    // CI fix applied — continue to next iteration for re-review + re-CI-check
-    continue
   }
 
   const blocking = review.issues.filter((x) => x.severity === 'critical' || x.severity === 'major')

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -81,6 +81,26 @@ const FIX = {
   },
 }
 
+// CI gate schema — restores the gate lost in eb8aa7e (issue #133).
+// dev-runner runs pr-iterate/scripts/check-ci.sh and returns its stdout JSON unchanged.
+const CI_STATUS = {
+  type: 'object',
+  required: ['status'],
+  properties: {
+    status: { type: 'string', enum: ['passed', 'failed', 'pending', 'no_checks'] },
+    failed_checks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          conclusion: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
 phase('Iterate')
 
 let lastReview = null
@@ -105,9 +125,100 @@ for (i = 1; i <= MAX; i++) {
   lastReview = review
 
   if (review.decision === 'approve') {
-    lgtm = true
-    log(`iteration ${i}: LGTM`)
-    break
+    // CI gate — restores the gate lost in eb8aa7e (issue #133).
+    // pr-reviewer may LGTM the code but CI must also be green before we declare lgtm.
+    // no_checks is treated as passing (consistent with e4e2b92: repos without CI are fine).
+    const ci = await agent(
+      `## Objective\n`
+      + `PR #${PR} の CI ステータスを取得し、JSON をそのまま返せ。\n\n`
+      + `## Tools\n`
+      + `- 使用可: Bash のみ\n`
+      + `- 禁止: Write, Edit, git commit, git push\n\n`
+      + `## Boundary\n`
+      + `- 読み取り専用。git mutation（commit/push/reset 等）禁止\n`
+      + `- 実行するスクリプト以外のファイルを変更しない\n\n`
+      + `## Steps\n`
+      + `skills repo（インストール済みの場合は \`$HOME/.claude/skills\`、`
+      + `またはリポジトリのワーキングツリーを locate して）の `
+      + `\`pr-iterate/scripts/check-ci.sh\` を実行せよ:\n`
+      + `\`\`\`\nbash pr-iterate/scripts/check-ci.sh ${PR}\n\`\`\`\n`
+      + `スクリプトの stdout JSON（{status, failed_checks, ...}）をそのまま返せ。\n\n`
+      + `## Output format\n`
+      + `{ "status": "passed"|"failed"|"pending"|"no_checks", "failed_checks": [{name, conclusion}, ...] }\n`
+      + `prose 禁止。JSON のみ返せ。\n\n`
+      + `## Token cap\n`
+      + `JSON のみ。1 行以内。`,
+      { agentType: 'dev-runner', schema: CI_STATUS, label: `ci-check#${i}`, phase: 'Iterate' },
+    )
+
+    if (ci == null) throw new Error(`pr-iterate: ci-check#${i} が結果を返しませんでした`)
+
+    if (ci.status === 'passed' || ci.status === 'no_checks') {
+      lgtm = true
+      log(`iteration ${i}: LGTM（CI status=${ci.status}）`)
+      break
+    }
+
+    if (ci.status === 'pending') {
+      terminal = 'ci_pending'
+      log(`⚠️ CI pending — checks incomplete, never auto-approve. 人間/CI 完了待ちへエスカレーション`)
+      break
+    }
+
+    // ci.status === 'failed': convert failed_checks into synthetic blocking findings and route
+    // through the existing pr-fix path. Repeated identical ci::<name> topics hit REVIEW_STUCK
+    // automatically via the existing stuckTopics computation below.
+    const ciFindings = (ci.failed_checks && ci.failed_checks.length > 0)
+      ? ci.failed_checks.map((c) => ({
+          severity: 'critical',
+          topic: `ci::${c.name}`,
+          description: `CI check failed: ${c.name} (${c.conclusion})`,
+          suggestion: 'CI を green にする',
+        }))
+      : [{
+          severity: 'critical',
+          topic: 'ci::unknown',
+          description: 'CI failed (no specific check details available)',
+          suggestion: 'CI を green にする',
+        }]
+
+    // Register CI findings into reviewSeen exactly like the existing blocking loop so that
+    // repeated identical CI failures (same ci::<name> topic) trigger REVIEW_STUCK escalation.
+    for (const x of ciFindings) {
+      const t = issueTopic(x)
+      if (reviewSeen[t]) { reviewSeen[t].issue = x; reviewSeen[t].count += 1 }
+      else reviewSeen[t] = { issue: x, count: 1 }
+    }
+    const ciStuckTopics = Object.entries(reviewSeen).filter(([, s]) => s.count >= REVIEW_STUCK).map(([t]) => t)
+    log(`iteration ${i}: approve but CI failed — ${ciFindings.length} failing check(s)`
+      + `${ciStuckTopics.length ? ` [REVIEW_STUCK: ${ciStuckTopics.join(' / ')}]` : ''}`)
+
+    if (ciStuckTopics.length) {
+      terminal = 'stuck'
+      log(`⚠️ Review STUCK — 同一 CI failure topic が ${REVIEW_STUCK} 回反復（${ciStuckTopics.join(' / ')}）。`
+        + `relax せず人間レビューへエスカレーション（critical/major のゲートは後退させない）`)
+      break
+    }
+
+    const issuesText = ciFindings
+      .map((x) => `- [${x.severity}] ${x.description}${x.suggestion ? ' → ' + x.suggestion : ''}`)
+      .join('\n')
+
+    const fix = await agent(
+      `PR #${PR} の CI 失敗を修正する。次の CI 失敗を解消するため \`Skill: pr-fix ${PR}\` を実行し、`
+      + `修正を push まで行え。解消すべき CI 失敗:\n${issuesText}`,
+      { agentType: 'dev-runner', schema: FIX, label: `fix#${i}`, phase: 'Iterate' },
+    )
+
+    if (fix == null || fix.applied !== true) {
+      terminal = 'fix_failed'
+      log(`⚠️ fix#${i} が適用されず（applied=${fix?.applied ?? 'null'}）— ${fix?.summary ?? '理由不明'}。`
+        + `無言で再レビューを繰り返さず人間へエスカレーション`)
+      break
+    }
+
+    // CI fix applied — continue to next iteration for re-review + re-CI-check
+    continue
   }
 
   const blocking = review.issues.filter((x) => x.severity === 'critical' || x.severity === 'major')

--- a/pr-iterate/scripts/check-ci.bats
+++ b/pr-iterate/scripts/check-ci.bats
@@ -2,7 +2,13 @@
 # Tests for pr-iterate/scripts/check-ci.sh
 #
 # Strategy: stub `gh` via a PATH-prepended script that responds to
-# `pr checks ... --json name,state,conclusion` with canned JSON.
+# `pr checks ... --json name,state,bucket` with canned JSON matching the
+# real gh pr checks --json output schema (bucket + state, no conclusion field).
+#
+# gh exit code semantics mirrored from real gh:
+#   0  = all checks complete
+#   8  = checks still pending
+#   1  = real API error
 
 setup() {
     SKILLS_REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
@@ -12,15 +18,16 @@ setup() {
     mkdir -p "$STUB_DIR"
 
     # Default gh stub: responds to `pr checks` with canned JSON stored in
-    # $GH_CHECKS_OUTPUT. Other sub-commands are no-ops.
+    # $GH_CHECKS_OUTPUT (exit code from $GH_EXIT_CODE, default 0).
     GH_CHECKS_OUTPUT="[]"
-    export GH_CHECKS_OUTPUT
+    GH_EXIT_CODE=0
+    export GH_CHECKS_OUTPUT GH_EXIT_CODE
 
     cat > "$STUB_DIR/gh" << 'EOF'
 #!/usr/bin/env bash
 if [[ "$1" == "pr" && "$2" == "checks" ]]; then
     echo "$GH_CHECKS_OUTPUT"
-    exit 0
+    exit "${GH_EXIT_CODE:-0}"
 fi
 exit 0
 EOF
@@ -33,6 +40,7 @@ EOF
 # ---------------------------------------------------------------------------
 @test "empty checks array -> status no_checks" {
     export GH_CHECKS_OUTPUT='[]'
+    export GH_EXIT_CODE=0
     run "$SCRIPT" 42
     [ "$status" -eq 0 ]
     result=$(echo "$output" | tail -1)
@@ -43,13 +51,15 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 2: all SUCCESS conclusions -> status 'passed'
+# Test 2: all bucket=pass -> status 'passed'
+# Real gh schema: {"bucket":"pass","name":"...","state":"SUCCESS"}
 # ---------------------------------------------------------------------------
-@test "all SUCCESS conclusions -> status passed" {
+@test "all bucket=pass -> status passed" {
     export GH_CHECKS_OUTPUT='[
-      {"name":"lint","state":"COMPLETED","conclusion":"SUCCESS"},
-      {"name":"test","state":"COMPLETED","conclusion":"SUCCESS"}
+      {"name":"lint","state":"SUCCESS","bucket":"pass"},
+      {"name":"test","state":"SUCCESS","bucket":"pass"}
     ]'
+    export GH_EXIT_CODE=0
     run "$SCRIPT" 42
     [ "$status" -eq 0 ]
     result=$(echo "$output" | tail -1)
@@ -59,13 +69,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 3: one FAILURE conclusion -> status 'failed', failed_checks populated
+# Test 3: one bucket=fail -> status 'failed', failed_checks populated
 # ---------------------------------------------------------------------------
-@test "one FAILURE conclusion -> status failed with failed_checks" {
+@test "one bucket=fail -> status failed with failed_checks" {
     export GH_CHECKS_OUTPUT='[
-      {"name":"lint","state":"COMPLETED","conclusion":"SUCCESS"},
-      {"name":"test","state":"COMPLETED","conclusion":"FAILURE"}
+      {"name":"lint","state":"SUCCESS","bucket":"pass"},
+      {"name":"test","state":"FAILURE","bucket":"fail"}
     ]'
+    export GH_EXIT_CODE=0
     run "$SCRIPT" 42
     [ "$status" -eq 0 ]
     result=$(echo "$output" | tail -1)
@@ -76,12 +87,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 4: null conclusion + non-COMPLETED state -> status 'pending'
+# Test 4: bucket=pending + gh exit 8 -> status 'pending'
+# Real gh exits 8 when checks are still in progress
 # ---------------------------------------------------------------------------
-@test "null conclusion with IN_PROGRESS state -> status pending" {
+@test "bucket=pending with gh exit 8 -> status pending" {
     export GH_CHECKS_OUTPUT='[
-      {"name":"build","state":"IN_PROGRESS","conclusion":null}
+      {"name":"build","state":"IN_PROGRESS","bucket":"pending"}
     ]'
+    export GH_EXIT_CODE=8
     run "$SCRIPT" 42
     [ "$status" -eq 0 ]
     result=$(echo "$output" | tail -1)
@@ -92,13 +105,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 5: mix of FAILURE + pending -> status 'failed' (failure takes priority)
+# Test 5: mix of bucket=fail + bucket=pending -> status 'failed' (failure wins)
 # ---------------------------------------------------------------------------
-@test "FAILURE + pending -> status failed (failure wins)" {
+@test "bucket=fail + bucket=pending -> status failed (failure wins)" {
     export GH_CHECKS_OUTPUT='[
-      {"name":"test","state":"COMPLETED","conclusion":"FAILURE"},
-      {"name":"deploy","state":"IN_PROGRESS","conclusion":null}
+      {"name":"test","state":"FAILURE","bucket":"fail"},
+      {"name":"deploy","state":"IN_PROGRESS","bucket":"pending"}
     ]'
+    export GH_EXIT_CODE=0
     run "$SCRIPT" 42
     [ "$status" -eq 0 ]
     result=$(echo "$output" | tail -1)
@@ -108,13 +122,14 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 6: SKIPPED/NEUTRAL conclusions -> counted as passed (status 'passed')
+# Test 6: bucket=skipping -> counted as passed (status 'passed')
 # ---------------------------------------------------------------------------
-@test "SKIPPED and NEUTRAL conclusions -> status passed" {
+@test "bucket=skipping -> status passed" {
     export GH_CHECKS_OUTPUT='[
-      {"name":"skip-check","state":"COMPLETED","conclusion":"SKIPPED"},
-      {"name":"neutral-check","state":"COMPLETED","conclusion":"NEUTRAL"}
+      {"name":"skip-check","state":"SKIPPED","bucket":"skipping"},
+      {"name":"pass-check","state":"SUCCESS","bucket":"pass"}
     ]'
+    export GH_EXIT_CODE=0
     run "$SCRIPT" 42
     [ "$status" -eq 0 ]
     result=$(echo "$output" | tail -1)
@@ -122,4 +137,28 @@ EOF
     [ "$(echo "$result" | jq -r '.failed')" = "0" ]
     skipped=$(echo "$result" | jq -r '.skipped')
     [ "$skipped" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: gh exits 1 (real API error) -> script exits 1 with status=error
+# Regression: must NOT silently degrade to no_checks (passing) on API failure.
+# ---------------------------------------------------------------------------
+@test "gh API error (exit 1) -> script exits 1 with status=error, not no_checks" {
+    # Stub: print an error message to stderr and exit 1
+    cat > "$BATS_TMPDIR/stub-bin/gh" << 'GHEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    echo 'Unknown JSON field: "conclusion"' >&2
+    exit 1
+fi
+exit 0
+GHEOF
+    chmod +x "$BATS_TMPDIR/stub-bin/gh"
+
+    run "$SCRIPT" 42
+    # Script must exit 1 on real API error
+    [ "$status" -eq 1 ]
+    # Output must contain status=error, NOT no_checks
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "error" ]
 }

--- a/pr-iterate/scripts/check-ci.bats
+++ b/pr-iterate/scripts/check-ci.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# Tests for pr-iterate/scripts/check-ci.sh
+#
+# Strategy: stub `gh` via a PATH-prepended script that responds to
+# `pr checks ... --json name,state,conclusion` with canned JSON.
+
+setup() {
+    SKILLS_REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCRIPT="$SKILLS_REPO/pr-iterate/scripts/check-ci.sh"
+
+    STUB_DIR="$BATS_TMPDIR/stub-bin"
+    mkdir -p "$STUB_DIR"
+
+    # Default gh stub: responds to `pr checks` with canned JSON stored in
+    # $GH_CHECKS_OUTPUT. Other sub-commands are no-ops.
+    GH_CHECKS_OUTPUT="[]"
+    export GH_CHECKS_OUTPUT
+
+    cat > "$STUB_DIR/gh" << 'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    echo "$GH_CHECKS_OUTPUT"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$STUB_DIR/gh"
+    export PATH="$STUB_DIR:$PATH"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: empty checks array -> status 'no_checks'
+# ---------------------------------------------------------------------------
+@test "empty checks array -> status no_checks" {
+    export GH_CHECKS_OUTPUT='[]'
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "no_checks" ]
+    [ "$(echo "$result" | jq -r '.passed')" = "0" ]
+    [ "$(echo "$result" | jq -r '.failed')" = "0" ]
+    [ "$(echo "$result" | jq -r '.pending')" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: all SUCCESS conclusions -> status 'passed'
+# ---------------------------------------------------------------------------
+@test "all SUCCESS conclusions -> status passed" {
+    export GH_CHECKS_OUTPUT='[
+      {"name":"lint","state":"COMPLETED","conclusion":"SUCCESS"},
+      {"name":"test","state":"COMPLETED","conclusion":"SUCCESS"}
+    ]'
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "passed" ]
+    [ "$(echo "$result" | jq -r '.passed')" = "2" ]
+    [ "$(echo "$result" | jq -r '.failed')" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: one FAILURE conclusion -> status 'failed', failed_checks populated
+# ---------------------------------------------------------------------------
+@test "one FAILURE conclusion -> status failed with failed_checks" {
+    export GH_CHECKS_OUTPUT='[
+      {"name":"lint","state":"COMPLETED","conclusion":"SUCCESS"},
+      {"name":"test","state":"COMPLETED","conclusion":"FAILURE"}
+    ]'
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "failed" ]
+    [ "$(echo "$result" | jq -r '.failed')" = "1" ]
+    failed_names=$(echo "$result" | jq -r '.failed_checks[].name')
+    [[ "$failed_names" == *"test"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: null conclusion + non-COMPLETED state -> status 'pending'
+# ---------------------------------------------------------------------------
+@test "null conclusion with IN_PROGRESS state -> status pending" {
+    export GH_CHECKS_OUTPUT='[
+      {"name":"build","state":"IN_PROGRESS","conclusion":null}
+    ]'
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "pending" ]
+    [ "$(echo "$result" | jq -r '.pending')" = "1" ]
+    pending_count=$(echo "$result" | jq '.pending_checks | length')
+    [ "$pending_count" -gt 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: mix of FAILURE + pending -> status 'failed' (failure takes priority)
+# ---------------------------------------------------------------------------
+@test "FAILURE + pending -> status failed (failure wins)" {
+    export GH_CHECKS_OUTPUT='[
+      {"name":"test","state":"COMPLETED","conclusion":"FAILURE"},
+      {"name":"deploy","state":"IN_PROGRESS","conclusion":null}
+    ]'
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "failed" ]
+    [ "$(echo "$result" | jq -r '.failed')" = "1" ]
+    [ "$(echo "$result" | jq -r '.pending')" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: SKIPPED/NEUTRAL conclusions -> counted as passed (status 'passed')
+# ---------------------------------------------------------------------------
+@test "SKIPPED and NEUTRAL conclusions -> status passed" {
+    export GH_CHECKS_OUTPUT='[
+      {"name":"skip-check","state":"COMPLETED","conclusion":"SKIPPED"},
+      {"name":"neutral-check","state":"COMPLETED","conclusion":"NEUTRAL"}
+    ]'
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "passed" ]
+    [ "$(echo "$result" | jq -r '.failed')" = "0" ]
+    skipped=$(echo "$result" | jq -r '.skipped')
+    [ "$skipped" = "1" ]
+}

--- a/pr-iterate/scripts/check-ci.sh
+++ b/pr-iterate/scripts/check-ci.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# check-ci.sh - Query PR CI status with pending vs failure disambiguation.
+# Usage: check-ci.sh <pr-number-or-url> [--repo <owner/repo>]
+#
+# Always exits 0 unless the gh API itself errors. CI state is reported via
+# stdout JSON so the caller can treat pending != failure.
+#
+# Output JSON:
+#   { "status": "passed" | "failed" | "pending" | "no_checks",
+#     "passed": N, "failed": N, "pending": N, "skipped": N,
+#     "failed_checks": [...], "pending_checks": [...] }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+require_cmd jq
+require_cmd gh
+
+PR_REF=""
+REPO_FLAG=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO_FLAG=(--repo "$2"); shift 2 ;;
+        -*) die_json "Unknown option: $1" 1 ;;
+        *) PR_REF="$1"; shift ;;
+    esac
+done
+
+[[ -n "$PR_REF" ]] || die_json "PR reference required" 1
+
+# gh pr checks --json never sets a non-zero exit for pending (only for API
+# errors), so we can capture without `|| true`. If the API fails entirely,
+# the script propagates the error.
+checks_json=$(gh pr checks "$PR_REF" "${REPO_FLAG[@]}" --json name,state,conclusion 2>/dev/null || echo "[]")
+
+# State / conclusion mapping (GitHub Checks API):
+#   conclusion: "SUCCESS" | "FAILURE" | "CANCELLED" | "SKIPPED" | "NEUTRAL" | "TIMED_OUT" | "ACTION_REQUIRED" | null
+#   state:      "PENDING" | "COMPLETED" | "IN_PROGRESS" | ...
+# Treat null conclusion + non-COMPLETED state as pending.
+echo "$checks_json" | jq -c '
+  def is_pending: (.conclusion // "") == "" and ((.state // "") != "COMPLETED");
+  def is_passed:  (.conclusion // "") | ascii_upcase | IN("SUCCESS", "NEUTRAL", "SKIPPED");
+  def is_failed:  (.conclusion // "") | ascii_upcase | IN("FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED");
+
+  if length == 0 then
+    {status: "no_checks", passed: 0, failed: 0, pending: 0, skipped: 0,
+     failed_checks: [], pending_checks: []}
+  else
+    {
+      passed:  ([.[] | select(is_passed)]  | length),
+      failed:  ([.[] | select(is_failed)]  | length),
+      pending: ([.[] | select(is_pending)] | length),
+      skipped: ([.[] | select(.conclusion == "SKIPPED")] | length),
+      failed_checks:  [.[] | select(is_failed)  | {name, conclusion}],
+      pending_checks: [.[] | select(is_pending) | {name, state}]
+    } |
+    . + {
+      status: (if .failed > 0 then "failed"
+               elif .pending > 0 then "pending"
+               else "passed" end)
+    }
+  end
+'

--- a/pr-iterate/scripts/check-ci.sh
+++ b/pr-iterate/scripts/check-ci.sh
@@ -2,13 +2,21 @@
 # check-ci.sh - Query PR CI status with pending vs failure disambiguation.
 # Usage: check-ci.sh <pr-number-or-url> [--repo <owner/repo>]
 #
-# Always exits 0 unless the gh API itself errors. CI state is reported via
-# stdout JSON so the caller can treat pending != failure.
+# Exits 0 when CI status is determined (passed/failed/pending/no_checks).
+# Exits 1 when gh API fails with a real error (auth, network, unknown field).
+# CI state is reported via stdout JSON so the caller can treat pending != failure.
 #
 # Output JSON:
-#   { "status": "passed" | "failed" | "pending" | "no_checks",
+#   { "status": "passed" | "failed" | "pending" | "no_checks" | "error",
 #     "passed": N, "failed": N, "pending": N, "skipped": N,
 #     "failed_checks": [...], "pending_checks": [...] }
+#
+# gh bucket field values (gh help pr checks):
+#   pass | fail | pending | skipping | cancel
+# gh exit codes:
+#   0  = all checks complete (passed or failed)
+#   8  = checks still pending
+#   1  = real API error (auth, network, unknown JSON field, etc.)
 
 set -euo pipefail
 
@@ -30,19 +38,30 @@ done
 
 [[ -n "$PR_REF" ]] || die_json "PR reference required" 1
 
-# gh pr checks --json never sets a non-zero exit for pending (only for API
-# errors), so we can capture without `|| true`. If the API fails entirely,
-# the script propagates the error.
-checks_json=$(gh pr checks "$PR_REF" "${REPO_FLAG[@]}" --json name,state,conclusion 2>/dev/null || echo "[]")
+# Capture gh output and exit code explicitly.
+# gh exits 0 for complete checks, 8 for pending, 1 for real errors.
+# We allow exit 0 and 8; anything else is surfaced as {"status":"error"}.
+gh_stderr_file=$(mktemp)
+checks_json=""
+gh_exit=0
+checks_json=$(gh pr checks "$PR_REF" "${REPO_FLAG[@]}" --json name,state,bucket 2>"$gh_stderr_file") || gh_exit=$?
+gh_stderr=$(cat "$gh_stderr_file")
+rm -f "$gh_stderr_file"
 
-# State / conclusion mapping (GitHub Checks API):
-#   conclusion: "SUCCESS" | "FAILURE" | "CANCELLED" | "SKIPPED" | "NEUTRAL" | "TIMED_OUT" | "ACTION_REQUIRED" | null
-#   state:      "PENDING" | "COMPLETED" | "IN_PROGRESS" | ...
-# Treat null conclusion + non-COMPLETED state as pending.
+# exit 1 = real API error (auth failure, network error, unknown field, etc.)
+if [[ $gh_exit -ne 0 && $gh_exit -ne 8 ]]; then
+    printf '{"status":"error","message":%s}\n' "$(printf '%s' "$gh_stderr" | jq -Rs '.')"
+    exit 1
+fi
+
+# bucket field values: pass | fail | pending | skipping | cancel
+# is_passed:  bucket IN("pass", "skipping")   — completed successfully or intentionally skipped
+# is_failed:  bucket IN("fail", "cancel")     — failed or cancelled
+# is_pending: bucket == "pending"             — still running
 echo "$checks_json" | jq -c '
-  def is_pending: (.conclusion // "") == "" and ((.state // "") != "COMPLETED");
-  def is_passed:  (.conclusion // "") | ascii_upcase | IN("SUCCESS", "NEUTRAL", "SKIPPED");
-  def is_failed:  (.conclusion // "") | ascii_upcase | IN("FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED");
+  def is_passed:  .bucket | IN("pass", "skipping");
+  def is_failed:  .bucket | IN("fail", "cancel");
+  def is_pending: .bucket == "pending";
 
   if length == 0 then
     {status: "no_checks", passed: 0, failed: 0, pending: 0, skipped: 0,
@@ -52,8 +71,8 @@ echo "$checks_json" | jq -c '
       passed:  ([.[] | select(is_passed)]  | length),
       failed:  ([.[] | select(is_failed)]  | length),
       pending: ([.[] | select(is_pending)] | length),
-      skipped: ([.[] | select(.conclusion == "SKIPPED")] | length),
-      failed_checks:  [.[] | select(is_failed)  | {name, conclusion}],
+      skipped: ([.[] | select(.bucket == "skipping")] | length),
+      failed_checks:  [.[] | select(is_failed)  | {name, bucket, state}],
       pending_checks: [.[] | select(is_pending) | {name, state}]
     } |
     . + {


### PR DESCRIPTION
## 概要

Closes #133

- `pr-iterate.js` の approve 分岐に CI ゲートを復元（`eb8aa7e` で失われた機能）
- `pr-iterate/scripts/check-ci.sh` を新規追加（決定論的スクリプトとして CI 状態を構造化 JSON で返す）
- `pr-iterate/scripts/check-ci.bats` で 6 ケースの bats テストを追加

## 動機

`eb8aa7e`（skill→workflow 全面移行）で旧 skill が持っていた CI ゲートが削除され、
workflow に引き継がれなかった。その結果、PR レビュアーが差分を approve しても CI が
失敗していれば LGTM にならないはずが、CI 状態を一切チェックせず即 LGTM が出る状態だった。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/pr-iterate.js` | approve 後に dev-runner 経由で `check-ci.sh` を実行する CI ゲートを追加。passed/no_checks → lgtm、pending → ci_pending でエスカレーション、failed → ciFindings として pr-fix パスへ振り分け |
| `pr-iterate/scripts/check-ci.sh` | `gh pr checks` の JSON を passed/failed/pending/no_checks に分類して返す決定論的スクリプト。SKIPPED/NEUTRAL は passed 扱い |
| `pr-iterate/scripts/check-ci.bats` | empty/all-passed/failure/pending/failure+pending mix/skipped の 6 ケース bats テスト |

## CI 失敗時の挙動

- **passed / no_checks**: 通常通り lgtm=true → ループ終了
- **pending**: `ci_pending` で終端し人間へエスカレーション（CI 未完了を LGTM にしない）
- **failed**: `ciFindings` として既存の `reviewSeen` に登録し pr-fix ループへ。同一 CI failure が `REVIEW_STUCK` 回続いたら `stuck` で人間へエスカレーション

## テスト計画

- [x] `bats pr-iterate/scripts/check-ci.bats` — 6 ケース全通過を確認
- [ ] PR ワークフロー統合テスト（CI 失敗 PR に対して pr-iterate を実行し CI ゲートが動作することを確認）