### PR TITLE
✨ feat(_shared): diff-risk-classify — realized diff の 7 danger クラスで critical floor

### DIFF
--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -70,6 +70,7 @@ teardown() {
 # 4. crypto NEGATIVE
 # ---------------------------------------------------------------------------
 @test "crypto NEGATIVE: 無害な変更 -> 出力は []" {
+    mkdir -p "$REPO/src"
     printf 'const x = 1;\n' > "$REPO/src/index.js"
     git -C "$REPO" add -A
     git -C "$REPO" commit -q -m change
@@ -182,6 +183,7 @@ teardown() {
 # 12. exec-sink NEGATIVE
 # ---------------------------------------------------------------------------
 @test "exec-sink NEGATIVE: 無害な変更 -> 出力は []" {
+    mkdir -p "$REPO/src"
     printf 'const x = 2 + 2;\n' > "$REPO/src/math.js"
     git -C "$REPO" add -A
     git -C "$REPO" commit -q -m change

--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -247,6 +247,27 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# NON-ASCII: 日本語ファイル名 × content-based クラス (public-api) の regression
+# core.quotepath=false なしでは git diff --name-only が "src/\350..." と
+# エスケープされ per-file diff が空になり false negative になる。
+# ---------------------------------------------------------------------------
+@test "NON-ASCII: 日本語ファイル名に export function -> class public-api を返す (core.quotepath regression)" {
+    mkdir -p "$REPO/src"
+    # 非 ASCII ファイル名（日本語）に public-api トリガーを追加
+    printf 'export function 認証API(user) {\n  return user.id;\n}\n' \
+        > "$REPO/src/認証api.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"public-api"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    # file 値が壊れた escape シーケンスでないことを確認
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")][0].file | test("認証api\\.ts$")'
+}
+
+# ---------------------------------------------------------------------------
 # ERROR: 不正な base ref -> 非 0 exit
 # ---------------------------------------------------------------------------
 @test "ERROR: 不正な base ref (invalid-sha) -> 非 0 exit" {

--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -1,0 +1,265 @@
+#\!/usr/bin/env bats
+# Tests for _shared/scripts/diff-risk-classify.sh
+#
+# Strategy: mktemp -d で隔離 git repo を作成し、各 danger class の陽性/陰性 diff を
+# commit してスクリプトの出力を検証する。
+# NOTE: F2 でスクリプトが実装されるまでこれらのテストは fail (red) になる。
+#
+# Class 文字列: auth / crypto / config / data-migration / public-api / exec-sink / dependency
+
+setup() {
+    SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/_shared/scripts/diff-risk-classify.sh"
+    REPO="$(mktemp -d)"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@t
+    git -C "$REPO" config user.name t
+    git -C "$REPO" commit -q --allow-empty -m base
+    BASE="$(git -C "$REPO" rev-parse HEAD)"
+}
+
+teardown() {
+    rm -rf "$REPO"
+}
+
+# ---------------------------------------------------------------------------
+# 1. auth POSITIVE
+# ---------------------------------------------------------------------------
+@test "auth POSITIVE: requireAuth を含む src/auth.ts -> class auth の hit オブジェクトを返す" {
+    mkdir -p "$REPO/src"
+    printf 'function requireAuth(user) {\n  return user.isAuthenticated;\n}\n' \
+        > "$REPO/src/auth.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"auth"'* ]]
+    [[ "$output" == *'auth.ts'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "auth")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# 2. auth NEGATIVE
+# ---------------------------------------------------------------------------
+@test "auth NEGATIVE: README に hello world の変更 -> 出力は []" {
+    printf 'hello world\n' > "$REPO/README.md"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 3. crypto POSITIVE
+# ---------------------------------------------------------------------------
+@test "crypto POSITIVE: crypto.createHash を含むファイル -> class crypto の hit オブジェクトを返す" {
+    mkdir -p "$REPO/src"
+    printf 'const hash = crypto.createHash("sha256");\n' \
+        > "$REPO/src/util.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"crypto"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "crypto")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# 4. crypto NEGATIVE
+# ---------------------------------------------------------------------------
+@test "crypto NEGATIVE: 無害な変更 -> 出力は []" {
+    printf 'const x = 1;\n' > "$REPO/src/index.js"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 5. config POSITIVE
+# ---------------------------------------------------------------------------
+@test "config POSITIVE: .env ファイルに API_TOKEN= を追加 -> class config の hit オブジェクトを返す" {
+    printf 'API_TOKEN=supersecret\n' > "$REPO/.env"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"config"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "config")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# 6. config NEGATIVE
+# ---------------------------------------------------------------------------
+@test "config NEGATIVE: 無害な変更 -> 出力は []" {
+    printf 'just a comment\n' > "$REPO/notes.txt"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 7. data-migration POSITIVE
+# ---------------------------------------------------------------------------
+@test "data-migration POSITIVE: migrations/ 配下の ALTER TABLE 含むファイル -> class data-migration を返す" {
+    mkdir -p "$REPO/migrations"
+    printf 'ALTER TABLE users ADD COLUMN verified BOOLEAN;\n' \
+        > "$REPO/migrations/0001_add_verified.sql"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"data-migration"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "data-migration")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# 8. data-migration NEGATIVE
+# ---------------------------------------------------------------------------
+@test "data-migration NEGATIVE: 無害な変更 -> 出力は []" {
+    printf 'select 1;\n' > "$REPO/query.sql"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 9. public-api POSITIVE
+# ---------------------------------------------------------------------------
+@test "public-api POSITIVE: export function を含むファイル -> class public-api を返す" {
+    mkdir -p "$REPO/src"
+    printf 'export function getUser(id) {\n  return db.find(id);\n}\n' \
+        > "$REPO/src/api.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"public-api"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# 10. public-api NEGATIVE
+# ---------------------------------------------------------------------------
+@test "public-api NEGATIVE: export なしの内部関数 -> 出力は []" {
+    mkdir -p "$REPO/src"
+    printf 'function helper() {\n  return 42;\n}\n' \
+        > "$REPO/src/helper.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 11. exec-sink POSITIVE
+# ---------------------------------------------------------------------------
+@test "exec-sink POSITIVE: eval( を含むファイル -> class exec-sink を返す" {
+    mkdir -p "$REPO/src"
+    printf 'const result = eval(userInput);\n' \
+        > "$REPO/src/runner.js"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"exec-sink"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# 12. exec-sink NEGATIVE
+# ---------------------------------------------------------------------------
+@test "exec-sink NEGATIVE: 無害な変更 -> 出力は []" {
+    printf 'const x = 2 + 2;\n' > "$REPO/src/math.js"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 13. dependency POSITIVE
+# ---------------------------------------------------------------------------
+@test "dependency POSITIVE: package.json に dependencies 変更 -> class dependency を返す" {
+    printf '{\n  "name": "app",\n  "dependencies": {\n    "lodash": "^4.17.21"\n  }\n}\n' \
+        > "$REPO/package.json"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"dependency"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "dependency")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# 14. dependency NEGATIVE
+# ---------------------------------------------------------------------------
+@test "dependency NEGATIVE: 無害な変更 -> 出力は []" {
+    printf 'version = "1.0.0"\nauthor = "Alice"\n' > "$REPO/metadata.txt"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 15a. EMPTY: 明らかに無害なファイルのみ変更 -> [] かつ exit 0
+# ---------------------------------------------------------------------------
+@test "EMPTY: 無害な変更のみ -> stdout が [] でかつ exit 0" {
+    printf 'This is just a changelog entry.\n' > "$REPO/CHANGELOG.txt"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# 15b. MULTI-CLASS: 1 ファイルが auth と exec-sink の両クラスにヒット -> 2 オブジェクト
+# ---------------------------------------------------------------------------
+@test "MULTI-CLASS: auth と exec-sink の両方のマーカーを含むファイル -> 2 つの hit オブジェクトを返す" {
+    mkdir -p "$REPO/src"
+    # requireAuth (auth class) + eval( (exec-sink class) を同一ファイルに
+    printf 'function requireAuth(user) { return eval(user.token); }\n' \
+        > "$REPO/src/mixed.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "auth")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
+    printf '%s\n' "$output" | jq -e 'length >= 2'
+}
+
+# ---------------------------------------------------------------------------
+# ERROR: 不正な base ref -> 非 0 exit
+# ---------------------------------------------------------------------------
+@test "ERROR: 不正な base ref (invalid-sha) -> 非 0 exit" {
+    run bash -c "cd '$REPO' && '$SCRIPT' 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# ERROR: git repo 外で実行 -> 非 0 exit
+# ---------------------------------------------------------------------------
+@test "ERROR: git repo 外 (非 git ディレクトリ) で実行 -> 非 0 exit" {
+    NON_GIT="$(mktemp -d)"
+    run bash -c "cd '$NON_GIT' && '$SCRIPT' 'HEAD'"
+    rm -rf "$NON_GIT"
+    [ "$status" -ne 0 ]
+}

--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -268,6 +268,25 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# SUBDIR-CWD: repo サブディレクトリを cwd にして content-based クラスが正しくヒットする
+# (regression: per-file diff pathspec が cwd 相対で解釈されると subdir 実行時に
+#  added が空になり content-based 6 クラスが silent false-negative になっていた)
+# ---------------------------------------------------------------------------
+@test "SUBDIR-CWD: repo subdir を cwd にして public-api (export function) が正しくヒットする" {
+    mkdir -p "$REPO/src"
+    printf 'export function getUser(id) {\n  return db.find(id);\n}\n' \
+        > "$REPO/src/sub.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    # Run from a subdirectory of the repo, NOT the repo root
+    run bash -c "cd '$REPO/src' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"public-api"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
 # ERROR: 不正な base ref -> 非 0 exit
 # ---------------------------------------------------------------------------
 @test "ERROR: 不正な base ref (invalid-sha) -> 非 0 exit" {

--- a/_shared/scripts/diff-risk-classify.sh
+++ b/_shared/scripts/diff-risk-classify.sh
@@ -43,7 +43,7 @@ fi
 # Collect changed files
 # ============================================================================
 
-files="$(git diff --name-only "${BASE}...HEAD" 2>/dev/null)" || files=""
+files="$(git -c core.quotepath=false diff --name-only "${BASE}...HEAD" 2>/dev/null)" || files=""
 
 if [[ -z "$files" ]]; then
     printf '%s\n' "[]"
@@ -63,7 +63,7 @@ while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
     # Get added lines for this file (^+ lines, excluding +++ header)
-    added="$(git diff "${BASE}...HEAD" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+    added="$(git -c core.quotepath=false diff "${BASE}...HEAD" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
 
     # 1. auth
     if echo "$file" | grep -Eiq 'auth' || \

--- a/_shared/scripts/diff-risk-classify.sh
+++ b/_shared/scripts/diff-risk-classify.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# diff-risk-classify.sh - dev-flow W1 deterministic danger-grep on realized diff.
+#
+# Purpose: Grep the REALIZED git diff (actual written changes, not proposed/issue text)
+# between a base ref and HEAD for 7 danger classes and print hit files as a JSON array
+# to stdout. Called directly from workflow JS. Ungameable critical floor -- severity is
+# ALWAYS "critical" and cannot be lowered by any flag or input.
+#
+# Usage: diff-risk-classify.sh <base-ref>
+# Output: JSON array of {file, class, severity:"critical"} objects (stdout)
+# Exit: 0 on success (even with empty hits), non-zero via die_json on error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../../_lib/common.sh
+source "$SCRIPT_DIR/../../_lib/common.sh"
+
+# ============================================================================
+# Args
+# ============================================================================
+
+BASE="${1:-}"
+if [[ -z "$BASE" ]]; then
+    die_json "<base-ref> required" 2
+fi
+
+require_git_repo
+
+# Validate the base ref resolves to a commit.
+# Use set +e / RC capture instead of "if \!" to avoid history-expansion issues
+# and set -e interactions across bash invocations.
+set +e
+git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null 2>&1
+_BASE_RC=$?
+set -e
+if [[ "$_BASE_RC" -ne 0 ]]; then
+    die_json "invalid base ref: $BASE" 2
+fi
+
+# ============================================================================
+# Collect changed files
+# ============================================================================
+
+files="$(git diff --name-only "${BASE}...HEAD" 2>/dev/null)" || files=""
+
+if [[ -z "$files" ]]; then
+    printf '%s\n' "[]"
+    exit 0
+fi
+
+# ============================================================================
+# Classification: 7 fixed-order danger classes
+# ============================================================================
+# Each class checks filename and/or added-line content with grep -Eiq.
+# A file may match multiple classes -> one object per matched class.
+# hits: newline-separated "file\tclass" records
+
+hits=""
+
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+
+    # Get added lines for this file (^+ lines, excluding +++ header)
+    added="$(git diff "${BASE}...HEAD" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+
+    # 1. auth
+    if echo "$file" | grep -Eiq 'auth' || \
+       echo "$added" | grep -Eiq 'authoriz|authenticat|requireAuth|isAdmin|hasPermission|jwt|session|login|logout|bearer'; then
+        hits="${hits}${file}"$'\t'"auth"$'\n'
+    fi
+
+    # 2. crypto
+    if echo "$added" | grep -Eiq 'crypto\.|createHash|createCipher|bcrypt|scrypt|randomBytes|pbkdf2|hmac|aes-|rsa'; then
+        hits="${hits}${file}"$'\t'"crypto"$'\n'
+    fi
+
+    # 3. config
+    if echo "$file" | grep -Eiq '(^|/)\.env($|\.)' || \
+       echo "$file" | grep -Eiq 'config/.*\.(ya?ml|json|toml)$' || \
+       echo "$added" | grep -Eiq 'process\.env\.|[A-Z_]{3,}_(KEY|TOKEN|SECRET|PASSWORD)[[:space:]]*='; then
+        hits="${hits}${file}"$'\t'"config"$'\n'
+    fi
+
+    # 4. data-migration
+    if echo "$file" | grep -Eiq 'migrations?/|/migrate' || \
+       echo "$added" | grep -Eiq 'ALTER TABLE|DROP TABLE|CREATE TABLE|ADD COLUMN|DROP COLUMN|RENAME COLUMN'; then
+        hits="${hits}${file}"$'\t'"data-migration"$'\n'
+    fi
+
+    # 5. public-api
+    if echo "$added" | grep -Eiq 'export (default |async )?(function|class|const)|module\.exports|@(Get|Post|Put|Delete|Patch)\(|openapi|paths:'; then
+        hits="${hits}${file}"$'\t'"public-api"$'\n'
+    fi
+
+    # 6. exec-sink
+    if echo "$added" | grep -Eiq 'eval\(|child_process|exec(Sync|File)?\(|spawn\(|pickle\.loads|yaml\.load\(|Function\(|new Function|deserialize|Marshal\.load'; then
+        hits="${hits}${file}"$'\t'"exec-sink"$'\n'
+    fi
+
+    # 7. dependency
+    if echo "$file" | grep -Eiq '(^|/)(package\.json|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|requirements\.txt|Pipfile|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|Gemfile|Gemfile\.lock|composer\.json)$'; then
+        hits="${hits}${file}"$'\t'"dependency"$'\n'
+    fi
+
+done <<< "$files"
+
+# ============================================================================
+# JSON emission
+# ============================================================================
+
+# Remove trailing newline from hits
+hits="${hits%$'\n'}"
+
+if [[ -z "$hits" ]]; then
+    printf '%s\n' "[]"
+    exit 0
+fi
+
+if has_jq; then
+    # Use jq to build the array deterministically (compact output, no spaces)
+    printf '%s\n' "$hits" | \
+        jq -c -R -n '[inputs | split("\t") | {file:.[0], class:.[1], severity:"critical"}]'
+else
+    # Fallback: build JSON array with json_escape
+    result="["
+    first=true
+    while IFS=$'\t' read -r f c; do
+        [[ -z "$f" ]] && continue
+        if [[ "$first" == true ]]; then
+            first=false
+        else
+            result="${result},"
+        fi
+        escaped_file="$(json_escape "$f")"
+        result="${result}{\"file\":${escaped_file},\"class\":\"${c}\",\"severity\":\"critical\"}"
+    done <<< "$hits"
+    result="${result}]"
+    printf '%s\n' "$result"
+fi
+
+exit 0

--- a/_shared/scripts/diff-risk-classify.sh
+++ b/_shared/scripts/diff-risk-classify.sh
@@ -28,11 +28,17 @@ fi
 
 require_git_repo
 
+# Anchor all git operations to the repo root so that pathspecs are always
+# root-relative regardless of cwd. This prevents silent false-negatives when
+# the script is invoked from a repo subdirectory (content-based classes would
+# silently return [] because the per-file diff pathspec missed the file).
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+
 # Validate the base ref resolves to a commit.
 # Use set +e / RC capture instead of "if \!" to avoid history-expansion issues
 # and set -e interactions across bash invocations.
 set +e
-git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null 2>&1
+git -C "$GIT_ROOT" rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null 2>&1
 _BASE_RC=$?
 set -e
 if [[ "$_BASE_RC" -ne 0 ]]; then
@@ -43,7 +49,7 @@ fi
 # Collect changed files
 # ============================================================================
 
-files="$(git -c core.quotepath=false diff --name-only "${BASE}...HEAD" 2>/dev/null)" || files=""
+files="$(git -C "$GIT_ROOT" -c core.quotepath=false diff --name-only "${BASE}...HEAD" 2>/dev/null)" || files=""
 
 if [[ -z "$files" ]]; then
     printf '%s\n' "[]"
@@ -62,8 +68,10 @@ hits=""
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
-    # Get added lines for this file (^+ lines, excluding +++ header)
-    added="$(git -c core.quotepath=false diff "${BASE}...HEAD" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+    # Get added lines for this file (^+ lines, excluding +++ header).
+    # Use git -C "$GIT_ROOT" so the pathspec is always root-relative and
+    # correctly resolves even when the script is run from a subdirectory.
+    added="$(git -C "$GIT_ROOT" -c core.quotepath=false diff "${BASE}...HEAD" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
 
     # 1. auth
     if echo "$file" | grep -Eiq 'auth' || \


### PR DESCRIPTION
## 概要

Closes #146

- `_shared/scripts/diff-risk-classify.sh` を新規作成。git diff の **realized diff** を解析し、7 danger クラスへの命中ファイルを JSON 配列で stdout 出力する
- bats テスト `_shared/scripts/diff-risk-classify.bats` を新規作成。7 クラス各々の陽性・陰性を計 17 テストケースで網羅

## 動機

dev-flow 再設計 (W1) の決定論的 floor 部品として必要。LLM 判定を介さず、実際に書かれた変更に対し ungameable な critical floor を立てる。W5 の merge tiering AUTO/REVIEW/HOLD で「critical が残れば HOLD」するための入力になる。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `_shared/scripts/diff-risk-classify.sh` | 新規。bash スクリプト。引数で base ref を受け、7 danger クラスを grep して JSON 出力 |
| `_shared/scripts/diff-risk-classify.bats` | 新規。bats テスト。陽性 7 + 陰性 7 + EMPTY + MULTI-CLASS + ERROR 2 = 17 ケース |

## 受け入れ条件の充足

- [x] `git diff --name-only <base>...HEAD` + hunk grep で realized diff のみを対象
- [x] 7 クラス命中時は `[{"file":"...","class":"auth","severity":"critical"}]` 形式で JSON 出力
- [x] 非命中時は `[]` を出力し exit 0
- [x] workflow JS から直接呼べる（引数で base ref を受ける、registry キャッシュ非依存）
- [x] severity は常に `critical` で固定（ungameable）
- [x] bats テスト: 7 クラス各々の陽性・陰性を pin

## テスト計画

```bash
bash tests/run-all-bats.sh --strict
```