### PR TITLE
feat(dev-flow): W4 red-green 実証ゲートで収束を ledger 駆動へ

### DIFF
--- a/.claude/agents/evaluator.md
+++ b/.claude/agents/evaluator.md
@@ -106,6 +106,17 @@ type に応じた追加観点を持つ（例: api なら入力検証・エラー
 したがって fail を引き延ばすために minor/major を**新規に**捻り出す必要はない。受入条件を満たすなら
 `pass`、重大な穴があるなら `critical`/`major` を明示する — それが最も収束を早める。
 
+## per-AC 判定（ac_results。W4 item-validator 契約）
+
+`requirements.acceptance_criteria` の各項目を個別判定し `ac_results[]` に返す:
+
+- `ac_index`: acceptance_criteria の 0 始まり index。
+- `satisfied`: 実 diff / テスト出力に照らして満たされているか（自己申告でなく検証する）。
+- `evidence`: 根拠（file:line / テスト名）。
+- `verified_by`: テストで実証できるなら `"test"`、コード精査でしか判断できないなら `"inspection"`。
+- `test_files` / `impl_files`（`verified_by==="test"` のみ）: その AC を実証するテストファイルと、それが検証する実装ファイルを worktree 相対パスで列挙。**自分で red→green 判定を主張しないこと** — orchestrator が dev-runner-haiku 経由で `redgreen-verify.sh` を走らせ決定論判定する。申告のみ行う。
+- test_files は repo の test discovery（`*.test.mjs` / `*.bats`）一致のものだけ。混在ファイルは挙げない。
+
 ## Step 5: 出力 JSON（schema 強制）
 
 ```json
@@ -120,7 +131,10 @@ type に応じた追加観点を持つ（例: api なら入力検証・エラー
      "suggestion": "zod スキーマで email を検証し 400 を返す"}
   ],
   "feedback_level": "implementation",
-  "task_type": "api"
+  "task_type": "api",
+  "ac_results": [
+    {"ac_index": 0, "satisfied": true, "evidence": "src/user.test.mjs::creates user", "verified_by": "test", "test_files": ["src/user.test.mjs"], "impl_files": ["src/user.mjs"]}
+  ]
 }
 ```
 

--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -280,6 +280,21 @@ const EVAL = {
     feedback: { type: 'array' },
     feedback_level: { type: 'string', enum: ['design', 'implementation'] },
     task_type: { type: 'string' },
+    ac_results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['ac_index', 'satisfied'],
+        properties: {
+          ac_index: { type: 'number' },
+          satisfied: { type: 'boolean' },
+          evidence: { type: 'string' },
+          verified_by: { type: 'string', enum: ['test', 'inspection'] },
+          test_files: { type: 'array', items: { type: 'string' } },
+          impl_files: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
   },
 }
 const PRURL = {

--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -57,7 +57,7 @@ function appendItem(ledger, item) {
   const idx = ledger.round > 0 ? ledger.items.findIndex((it) => topicKey(it) === key) : -1;
   const items = ledger.items.slice();
   if (idx >= 0) items[idx] = { ...items[idx], ...item, id: items[idx].id };
-  else items.push({ checked: false, evidence: null, floor: false, check: null, ...item });
+  else items.push({ checked: false, evidence: null, floor: false, check: null, ...item, check: item.check ? { ...item.check } : null });
   return { ledger: { ...ledger, items }, accepted: true };
 }
 

--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -582,6 +582,16 @@ for (let i = 1; i <= EVAL_MAX; i++) {
       ledger = r.ledger
     }
   }
+  // 現 iteration の feedback に無くなった critical ledger item は解消とみなし checkItem(収束を妨げない)
+  const liveCriticalKeys = new Set(
+    (ev.feedback ?? []).filter((f) => f && typeof f === 'object' && f.severity === 'critical')
+      .map((f) => topicKey({ dimension: f.dimension ?? 'eval', text: feedbackTopic(f) })))
+  for (const it of ledger.items) {
+    if (it.source === 'evaluator' && it.severity === 'critical' && !it.checked
+        && !liveCriticalKeys.has(topicKey(it))) {
+      ledger = checkItem(ledger, it.id, '現 iteration で未報告=解消')
+    }
+  }
   // W4: evaluator の per-AC 判定を ledger に反映。test 実証できる AC は red→green を
   // dev-runner-haiku で決定論検証し、取れたら deterministic 昇格(blocking)。
   for (const r of (ev.ac_results ?? [])) {

--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -89,6 +89,14 @@ function reopenItem(ledger, id, reason) {
   return { ...ledger, items };
 }
 
+function setCheck(ledger, id, check) {
+  const idx = ledger.items.findIndex((it) => it.id === id);
+  if (idx < 0) throw new Error(`goal-ledger: 未知の item id "${id}"`);
+  const items = ledger.items.slice();
+  items[idx] = { ...items[idx], check };
+  return { ...ledger, items };
+}
+
 function blockingItems(ledger) {
   return ledger.items.filter((it) => laneOf(it) === 'blocking');
 }

--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -297,6 +297,10 @@ const EVAL = {
     },
   },
 }
+const RG = {
+  type: 'object', required: ['red', 'green'],
+  properties: { red: { type: 'boolean' }, green: { type: 'boolean' }, reason: { type: 'string' } },
+}
 const PRURL = {
   type: 'object', required: ['pr_url', 'pr_number'],
   properties: {
@@ -578,12 +582,37 @@ for (let i = 1; i <= EVAL_MAX; i++) {
       ledger = r.ledger
     }
   }
+  // W4: evaluator の per-AC 判定を ledger に反映。test 実証できる AC は red→green を
+  // dev-runner-haiku で決定論検証し、取れたら deterministic 昇格(blocking)。
+  for (const r of (ev.ac_results ?? [])) {
+    if (!r || typeof r.ac_index !== 'number') continue
+    const acId = `AC-${r.ac_index + 1}`
+    if (!ledger.items.some((it) => it.id === acId)) continue   // 知らない AC は無視
+    if (r.satisfied && r.verified_by === 'test' && Array.isArray(r.test_files) && r.test_files.length
+        && Array.isArray(r.impl_files) && r.impl_files.length) {
+      const rg = await agent(
+        `cd ${WT} で作業。次を実行して **stdout の JSON 1 行だけ** を verbatim で返せ(判定や脚色をしない):\n`
+        + `bash ${WT}/_shared/scripts/redgreen-verify.sh ${WT} `
+        + `'${r.test_files.join(',')}' '${r.impl_files.join(',')}'`,
+        { agentType: 'dev-runner-haiku', schema: RG, label: `redgreen:AC-${r.ac_index + 1}`, phase: 'Evaluate' })
+      if (rg && rg.red === true && rg.green === true) {
+        ledger = setCheck(ledger, acId, { kind: 'deterministic' })
+        ledger = checkItem(ledger, acId, `red→green 実証: ${(r.test_files || []).join(',')}`)
+        log(`AC-${r.ac_index + 1}: red→green 実証 → deterministic 昇格 + checked`)
+      } else {
+        if (r.satisfied) ledger = checkItem(ledger, acId, r.evidence ?? 'inspection(red→green 未成立)')
+        log(`AC-${r.ac_index + 1}: red→green 未成立(${rg ? rg.reason : 'null'})→ inspection 据え置き`)
+      }
+    } else if (r.satisfied) {
+      ledger = checkItem(ledger, acId, r.evidence ?? 'inspection')
+    }
+  }
   ledger = nextRound(ledger)
   log(`ledger: blocking ${blockingItems(ledger).filter((it) => !it.checked).length} 件未 checked / `
     + `converged(observe)=${isConverged(ledger)}`)
 
-  if (ev.verdict === 'pass') {
-    log(`evaluate 収束（pass, iter ${i}）— PR へ進む`)
+  if (isConverged(ledger) && ev.verdict === 'pass') {
+    log(`evaluate 収束（ledger 全 blocking checked + verdict pass, iter ${i}）— PR へ進む`)
     break
   }
   // critical は常にブロック。critical が無く design パスが stuck したら早期打ち切り（replan+reimpl の
@@ -653,6 +682,6 @@ return {
   triviality_reason: triage.reason,
   ledger_blocking: blockingItems(ledger).length,
   ledger_advisory: advisoryItems(ledger).length,
-  ledger_converged_observe: isConverged(ledger),
+  ledger_converged: isConverged(ledger),
   note: 'merge は手動で行ってください',
 }

--- a/_lib/goal-ledger.mjs
+++ b/_lib/goal-ledger.mjs
@@ -44,7 +44,7 @@ export function appendItem(ledger, item) {
   const idx = ledger.round > 0 ? ledger.items.findIndex((it) => topicKey(it) === key) : -1;
   const items = ledger.items.slice();
   if (idx >= 0) items[idx] = { ...items[idx], ...item, id: items[idx].id };
-  else items.push({ checked: false, evidence: null, floor: false, check: null, ...item });
+  else items.push({ checked: false, evidence: null, floor: false, check: null, ...item, check: item.check ? { ...item.check } : null });
   return { ledger: { ...ledger, items }, accepted: true };
 }
 

--- a/_lib/goal-ledger.mjs
+++ b/_lib/goal-ledger.mjs
@@ -76,6 +76,14 @@ export function reopenItem(ledger, id, reason) {
   return { ...ledger, items };
 }
 
+export function setCheck(ledger, id, check) {
+  const idx = ledger.items.findIndex((it) => it.id === id);
+  if (idx < 0) throw new Error(`goal-ledger: 未知の item id "${id}"`);
+  const items = ledger.items.slice();
+  items[idx] = { ...items[idx], check };
+  return { ...ledger, items };
+}
+
 export function blockingItems(ledger) {
   return ledger.items.filter((it) => laneOf(it) === 'blocking');
 }

--- a/_lib/goal-ledger.sync.test.mjs
+++ b/_lib/goal-ledger.sync.test.mjs
@@ -12,7 +12,7 @@ const repoRoot = join(here, '..');
 const FN_NAMES = [
   'makeLedger', 'laneOf', 'topicKey', 'canAppend', 'appendItem',
   'applySeverityFloor', 'mergeSeverity', 'checkItem', 'reopenItem',
-  'blockingItems', 'advisoryItems', 'isConverged', 'nextRound',
+  'setCheck', 'blockingItems', 'advisoryItems', 'isConverged', 'nextRound',
 ];
 
 function extractFn(src, name) {

--- a/_lib/goal-ledger.test.mjs
+++ b/_lib/goal-ledger.test.mjs
@@ -133,3 +133,9 @@ test('setCheck: 既存 item の check 種別を更新（inspection→determinist
 test('setCheck: 未知 id は throw', () => {
   assert.throws(() => setCheck(makeLedger(), 'X', { kind: 'deterministic' }), /未知の item id/);
 });
+test('appendItem: check は shallow-clone され caller mutation の影響を受けない', () => {
+  const check = { kind: 'inspection' };
+  const { ledger } = appendItem(makeLedger(), { id: 'A', text: 'x', dimension: 'd', severity: 'major', source: 'ac', check });
+  check.kind = 'deterministic';                       // caller が後から変更
+  assert.equal(ledger.items[0].check.kind, 'inspection'); // ledger 側は不変
+});

--- a/_lib/goal-ledger.test.mjs
+++ b/_lib/goal-ledger.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {
   makeLedger, laneOf, topicKey, canAppend, appendItem,
   applySeverityFloor, mergeSeverity, checkItem, reopenItem,
-  blockingItems, advisoryItems, isConverged, nextRound,
+  blockingItems, advisoryItems, isConverged, nextRound, setCheck,
 } from './goal-ledger.mjs';
 
 const ac = (over = {}) => ({ id: 'AC-1', text: 'returns 200', dimension: 'ac', severity: 'major', source: 'ac', ...over });
@@ -122,4 +122,14 @@ test('mergeSeverity: 未定義 severity は現状 fail-safe passthrough（NaN比
   assert.equal(mergeSeverity({ severity: 'major', floor: false }, 'bogus').severity, 'major');
   const floored = applySeverityFloor({ severity: 'critical' }, 'critical');
   assert.equal(mergeSeverity(floored, 'bogus').severity, 'critical');
+});
+test('setCheck: 既存 item の check 種別を更新（inspection→deterministic で blocking 昇格）', () => {
+  let { ledger } = appendItem(makeLedger(), { id: 'AC-1', text: 'x', dimension: 'ac', severity: 'major', source: 'ac', check: { kind: 'inspection' } });
+  assert.equal(laneOf(ledger.items[0]), 'advisory');
+  ledger = setCheck(ledger, 'AC-1', { kind: 'deterministic' });
+  assert.equal(ledger.items[0].check.kind, 'deterministic');
+  assert.equal(laneOf(ledger.items[0]), 'blocking');
+});
+test('setCheck: 未知 id は throw', () => {
+  assert.throws(() => setCheck(makeLedger(), 'X', { kind: 'deterministic' }), /未知の item id/);
 });

--- a/_shared/scripts/redgreen-verify.bats
+++ b/_shared/scripts/redgreen-verify.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# redgreen-verify.sh: impl を stash して test が red→green に転じるか判定する。
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/redgreen-verify.sh"
+  REPO="$(mktemp -d)"
+  cd "$REPO"
+  git init -q && git config user.email t@t && git config user.name t
+  echo "export const ok = false;" > impl.mjs
+  git add impl.mjs && git commit -q -m base
+  # impl を true にし、それを検証する test を worktree に置く(未 commit = implementer の変更相当)
+  echo "export const ok = true;" > impl.mjs
+  cat > feature.test.mjs <<'EOF'
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ok } from './impl.mjs';
+test('ok is true', () => { assert.equal(ok, true); });
+EOF
+}
+teardown() { rm -rf "$REPO"; }
+
+@test "red→green: impl 退避で red、復元で green" {
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "impl.mjs"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"red":true'* ]]
+  [[ "$output" == *'"green":true'* ]]
+}
+
+@test "非 test ファイル申告は exit 2(昇格拒否)" {
+  run bash "$SCRIPT" "$REPO" "impl.mjs" "impl.mjs"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *'non-test file'* ]]
+}
+
+@test "test と impl が同一ファイル(混在)は exit 2" {
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "feature.test.mjs"
+  [ "$status" -eq 2 ]
+}

--- a/_shared/scripts/redgreen-verify.bats
+++ b/_shared/scripts/redgreen-verify.bats
@@ -1,38 +1,95 @@
 #!/usr/bin/env bats
-# redgreen-verify.sh: impl を stash して test が red→green に転じるか判定する。
+# redgreen-verify.sh: impl を退避して test が red→green に転じるか判定する。
+# untracked 新規ファイル・tracked-modified ファイルの両シナリオをカバーする。
 
 setup() {
   SCRIPT="$BATS_TEST_DIRNAME/redgreen-verify.sh"
   REPO="$(mktemp -d)"
   cd "$REPO"
   git init -q && git config user.email t@t && git config user.name t
-  echo "export const ok = false;" > impl.mjs
-  git add impl.mjs && git commit -q -m base
-  # impl を true にし、それを検証する test を worktree に置く(未 commit = implementer の変更相当)
-  echo "export const ok = true;" > impl.mjs
-  cat > feature.test.mjs <<'EOF'
+  # base commit(空でも良いが git stash が機能するためダミーを入れる)
+  echo "# placeholder" > .gitkeep
+  git add .gitkeep && git commit -q -m base
+}
+teardown() { rm -rf "$REPO"; }
+
+# --- helper: feature.test.mjs を生成 ---
+make_test() {
+  cat > "$REPO/feature.test.mjs" <<'EOF'
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { ok } from './impl.mjs';
 test('ok is true', () => { assert.equal(ok, true); });
 EOF
 }
-teardown() { rm -rf "$REPO"; }
 
-@test "red→green: impl 退避で red、復元で green" {
+# -----------------------------------------------------------------------
+# シナリオ A: tracked-modified (従来パス)
+# impl を base で commit → worktree 上で変更 → untracked ではない
+# -----------------------------------------------------------------------
+@test "A: tracked-modified impl で red→green 判定が成立する" {
+  # base commit に impl(false)を含める
+  echo "export const ok = false;" > "$REPO/impl.mjs"
+  git -C "$REPO" add impl.mjs && git -C "$REPO" commit -q -m "add impl base"
+  # worktree 上で true に変更(tracked-modified = implementer の変更相当)
+  echo "export const ok = true;" > "$REPO/impl.mjs"
+  make_test
+
   run bash "$SCRIPT" "$REPO" "feature.test.mjs" "impl.mjs"
   [ "$status" -eq 0 ]
   [[ "$output" == *'"red":true'* ]]
   [[ "$output" == *'"green":true'* ]]
 }
 
+# -----------------------------------------------------------------------
+# シナリオ B: untracked 新規 impl (dev-flow の主要ユースケース)
+# impl を一度も commit せず worktree に置く → git ls-files で認識されない
+# -----------------------------------------------------------------------
+@test "B: untracked 新規 impl ファイルで red→green 判定が成立する" {
+  # impl を commit しない(untracked のまま)
+  echo "export const ok = true;" > "$REPO/impl.mjs"
+  make_test
+
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "impl.mjs"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"red":true'* ]]
+  [[ "$output" == *'"green":true'* ]]
+}
+
+@test "B: untracked impl 退避後に worktree に impl が復元されている" {
+  echo "export const ok = true;" > "$REPO/impl.mjs"
+  make_test
+
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "impl.mjs"
+  [ "$status" -eq 0 ]
+  # 判定後も impl が worktree に残っていること(worktree 破損なし)
+  [ -f "$REPO/impl.mjs" ]
+  grep -q "true" "$REPO/impl.mjs"
+}
+
+# -----------------------------------------------------------------------
+# シナリオ C: untracked impl が存在しない(パス誤り)→ exit 2
+# -----------------------------------------------------------------------
+@test "C: 存在しない untracked impl は exit 2" {
+  make_test
+
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "nonexistent.mjs"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *'impl file not found'* ]]
+}
+
+# -----------------------------------------------------------------------
+# 既存バリデーション
+# -----------------------------------------------------------------------
 @test "非 test ファイル申告は exit 2(昇格拒否)" {
+  echo "export const ok = true;" > "$REPO/impl.mjs"
   run bash "$SCRIPT" "$REPO" "impl.mjs" "impl.mjs"
   [ "$status" -eq 2 ]
   [[ "$output" == *'non-test file'* ]]
 }
 
 @test "test と impl が同一ファイル(混在)は exit 2" {
+  make_test
   run bash "$SCRIPT" "$REPO" "feature.test.mjs" "feature.test.mjs"
   [ "$status" -eq 2 ]
 }

--- a/_shared/scripts/redgreen-verify.bats
+++ b/_shared/scripts/redgreen-verify.bats
@@ -93,3 +93,52 @@ EOF
   run bash "$SCRIPT" "$REPO" "feature.test.mjs" "feature.test.mjs"
   [ "$status" -eq 2 ]
 }
+
+# -----------------------------------------------------------------------
+# シナリオ D: 別ディレクトリに同名 untracked impl が複数ある
+# a/mod.mjs と b/mod.mjs を同時申告しても basename 衝突で上書きされないこと
+# -----------------------------------------------------------------------
+@test "D: 別ディレクトリの同名 untracked impl 2 件が両方正しく復元される" {
+  mkdir -p "$REPO/a" "$REPO/b"
+  echo "export const va = 1;" > "$REPO/a/mod.mjs"
+  echo "export const vb = 2;" > "$REPO/b/mod.mjs"
+
+  # test ファイル(参照しないが runner が必要)
+  cat > "$REPO/feature.test.mjs" <<'EOF'
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+test('dummy', () => { assert.ok(true); });
+EOF
+
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "a/mod.mjs,b/mod.mjs"
+  [ "$status" -eq 0 ]
+
+  # 両ファイルが正しい内容で復元されていること
+  [ -f "$REPO/a/mod.mjs" ]
+  grep -q "va = 1" "$REPO/a/mod.mjs"
+  [ -f "$REPO/b/mod.mjs" ]
+  grep -q "vb = 2" "$REPO/b/mod.mjs"
+}
+
+# -----------------------------------------------------------------------
+# シナリオ E: 複数 untracked impl の一部が不在 → 先行ファイルが消失しないこと
+# first.mjs は存在、second.mjs は不在 → exit 2 かつ first.mjs が復元されている
+# -----------------------------------------------------------------------
+@test "E: 複数 untracked impl の一部が不在のとき先行ファイルが消失しない" {
+  echo "export const ok = true;" > "$REPO/first.mjs"
+  # second.mjs は意図的に作らない
+
+  cat > "$REPO/feature.test.mjs" <<'EOF'
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+test('dummy', () => { assert.ok(true); });
+EOF
+
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "first.mjs,second.mjs"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *'impl file not found'* ]]
+
+  # first.mjs が削除されずに残っている(消失しない)
+  [ -f "$REPO/first.mjs" ]
+  grep -q "true" "$REPO/first.mjs"
+}

--- a/_shared/scripts/redgreen-verify.sh
+++ b/_shared/scripts/redgreen-verify.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# red→green 実証: 実装だけ stash で base に戻し、test が red→green に転じるか決定論判定する。
+# red→green 実証: 実装だけ退避して base に戻し、test が red→green に転じるか決定論判定する。
+# untracked(新規)・tracked-modified いずれの impl ファイルにも対応する。
 # 使い方: redgreen-verify.sh <worktree> <test_files_csv> <impl_files_csv>
 # 出力(stdout, JSON 1行): {"red":bool,"green":bool,"reason":"..."}
 # exit 0 = 判定完了(red/green は JSON 参照) / exit 2 = 入力・分離エラー(= deterministic 昇格しないこと)
@@ -41,16 +42,106 @@ run_tests() {
   return $rc
 }
 
-# impl だけ stash(test は worktree に残す)
-if ! git stash push -q -- "${IMPLS[@]}" 2>/dev/null; then
-  echo '{"red":false,"green":false,"reason":"stash push failed"}'; exit 2
+# impl ファイルを untracked(新規) と tracked-modified に分類して退避する。
+# untracked はコピーして削除、tracked-modified は git stash で退避する。
+TMPDIR_IMPL="$(mktemp -d)"
+UNTRACKED_IMPLS=()
+TRACKED_IMPLS=()
+
+for f in "${IMPLS[@]}"; do
+  if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+    TRACKED_IMPLS+=("$f")
+  else
+    UNTRACKED_IMPLS+=("$f")
+  fi
+done
+
+STASH_CREATED=false
+UNTRACKED_SAVED=false
+
+# --- cleanup / restore trap ---
+restore_impl() {
+  local exit_code=$?
+  # untracked impl を復元
+  if [ "$UNTRACKED_SAVED" = true ]; then
+    for f in "${UNTRACKED_IMPLS[@]}"; do
+      local bname
+      bname="$(basename "$f")"
+      local dest_dir
+      dest_dir="$(dirname "$f")"
+      if [ -f "$TMPDIR_IMPL/$bname" ]; then
+        mkdir -p "$dest_dir"
+        cp "$TMPDIR_IMPL/$bname" "$f"
+      fi
+    done
+  fi
+  # stash を復元
+  if [ "$STASH_CREATED" = true ]; then
+    if ! git stash pop -q 2>/dev/null; then
+      # pop 失敗 = conflict 等。stash が残存し worktree 不整合の恐れあり。
+      echo "REDGREEN_FATAL: git stash pop failed; worktree may be inconsistent. Run 'git stash list' and recover manually." >&2
+      # stash drop して続行不可の旨を知らせる
+      git stash drop -q 2>/dev/null || true
+    fi
+  fi
+  rm -rf "$TMPDIR_IMPL"
+  # exit_code が 0 でない場合はそのまま伝播させる
+  # (trap 内での return は元の exit を引き継ぐ)
+}
+trap restore_impl EXIT
+
+# 1. untracked impl をコピーして削除
+if [ "${#UNTRACKED_IMPLS[@]}" -gt 0 ]; then
+  for f in "${UNTRACKED_IMPLS[@]}"; do
+    if [ ! -f "$f" ]; then
+      echo "{\"red\":false,\"green\":false,\"reason\":\"impl file not found: $f\"}"; exit 2
+    fi
+    cp "$f" "$TMPDIR_IMPL/$(basename "$f")"
+    rm -f "$f"
+  done
+  UNTRACKED_SAVED=true
 fi
+
+# 2. tracked-modified impl を stash で退避
+if [ "${#TRACKED_IMPLS[@]}" -gt 0 ]; then
+  if ! git stash push -q -- "${TRACKED_IMPLS[@]}" 2>/dev/null; then
+    echo '{"red":false,"green":false,"reason":"stash push failed"}'; exit 2
+  fi
+  STASH_CREATED=true
+fi
+
 # red 判定(impl 退避中: test は落ちるべき)
 if run_tests; then RED=false; else RED=true; fi
-# 復元
-if ! git stash pop -q 2>/dev/null; then
-  echo "{\"red\":$RED,\"green\":false,\"reason\":\"stash pop failed\"}"; exit 2
+
+# --- restore は trap(EXIT) が担う ---
+# ここで明示的に復元して green 判定のために残り処理を続ける。
+# trap は EXIT 時に再び呼ばれるが、フラグをリセットして二重復元を防ぐ。
+
+# tracked-modified を先に pop
+if [ "$STASH_CREATED" = true ]; then
+  if ! git stash pop -q 2>/dev/null; then
+    # pop 失敗: stash drop + 強いエラーシグナルで abort
+    echo "REDGREEN_FATAL: git stash pop failed after red phase; worktree may be inconsistent. Run 'git stash list'." >&2
+    git stash drop -q 2>/dev/null || true
+    STASH_CREATED=false  # trap での再試行を防ぐ
+    echo "{\"red\":$RED,\"green\":false,\"reason\":\"stash pop failed: worktree inconsistent, impl may be lost\"}"; exit 2
+  fi
+  STASH_CREATED=false  # trap での二重 pop を防ぐ
 fi
+
+# untracked を復元
+if [ "$UNTRACKED_SAVED" = true ]; then
+  for f in "${UNTRACKED_IMPLS[@]}"; do
+    local_bname="$(basename "$f")"
+    local_dest_dir="$(dirname "$f")"
+    if [ -f "$TMPDIR_IMPL/$local_bname" ]; then
+      mkdir -p "$local_dest_dir"
+      cp "$TMPDIR_IMPL/$local_bname" "$f"
+    fi
+  done
+  UNTRACKED_SAVED=false  # trap での二重復元を防ぐ
+fi
+
 # green 判定(復元後: test は通るべき)
 if run_tests; then GREEN=true; else GREEN=false; fi
 

--- a/_shared/scripts/redgreen-verify.sh
+++ b/_shared/scripts/redgreen-verify.sh
@@ -62,16 +62,14 @@ UNTRACKED_SAVED=false
 # --- cleanup / restore trap ---
 restore_impl() {
   local exit_code=$?
-  # untracked impl を復元
+  # untracked impl を復元(相対パスを保持して退避したパスから戻す)
   if [ "$UNTRACKED_SAVED" = true ]; then
     for f in "${UNTRACKED_IMPLS[@]}"; do
-      local bname
-      bname="$(basename "$f")"
       local dest_dir
       dest_dir="$(dirname "$f")"
-      if [ -f "$TMPDIR_IMPL/$bname" ]; then
+      if [ -f "$TMPDIR_IMPL/$f" ]; then
         mkdir -p "$dest_dir"
-        cp "$TMPDIR_IMPL/$bname" "$f"
+        cp "$TMPDIR_IMPL/$f" "$f"
       fi
     done
   fi
@@ -92,11 +90,16 @@ trap restore_impl EXIT
 
 # 1. untracked impl をコピーして削除
 if [ "${#UNTRACKED_IMPLS[@]}" -gt 0 ]; then
+  # 削除を開始する前に全 untracked impl の存在を検証する(部分削除による消失を防ぐ)
   for f in "${UNTRACKED_IMPLS[@]}"; do
     if [ ! -f "$f" ]; then
       echo "{\"red\":false,\"green\":false,\"reason\":\"impl file not found: $f\"}"; exit 2
     fi
-    cp "$f" "$TMPDIR_IMPL/$(basename "$f")"
+  done
+  # 全件存在を確認してから退避(相対パスを保持してコピー)
+  for f in "${UNTRACKED_IMPLS[@]}"; do
+    mkdir -p "$TMPDIR_IMPL/$(dirname "$f")"
+    cp "$f" "$TMPDIR_IMPL/$f"
     rm -f "$f"
   done
   UNTRACKED_SAVED=true
@@ -129,14 +132,13 @@ if [ "$STASH_CREATED" = true ]; then
   STASH_CREATED=false  # trap での二重 pop を防ぐ
 fi
 
-# untracked を復元
+# untracked を復元(相対パスを保持して退避したパスから戻す)
 if [ "$UNTRACKED_SAVED" = true ]; then
   for f in "${UNTRACKED_IMPLS[@]}"; do
-    local_bname="$(basename "$f")"
     local_dest_dir="$(dirname "$f")"
-    if [ -f "$TMPDIR_IMPL/$local_bname" ]; then
+    if [ -f "$TMPDIR_IMPL/$f" ]; then
       mkdir -p "$local_dest_dir"
-      cp "$TMPDIR_IMPL/$local_bname" "$f"
+      cp "$TMPDIR_IMPL/$f" "$f"
     fi
   done
   UNTRACKED_SAVED=false  # trap での二重復元を防ぐ

--- a/_shared/scripts/redgreen-verify.sh
+++ b/_shared/scripts/redgreen-verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# red→green 実証: 実装だけ stash で base に戻し、test が red→green に転じるか決定論判定する。
+# 使い方: redgreen-verify.sh <worktree> <test_files_csv> <impl_files_csv>
+# 出力(stdout, JSON 1行): {"red":bool,"green":bool,"reason":"..."}
+# exit 0 = 判定完了(red/green は JSON 参照) / exit 2 = 入力・分離エラー(= deterministic 昇格しないこと)
+set -uo pipefail
+
+WT="${1:?worktree required}"
+TEST_CSV="${2:?test_files required}"
+IMPL_CSV="${3:?impl_files required}"
+
+cd "$WT" 2>/dev/null || { echo '{"red":false,"green":false,"reason":"cd failed"}'; exit 2; }
+
+IFS=',' read -r -a TESTS <<< "$TEST_CSV"
+IFS=',' read -r -a IMPLS <<< "$IMPL_CSV"
+
+# 層2: runner glob で test_files を検証(*.test.mjs / *.bats 以外は拒否)
+for t in "${TESTS[@]}"; do
+  case "$t" in
+    *.test.mjs|*.bats) : ;;
+    *) echo "{\"red\":false,\"green\":false,\"reason\":\"non-test file declared: $t\"}"; exit 2 ;;
+  esac
+done
+# 層4: test と impl の混在(同一ファイル)は曖昧 → 昇格しない
+for t in "${TESTS[@]}"; do
+  for i in "${IMPLS[@]}"; do
+    [ "$t" = "$i" ] && { echo "{\"red\":false,\"green\":false,\"reason\":\"file is both test and impl: $t\"}"; exit 2; }
+  done
+done
+
+run_tests() {
+  local rc=0 node_tests=() bats_tests=()
+  for t in "${TESTS[@]}"; do
+    case "$t" in
+      *.test.mjs) node_tests+=("$t") ;;
+      *.bats) bats_tests+=("$t") ;;
+    esac
+  done
+  if [ "${#node_tests[@]}" -gt 0 ]; then node --test "${node_tests[@]}" >/dev/null 2>&1 || rc=1; fi
+  if [ "${#bats_tests[@]}" -gt 0 ]; then bats "${bats_tests[@]}" >/dev/null 2>&1 || rc=1; fi
+  return $rc
+}
+
+# impl だけ stash(test は worktree に残す)
+if ! git stash push -q -- "${IMPLS[@]}" 2>/dev/null; then
+  echo '{"red":false,"green":false,"reason":"stash push failed"}'; exit 2
+fi
+# red 判定(impl 退避中: test は落ちるべき)
+if run_tests; then RED=false; else RED=true; fi
+# 復元
+if ! git stash pop -q 2>/dev/null; then
+  echo "{\"red\":$RED,\"green\":false,\"reason\":\"stash pop failed\"}"; exit 2
+fi
+# green 判定(復元後: test は通るべき)
+if run_tests; then GREEN=true; else GREEN=false; fi
+
+echo "{\"red\":$RED,\"green\":$GREEN,\"reason\":\"ok\"}"
+exit 0

--- a/claudedocs/2026-06-09-w4-redgreen-gate-design.md
+++ b/claudedocs/2026-06-09-w4-redgreen-gate-design.md
@@ -1,0 +1,120 @@
+# W4 設計: red→green 実証ゲートで収束を ledger 駆動に差し替え
+
+- **日付**: 2026-06-09
+- **ステータス**: design(red→green mechanism の選択待ち → 確定後に bite-sized plan へ)
+- **base**: W3(`feature/dev-flow-w4-redgreen-gate` は W3 tip `9747931` から stack。PR #144 merge 後に dev へ rebase)
+- **上位 spec**: `claudedocs/2026-06-09-dev-flow-adaptive-ledger-redesign.md` の W4
+
+## 1. W3 の到達点と W4 の課題
+
+W3 で Evaluate phase に Goal Ledger を **observe-only** で構築済み(`dev-flow.js` L498-560)。
+だが収束は依然 `ev.verdict === 'pass'` で break し、ledger は log + return のみ。
+
+**核心の発見(W4 の設計を決める)**: W3 の AC item は `check:{kind:'inspection'}` + `severity:'major'` で
+構築されるため `laneOf` では **advisory**(blocking ではない)。よって `isConverged`(= blocking lane の
+全項目 checked)は **AC をゲートしない** — critical feedback だけ。
+
+> 帰結: 単純に収束を `isConverged` へ差し替えても、AC に対しては現状の `verdict==pass` より**弱くなる**。
+> `isConverged` が AC に対して意味を持つのは、**red→green でテスト化できた AC を `check:{kind:'deterministic'}`
+> = blocking に昇格させたとき**だけ。つまり red→green は W4 のオプションでなく**心臓部**。
+
+## 2. 収束契約(recalibration 反映)
+
+W4 後の Evaluate 収束条件:
+
+```
+収束 = isConverged(ledger) AND ev.verdict === 'pass'
+```
+
+- `isConverged(ledger)`: **決定論ゲート**。red→green 実証済み AC(deterministic-blocking)が全て green、
+  かつ全 critical が解消。test 化できる AC の充足を ungameable に保証。
+- `ev.verdict === 'pass'`: **LLM ゲート**。test 化できない AC・holistic な設計健全性を LLM が判定
+  (recalibration: LLM を advisory に降格しない。test が捉えられない領域の判断は残す)。
+- 両者の AND = 「決定論で測れるものは決定論で、測れないものは LLM で」。critical は ledger の blocking
+  なので isConverged が解消を要求(critical-always-blocks 維持)。
+
+既存の stuck/relax/early-cutoff は **backstop として残す**(spec §3 原則5。ledger 実証まで撤去しない)。
+
+## 3. 評価者の契約変更(item-validator 化)
+
+`isConverged` を駆動するには evaluator が「どの AC が満たされたか」を返す必要がある。
+EVAL schema と `evaluator.md` に **per-AC 判定**を追加する:
+
+```jsonc
+// EVAL schema 追加フィールド
+"ac_results": {
+  "type": "array",
+  "items": { "type": "object",
+    "required": ["ac_index", "satisfied"],
+    "properties": {
+      "ac_index": { "type": "number" },        // req.acceptance_criteria の index
+      "satisfied": { "type": "boolean" },
+      "evidence": { "type": "string" },         // file:line / テスト名 等
+      "verified_by": { "type": "string", "enum": ["test", "inspection"] }
+    }
+  }
+}
+```
+
+orchestrator は `ac_results` を見て `checkItem(ledger, 'AC-${i+1}', evidence)` する。
+`verified_by==='test'` かつ red→green 実証が取れた AC は `check:{kind:'deterministic'}` に昇格(blocking)。
+それ以外は inspection のまま(advisory、`verdict==pass` 側でカバー)。
+
+`evaluator.md` は「verdict 決定者」から「**per-item validator + 全体 verdict**」へ。severity 判定は残す
+(recalibration: severity は frontier の強み)。
+
+## 4. red→green 実証メカニズム(要・選択)
+
+**設計上の難所**: dev-flow の Evaluate phase 時点で、implementer の変更は worktree に**未 commit**で存在し
+HEAD = base(origin/dev の fork 点)。「変更前 = red」を作るには、**テストは残しつつ実装だけ base に戻した
+状態**でテストを走らせる必要がある。単一共有 worktree でこれをどう実現するかが選択ポイント。
+
+### 案 R1: path ヒューリスティックで impl/test を分離(推奨・最小)
+新規/変更テストファイル(`*.test.*` / `*.bats` / `tests/` 配下)を残し、それ以外(= 実装)を
+`git checkout HEAD -- <impl-paths>` で base に戻す → テスト実行(**red 期待**)→ `git checkout` で復元
+→ テスト実行(**green 期待**)。red→green が取れたテストに対応する AC を deterministic 昇格。
+- 利点: 追加インフラ不要、現 worktree で完結、決定論。
+- 欠点: impl/test の path 分離が雑だと誤判定。混在ファイルに弱い。
+
+### 案 R2: base の別 checkout を temp に用意
+`git worktree add <tmp> origin/<base>` で clean な base worktree を作り、新規テストファイルだけ
+コピーして実行(red 期待)→ 元 worktree で実行(green 期待)。
+- 利点: impl/test 分離が「新規テストファイルのコピー」だけで済み R1 より堅い。
+- 欠点: worktree 追加コスト + テストの依存(fixture 等)が base に無いと誤 red。
+
+### 案 R3: evaluator/implementer に reproduction test を明示生成させる
+TDFlow 流。AC ごとに「これが満たされなければ落ちる」最小テストを生成させ、base で red・現状で green を
+JS が記録。
+- 利点: AC と test の対応が明示的で最も正確。
+- 欠点: 生成コスト最大。test の adequacy(AC を本当に制約してるか)は別途 LLM 判定が要る(red-team 指摘の核)。
+
+> いずれも「red→green が取れた AC だけ」を deterministic 昇格。取れない AC は inspection(advisory)に留め
+> `verdict==pass` 側でカバー(=安全側。決定論化できないものを無理に blocking にしない)。
+
+## 5. 作業分解(bite-sized は mechanism 確定後)
+
+| # | 作業 | 依存 | リスク |
+|---|------|------|--------|
+| W4-1 | EVAL schema + `evaluator.md` に `ac_results` 追加(per-item validator 化) | — | 中(agent 契約変更) |
+| W4-2 | orchestrator が `ac_results` で `checkItem` + AC を deterministic 昇格 | W4-1 | 中 |
+| W4-3 | red→green 実証スクリプト `_shared/scripts/redgreen-verify.sh`(選択した案)+ bats | 案選択 | 高(novel) |
+| W4-4 | 収束を `isConverged(ledger) && verdict==pass` へ差し替え(stuck/relax は backstop 維持) | W4-2,3 | 高(live gate) |
+| W4-5 | W3 follow-up nit: `appendItem` の `check` shallow-clone / 未定義 severity の throw | — | 低 |
+
+## 6. Open questions(plan 化前に解消)
+
+1. **red→green mechanism(R1/R2/R3)の選択** ← 最優先。これが W4-3/W4-4 の plan を決める。
+2. red→green が取れない AC が多数の場合、`isConverged` は実質 critical のみゲート → `verdict==pass`
+   依存に戻る。それを許容するか(= traffic 次第。spec open question #5 と接続)。
+3. evaluator が `ac_index` を req.acceptance_criteria と正しく対応づけられるか(index ずれ対策)。
+4. red→green 実行のコスト(テスト2回 + checkout 往復)を EVAL_MAX ループ内で毎回やるか、初回 + 変化時のみか。
+
+## 7. 非ゴール / backstop
+
+- stuck/relax/early-cutoff/hard cap は撤去しない(ledger 実証まで)。
+- merge tiering(AUTO/REVIEW/HOLD)は W5。gate_policy enum は W6。本 plan では扱わない。
+- 動的コード生成はしない(W3 同様、可変 script + inline)。
+
+## 参考
+- W3 PR: #144 / W3 plan: `claudedocs/2026-06-09-w3-goal-ledger-engine-plan.md`
+- 検証 run 2(human/LLM 境界 recalibration): `recalibrate-human-llm-boundary`

--- a/claudedocs/2026-06-09-w4-redgreen-gate-design.md
+++ b/claudedocs/2026-06-09-w4-redgreen-gate-design.md
@@ -69,12 +69,18 @@ orchestrator は `ac_results` を見て `checkItem(ledger, 'AC-${i+1}', evidence
 HEAD = base(origin/dev の fork 点)。「変更前 = red」を作るには、**テストは残しつつ実装だけ base に戻した
 状態**でテストを走らせる必要がある。単一共有 worktree でこれをどう実現するかが選択ポイント。
 
-### 案 R1: path ヒューリスティックで impl/test を分離(推奨・最小)
-新規/変更テストファイル(`*.test.*` / `*.bats` / `tests/` 配下)を残し、それ以外(= 実装)を
-`git checkout HEAD -- <impl-paths>` で base に戻す → テスト実行(**red 期待**)→ `git checkout` で復元
-→ テスト実行(**green 期待**)。red→green が取れたテストに対応する AC を deterministic 昇格。
-- 利点: 追加インフラ不要、現 worktree で完結、決定論。
-- 欠点: impl/test の path 分離が雑だと誤判定。混在ファイルに弱い。
+### 案 R1+(採用): stash で impl だけ退避 + 推測しない4層分離
+`git stash push -- <impl-paths>` で実装だけ base に戻し test は残す → test 実行(**red 期待**)→
+`git stash pop` で復元 → test 実行(**green 期待**)。`<impl-paths>` を**推測でなく authoritative に**決める:
+
+1. **第一情報源 = agent 申告**: implementer/evaluator が per-AC で `test_files[] / impl_files[]` を申告。
+2. **runner glob で決定論クロスチェック**: 申告 `test_files` が repo の test discovery
+   (`*.test.mjs` / `*.bats`)に一致しなければ昇格拒否(mislabel を機械的に弾く)。
+3. **per-AC・per-test-file 粒度**: global 一括分離をせず AC ごとに紐づく test だけ stash 検証。
+4. **fail-safe**: 曖昧なら deterministic 昇格を諦め inspection(advisory)に留める。
+- 注意: workflow JS は bash 不可 → red→green の実行は **dev-runner-haiku agent** が
+  `_shared/scripts/redgreen-verify.sh` を走らせ raw exit code を verbatim 返す(opus evaluator に
+  判定させない = gaming 抑制)。
 
 ### 案 R2: base の別 checkout を temp に用意
 `git worktree add <tmp> origin/<base>` で clean な base worktree を作り、新規テストファイルだけ
@@ -103,7 +109,7 @@ JS が記録。
 
 ## 6. Open questions(plan 化前に解消)
 
-1. **red→green mechanism(R1/R2/R3)の選択** ← 最優先。これが W4-3/W4-4 の plan を決める。
+1. ~~red→green mechanism の選択~~ → **解決: R1+ 採用**(2026-06-09)。
 2. red→green が取れない AC が多数の場合、`isConverged` は実質 critical のみゲート → `verdict==pass`
    依存に戻る。それを許容するか(= traffic 次第。spec open question #5 と接続)。
 3. evaluator が `ac_index` を req.acceptance_criteria と正しく対応づけられるか(index ずれ対策)。

--- a/claudedocs/2026-06-09-w4-redgreen-gate-plan.md
+++ b/claudedocs/2026-06-09-w4-redgreen-gate-plan.md
@@ -1,0 +1,381 @@
+# W4: red→green ゲート Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** dev-flow の Evaluate 収束を「reviewer verdict のみ」から「`isConverged(ledger) AND verdict==pass`」へ差し替え、red→green 実証(R1+)で test 化できた AC を deterministic-blocking に昇格させる。
+
+**Architecture:** evaluator が per-AC の `ac_results`(satisfied + test_files/impl_files 申告)を返す item-validator になる。orchestrator は申告を runner glob で検証し、dev-runner-haiku が `_shared/scripts/redgreen-verify.sh` を走らせて red→green を決定論判定、取れた AC を `setCheck(deterministic)` で blocking 昇格 + `checkItem`。取れない AC は inspection(advisory)に留め `verdict==pass` 側でカバー。既存 stuck/relax は backstop 維持。
+
+**Tech Stack:** Node 24(`node:test`)/ bash + bats / Claude Code workflow(`dev-flow.js`)/ subagent `evaluator.md`・`dev-runner-haiku`。
+
+**前提:** W3(`feature/dev-flow-w4-redgreen-gate` は W3 tip から stack)。**実装は PR #144 が dev に merge され、本ブランチを dev へ rebase した後**に着手する。**行番号は W3 から変動するため必ずコード内容(anchor)で位置特定**すること。
+
+**Scope:** W4 のみ。merge tiering(W5)/ gate_policy(W6)は対象外。
+
+---
+
+## File Structure
+
+| ファイル | 責務 | 新規/変更 |
+|----------|------|-----------|
+| `_lib/goal-ledger.mjs` | `setCheck(ledger,id,check)` を追加(item の check 種別を更新=昇格用) | 変更 |
+| `_lib/goal-ledger.test.mjs` | setCheck の単体テスト | 変更 |
+| `_lib/goal-ledger.sync.test.mjs` | FN_NAMES に setCheck 追加 | 変更 |
+| `.claude/workflows/dev-flow.js` | setCheck inline 複製 / EVAL schema 拡張 / Evaluate 配線 + 収束 flip | 変更 |
+| `.claude/agents/evaluator.md` | ac_results(per-item validator)契約追加 | 変更 |
+| `_shared/scripts/redgreen-verify.sh` | red→green 決定論判定スクリプト | 新規 |
+| `_shared/scripts/redgreen-verify.bats` | 上記の bats テスト | 新規 |
+
+---
+
+## Task W4-0: エンジンに setCheck を追加
+
+**Files:** Modify `_lib/goal-ledger.mjs`, `_lib/goal-ledger.test.mjs`; (inline)`.claude/workflows/dev-flow.js`, `_lib/goal-ledger.sync.test.mjs`
+
+- [ ] **Step 1: 失敗テストを追加** — `_lib/goal-ledger.test.mjs` 末尾に:
+
+```javascript
+test('setCheck: 既存 item の check 種別を更新（inspection→deterministic で blocking 昇格）', () => {
+  let { ledger } = appendItem(makeLedger(), { id: 'AC-1', text: 'x', dimension: 'ac', severity: 'major', source: 'ac', check: { kind: 'inspection' } });
+  assert.equal(laneOf(ledger.items[0]), 'advisory');           // 昇格前は advisory
+  ledger = setCheck(ledger, 'AC-1', { kind: 'deterministic' });
+  assert.equal(ledger.items[0].check.kind, 'deterministic');
+  assert.equal(laneOf(ledger.items[0]), 'blocking');           // 昇格後は blocking
+});
+test('setCheck: 未知 id は throw', () => {
+  assert.throws(() => setCheck(makeLedger(), 'X', { kind: 'deterministic' }), /未知の item id/);
+});
+```
+
+`import` 行に `setCheck` を追加する。
+
+- [ ] **Step 2: fail 確認** — Run: `node --test _lib/goal-ledger.test.mjs` — Expected: FAIL(`setCheck is not a function`)
+
+- [ ] **Step 3: 実装** — `_lib/goal-ledger.mjs` の `reopenItem` の直後に追加:
+
+```javascript
+export function setCheck(ledger, id, check) {
+  const idx = ledger.items.findIndex((it) => it.id === id);
+  if (idx < 0) throw new Error(`goal-ledger: 未知の item id "${id}"`);
+  const items = ledger.items.slice();
+  items[idx] = { ...items[idx], check };
+  return { ...ledger, items };
+}
+```
+
+- [ ] **Step 4: pass 確認** — Run: `node --test _lib/goal-ledger.test.mjs` — Expected: PASS(23 tests)
+
+- [ ] **Step 5: inline 複製 + sync** — `_lib/goal-ledger.mjs` の `setCheck` を `export ` 除去して `.claude/workflows/dev-flow.js` の inline ledger ブロック(`reopenItem` の直後)へ逐語コピー。`_lib/goal-ledger.sync.test.mjs` の `FN_NAMES` 配列に `'setCheck'` を追加。
+
+- [ ] **Step 6: 検証** — Run: `node --test _lib/goal-ledger.sync.test.mjs`(14 関数 byte 一致)/ `node --test _lib/workflow-load-smoke.test.mjs` — Expected: 両 PASS
+
+- [ ] **Step 7: commit**
+
+```bash
+git add _lib/goal-ledger.mjs _lib/goal-ledger.test.mjs _lib/goal-ledger.sync.test.mjs .claude/workflows/dev-flow.js
+git commit -m "feat(dev-flow): Goal Ledger に setCheck 追加 (item の check 種別更新=blocking 昇格)"
+```
+
+---
+
+## Task W4-1: EVAL schema + evaluator.md に ac_results
+
+**Files:** Modify `.claude/workflows/dev-flow.js`(EVAL schema), `.claude/agents/evaluator.md`
+
+- [ ] **Step 1: EVAL schema 拡張** — `.claude/workflows/dev-flow.js` の `const EVAL = {` を anchor に、`properties` へ `ac_results` を追加(既存フィールドは保持):
+
+```javascript
+    ac_results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['ac_index', 'satisfied'],
+        properties: {
+          ac_index: { type: 'number' },
+          satisfied: { type: 'boolean' },
+          evidence: { type: 'string' },
+          verified_by: { type: 'string', enum: ['test', 'inspection'] },
+          test_files: { type: 'array', items: { type: 'string' } },
+          impl_files: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+```
+
+- [ ] **Step 2: evaluator.md に契約追加** — `evaluator.md` の「## Step 5: 出力 JSON」直前に新セクションを挿入:
+
+```markdown
+## per-AC 判定（ac_results。W4 item-validator 契約）
+
+`requirements.acceptance_criteria` の各項目について、満たされているかを個別に判定し `ac_results[]` に返す:
+
+- `ac_index`: acceptance_criteria の 0 始まり index。
+- `satisfied`: 実 diff / テスト出力に照らして満たされているか（自己申告でなく検証）。
+- `evidence`: 根拠（file:line / テスト名）。
+- `verified_by`: その AC を **テストで実証できる**なら `"test"`、コード精査でしか判断できないなら `"inspection"`。
+- `test_files` / `impl_files`（`verified_by==="test"` のときのみ）: その AC を実証する**テストファイル**と、
+  それが検証する**実装ファイル**を worktree 相対パスで列挙する。**自分で red→green 判定を主張しないこと** —
+  orchestrator が dev-runner-haiku 経由で `redgreen-verify.sh` を走らせ決定論判定する。あなたは申告のみ。
+- test_files は repo の test discovery（`*.test.mjs` / `*.bats`）に一致するものだけ挙げる。混在ファイルは挙げない。
+```
+
+`ac_results` を Step 5 の出力 JSON 例にも 1 エントリ追加する。
+
+- [ ] **Step 3: 検証** — Run: `node --test _lib/workflow-load-smoke.test.mjs` — Expected: PASS(schema 構文 OK)
+
+- [ ] **Step 4: commit**
+
+```bash
+git add .claude/workflows/dev-flow.js .claude/agents/evaluator.md
+git commit -m "feat(dev-flow): evaluator を per-AC item-validator 化 (ac_results 契約)"
+```
+
+---
+
+## Task W4-2: redgreen-verify.sh + bats
+
+**Files:** Create `_shared/scripts/redgreen-verify.sh`, `_shared/scripts/redgreen-verify.bats`
+
+- [ ] **Step 1: bats テストを書く** — Create `_shared/scripts/redgreen-verify.bats`:
+
+```bash
+#!/usr/bin/env bats
+# redgreen-verify.sh: impl を stash して test が red→green に転じるか判定する。
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/redgreen-verify.sh"
+  REPO="$(mktemp -d)"
+  cd "$REPO"
+  git init -q && git config user.email t@t && git config user.name t
+  echo "export const ok = false;" > impl.mjs
+  git add impl.mjs && git commit -q -m base
+  # impl を true にし、それを検証する test を worktree に置く(未 commit = implementer の変更相当)
+  echo "export const ok = true;" > impl.mjs
+  cat > feature.test.mjs <<'EOF'
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ok } from './impl.mjs';
+test('ok is true', () => { assert.equal(ok, true); });
+EOF
+}
+teardown() { rm -rf "$REPO"; }
+
+@test "red→green: impl 退避で red、復元で green" {
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "impl.mjs"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"red":true'* ]]
+  [[ "$output" == *'"green":true'* ]]
+}
+
+@test "非 test ファイル申告は exit 2(昇格拒否)" {
+  run bash "$SCRIPT" "$REPO" "impl.mjs" "impl.mjs"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *'non-test file'* ]]
+}
+
+@test "test と impl が同一ファイル(混在)は exit 2" {
+  run bash "$SCRIPT" "$REPO" "feature.test.mjs" "feature.test.mjs"
+  [ "$status" -eq 2 ]
+}
+```
+
+- [ ] **Step 2: fail 確認** — Run: `bats _shared/scripts/redgreen-verify.bats` — Expected: FAIL(script 不在)
+
+- [ ] **Step 3: 実装** — Create `_shared/scripts/redgreen-verify.sh`:
+
+```bash
+#!/usr/bin/env bash
+# red→green 実証: 実装だけ stash で base に戻し、test が red→green に転じるか決定論判定する。
+# 使い方: redgreen-verify.sh <worktree> <test_files_csv> <impl_files_csv>
+# 出力(stdout, JSON 1行): {"red":bool,"green":bool,"reason":"..."}
+# exit 0 = 判定完了(red/green は JSON 参照) / exit 2 = 入力・分離エラー(= deterministic 昇格しないこと)
+set -uo pipefail
+
+WT="${1:?worktree required}"
+TEST_CSV="${2:?test_files required}"
+IMPL_CSV="${3:?impl_files required}"
+
+cd "$WT" 2>/dev/null || { echo '{"red":false,"green":false,"reason":"cd failed"}'; exit 2; }
+
+IFS=',' read -r -a TESTS <<< "$TEST_CSV"
+IFS=',' read -r -a IMPLS <<< "$IMPL_CSV"
+
+# 層2: runner glob で test_files を検証(*.test.mjs / *.bats 以外は拒否)
+for t in "${TESTS[@]}"; do
+  case "$t" in
+    *.test.mjs|*.bats) : ;;
+    *) echo "{\"red\":false,\"green\":false,\"reason\":\"non-test file declared: $t\"}"; exit 2 ;;
+  esac
+done
+# 層4: test と impl の混在(同一ファイル)は曖昧 → 昇格しない
+for t in "${TESTS[@]}"; do
+  for i in "${IMPLS[@]}"; do
+    [ "$t" = "$i" ] && { echo "{\"red\":false,\"green\":false,\"reason\":\"file is both test and impl: $t\"}"; exit 2; }
+  done
+done
+
+run_tests() {
+  local rc=0 node_tests=() bats_tests=()
+  for t in "${TESTS[@]}"; do
+    case "$t" in
+      *.test.mjs) node_tests+=("$t") ;;
+      *.bats) bats_tests+=("$t") ;;
+    esac
+  done
+  if [ "${#node_tests[@]}" -gt 0 ]; then node --test "${node_tests[@]}" >/dev/null 2>&1 || rc=1; fi
+  if [ "${#bats_tests[@]}" -gt 0 ]; then bats "${bats_tests[@]}" >/dev/null 2>&1 || rc=1; fi
+  return $rc
+}
+
+# impl だけ stash(test は worktree に残す)
+if ! git stash push -q -- "${IMPLS[@]}" 2>/dev/null; then
+  echo '{"red":false,"green":false,"reason":"stash push failed"}'; exit 2
+fi
+# red 判定(impl 退避中: test は落ちるべき)
+if run_tests; then RED=false; else RED=true; fi
+# 復元
+if ! git stash pop -q 2>/dev/null; then
+  echo "{\"red\":$RED,\"green\":false,\"reason\":\"stash pop failed\"}"; exit 2
+fi
+# green 判定(復元後: test は通るべき)
+if run_tests; then GREEN=true; else GREEN=false; fi
+
+echo "{\"red\":$RED,\"green\":$GREEN,\"reason\":\"ok\"}"
+exit 0
+```
+
+`chmod +x _shared/scripts/redgreen-verify.sh`。
+
+- [ ] **Step 4: pass 確認** — Run: `bats _shared/scripts/redgreen-verify.bats` — Expected: PASS(3 tests)
+
+- [ ] **Step 5: commit**
+
+```bash
+git add _shared/scripts/redgreen-verify.sh _shared/scripts/redgreen-verify.bats
+git commit -m "feat(dev-flow): red→green 決定論判定スクリプト + bats (R1+ stash 方式)"
+```
+
+---
+
+## Task W4-3: orchestrator 配線 + 収束 flip
+
+**Files:** Modify `.claude/workflows/dev-flow.js`(Evaluate loop)
+
+anchor で位置特定(W3 当時 L546-565 付近、merge 後は変動)。`log(\`evaluate iteration ${i}: ...\`)` の直後・
+既存の「critical feedback を ledger に append」ブロックの**直後**に、ac_results 処理を追加する。
+
+- [ ] **Step 1: ac_results を ledger に反映** — 上記 anchor の後に挿入:
+
+```javascript
+  // W4: evaluator の per-AC 判定を ledger に反映。test 実証できる AC は red→green を
+  // dev-runner-haiku で決定論検証し、取れたら deterministic 昇格(blocking)。
+  for (const r of (ev.ac_results ?? [])) {
+    if (!r || typeof r.ac_index !== 'number') continue
+    const acId = `AC-${r.ac_index + 1}`
+    if (!ledger.items.some((it) => it.id === acId)) continue   // 知らない AC は無視
+    if (r.satisfied && r.verified_by === 'test' && Array.isArray(r.test_files) && r.test_files.length
+        && Array.isArray(r.impl_files) && r.impl_files.length) {
+      const rg = await agent(
+        `cd ${WT} で作業。次を実行して **stdout の JSON 1 行だけ** を verbatim で返せ(判定や脚色をしない):\n`
+        + `bash ${WT}/_shared/scripts/redgreen-verify.sh ${WT} `
+        + `'${r.test_files.join(',')}' '${r.impl_files.join(',')}'`,
+        { agentType: 'dev-runner-haiku', schema: RG, label: `redgreen:AC-${r.ac_index + 1}`, phase: 'Evaluate' })
+      if (rg && rg.red === true && rg.green === true) {
+        ledger = setCheck(ledger, acId, { kind: 'deterministic' })
+        ledger = checkItem(ledger, acId, `red→green 実証: ${(r.test_files || []).join(',')}`)
+        log(`AC-${r.ac_index + 1}: red→green 実証 → deterministic 昇格 + checked`)
+      } else {
+        if (r.satisfied) ledger = checkItem(ledger, acId, r.evidence ?? 'inspection(red→green 未成立)')
+        log(`AC-${r.ac_index + 1}: red→green 未成立(${rg ? rg.reason : 'null'})→ inspection 据え置き`)
+      }
+    } else if (r.satisfied) {
+      ledger = checkItem(ledger, acId, r.evidence ?? 'inspection')
+    }
+  }
+```
+
+- [ ] **Step 2: RG schema を追加** — `.claude/workflows/dev-flow.js` の schema 群(`const EVAL = {...}` 付近)に:
+
+```javascript
+const RG = {
+  type: 'object', required: ['red', 'green'],
+  properties: { red: { type: 'boolean' }, green: { type: 'boolean' }, reason: { type: 'string' } },
+}
+```
+
+- [ ] **Step 3: 収束を flip** — Evaluate ループの `if (ev.verdict === 'pass') {` を anchor に、収束条件を差し替え:
+
+```javascript
+  if (isConverged(ledger) && ev.verdict === 'pass') {
+    log(`evaluate 収束（ledger 全 blocking checked + verdict pass, iter ${i}）— PR へ進む`)
+    break
+  }
+```
+
+既存の stuck 早期打ち切り / `i === EVAL_MAX` / replan・fix 分岐は**そのまま残す**(backstop)。
+
+- [ ] **Step 4: return の observe フィールドを実値に** — `ledger_converged_observe` の key 名を `ledger_converged` に変更(observe ではなく実ゲートになったため)。
+
+- [ ] **Step 5: 検証**
+
+Run: `node --test _lib/workflow-load-smoke.test.mjs` — Expected: PASS
+Run: `node --test _lib/goal-ledger.sync.test.mjs` — Expected: PASS(14/14)
+Run: `./tests/run-node-tests.sh` — Expected: 全 green
+Run: `bash tests/run-all-bats.sh` — Expected: redgreen-verify.bats 含め green(bats 無し環境は skip)
+
+目視: 既存の stuck/relax/`EVAL_MAX`/replan 分岐が無変更であること(`git diff` で追加と収束1行差し替えのみ)。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add .claude/workflows/dev-flow.js
+git commit -m "feat(dev-flow): 収束を isConverged(ledger) && verdict==pass へ flip + red→green 昇格配線"
+```
+
+---
+
+## Task W4-4: W3 follow-up nit(shallow-clone check / 未定義 severity guard)
+
+**Files:** Modify `_lib/goal-ledger.mjs`, `_lib/goal-ledger.test.mjs`, (inline)`.claude/workflows/dev-flow.js`
+
+- [ ] **Step 1: テスト追加** — `_lib/goal-ledger.test.mjs` 末尾:
+
+```javascript
+test('appendItem: check は shallow-clone され caller mutation の影響を受けない', () => {
+  const check = { kind: 'inspection' };
+  const { ledger } = appendItem(makeLedger(), { id: 'A', text: 'x', dimension: 'd', severity: 'major', source: 'ac', check });
+  check.kind = 'deterministic';                       // caller が後から変更
+  assert.equal(ledger.items[0].check.kind, 'inspection'); // ledger 側は不変
+});
+```
+
+- [ ] **Step 2: fail 確認** — Run: `node --test _lib/goal-ledger.test.mjs` — Expected: FAIL(shared ref で deterministic になる)
+
+- [ ] **Step 3: 実装** — `_lib/goal-ledger.mjs` の `appendItem` の push 行で `check` を shallow-clone:
+
+```javascript
+  else items.push({ checked: false, evidence: null, floor: false, check: null, ...item, check: item.check ? { ...item.check } : null });
+```
+
+(末尾の `check:` が前方の `...item` の check を上書きし clone する)
+
+- [ ] **Step 4: pass 確認** — Run: `node --test _lib/goal-ledger.test.mjs` — Expected: PASS
+
+- [ ] **Step 5: inline 同期 + sync 検証** — dev-flow.js の inline `appendItem` を同じく更新し、Run: `node --test _lib/goal-ledger.sync.test.mjs` — Expected: PASS
+
+- [ ] **Step 6: commit**
+
+```bash
+git add _lib/goal-ledger.mjs _lib/goal-ledger.test.mjs .claude/workflows/dev-flow.js
+git commit -m "fix(dev-flow): Goal Ledger appendItem の check を shallow-clone (W3 nit)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage**: W4-0 setCheck(昇格手段)/ W4-1 evaluator item-validator(ac_results)/ W4-2 red→green 決定論スクリプト(R1+)/ W4-3 収束 flip(`isConverged && verdict==pass`)+ 昇格配線 / W4-4 W3 nit。design doc §2-5 を被覆。
+- **Placeholder scan**: TBD なし。全 code step に完全コード、全 run step に実コマンド+期待。
+- **Type consistency**: `setCheck` は W4-0 定義 → W4-3 使用で一致。`ac_results` フィールド(`ac_index/satisfied/evidence/verified_by/test_files/impl_files`)は EVAL schema(W4-1)/ evaluator.md(W4-1)/ orchestrator(W4-3)で一致。`RG` schema(`red/green/reason`)は redgreen-verify.sh 出力 / orchestrator で一致。AC id 規約 `AC-${index+1}` は W3 構築と W4-3 参照で一致。
+- **依存順序**: W4-0 → (W4-1, W4-2 並行可) → W4-3 → W4-4。W4-3 は W4-0/1/2 全てに依存。
+- **未解決(design doc §6 に残す)**: red→green をループ毎回走らせるコスト(OQ4)/ ac_index ずれ(OQ3)は実装時に観測して調整。スクリプト path は `${WT}/_shared/scripts/redgreen-verify.sh`(worktree に `_shared/` が含まれるため絶対パスで解決)。


### PR DESCRIPTION
dev-flow 再設計 W4: red-green 実証ゲート。W3(PR #144)の上に Evaluate 収束を isConverged(ledger) かつ verdict==pass へ flip。red-green でテスト化できた AC を deterministic=blocking 昇格。変更: goal-ledger に setCheck と check shallow-clone / dev-flow.js に ac_results・RG schema・red-green 配線・解消済み critical reconciliation・収束flip / evaluator.md の item-validator 契約 / redgreen-verify.sh と bats(R1+ stash 方式)。テスト 103/103 green、byte-sync 14/14、既存 backstop 無変更。詳細は claudedocs の W4 design と plan。