### PR TITLE
✨ feat(dev-flow): W2 shape 三値化 — classifyTriviality を classifyShape (micro/standard/complex) へ拡張

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -27,6 +27,7 @@ function resolvePositiveIntArg(args, name) {
 
 // ---- Goal Ledger エンジン (canonical: _lib/goal-ledger.mjs。修正時は両者を同期。byte 一致は _lib/goal-ledger.sync.test.mjs が保証) ----
 const SEVERITY_RANK = { minor: 0, major: 1, critical: 2 };
+const SHAPE_RANK = { micro: 0, standard: 1, complex: 2 };
 
 function makeLedger() {
   return { items: [], round: 0 };
@@ -114,31 +115,64 @@ function nextRound(ledger) {
 }
 // ---- /Goal Ledger エンジン ----
 
-function classifyTriviality(req) {
+function mergeShape(floor, llmShape) {
+  if (!(llmShape in SHAPE_RANK)) {
+    return floor;
+  }
+  return SHAPE_RANK[llmShape] > SHAPE_RANK[floor] ? llmShape : floor;
+}
+
+function classifyShape(req) {
   const count = req.estimated_change_file_count;
   if (typeof count !== 'number' || count < 0) {
-    return { trivial: false, reason: 'estimated_change_file_count missing or invalid → safe non-trivial' };
+    const floor = 'complex';
+    const reason = `estimated_change_file_count missing or invalid → safe floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
-  if (count > 2) {
-    return { trivial: false, reason: `estimated ${count} files > 2 → non-trivial` };
-  }
+
   const ac = req.acceptance_criteria;
   if (!Array.isArray(ac)) {
-    return { trivial: false, reason: 'acceptance_criteria missing or not array → safe non-trivial' };
+    const floor = 'complex';
+    const reason = `acceptance_criteria missing or not array → safe floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
-  if (ac.length > 3) {
-    return { trivial: false, reason: `${ac.length} acceptance criteria > 3 → non-trivial` };
-  }
+
   const validTypes = ['feat', 'fix', 'docs', 'refactor'];
   if (!validTypes.includes(req.issue_type)) {
-    return { trivial: false, reason: `issue_type '${req.issue_type}' not in allowed set → non-trivial` };
+    const floor = 'complex';
+    const reason = `issue_type '${req.issue_type}' not in allowed set → floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
+
   const breakingPattern = /breaking|incompatible|migration|破壊的|非互換/i;
   const combined = `${req.scope ?? ''} ${req.summary ?? ''}`;
   if (breakingPattern.test(combined)) {
-    return { trivial: false, reason: 'breaking change detected in scope/summary → non-trivial' };
+    const floor = 'complex';
+    const reason = `breaking change detected in scope/summary → floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
-  return { trivial: true, reason: `estimated ${count} file(s), ${ac.length} AC, type=${req.issue_type}, no breaking — trivial path` };
+
+  let floor;
+  if (count <= 2 && ac.length <= 3) {
+    floor = 'micro';
+  } else if (count <= 5 && ac.length <= 6) {
+    floor = 'standard';
+  } else {
+    floor = 'complex';
+  }
+
+  const shape = mergeShape(floor, req.shape);
+  let reason;
+  if (shape !== floor) {
+    reason = `LLM raised ${floor}→${shape}`;
+  } else {
+    reason = `estimated ${count} file(s), ${ac.length} AC, type=${req.issue_type} → floor=${floor}`;
+  }
+  return { shape, reason };
 }
 
 // ---- args ----
@@ -218,6 +252,7 @@ const REQ = {
     acceptance_criteria: { type: 'array', items: { type: 'string' } },
     scope: { type: 'string' },
     estimated_change_file_count: { type: 'number' },
+    shape: { type: 'string', enum: ['micro', 'standard', 'complex'] },
   },
 }
 const TASK = {
@@ -366,13 +401,15 @@ const req = need(await agent(
   `cd ${WT} で作業。\`Skill: dev-issue-analyze ${ISSUE} --depth ${DEPTH}\` を実行し、`
   + `issue #${ISSUE} の要件・受入条件・issue type を抽出して返せ。`
   + `さらに、この issue を実装する際に新規作成/変更すると見込まれるファイル数を整数で見積もり estimated_change_file_count として返せ。`
-  + `issue 本文に列挙されたパス数ではなく、実装に実際に必要なファイル数の見積りであること。判断に迷えば大きめ(安全側)に見積もれ。`,
+  + `issue 本文に列挙されたパス数ではなく、実装に実際に必要なファイル数の見積りであること。判断に迷えば大きめ(安全側)に見積もれ。`
+  + `さらに、この issue の実装規模を micro / standard / complex のいずれかで評価し shape として返せ。micro=単一ファイル軽微変更・AC 少数、standard=複数ファイルの通常実装、complex=多数ファイル・破壊的変更・設計判断を要する。判断に迷えば大きめ（安全側=complex 寄り）に評価せよ。`,
   { agentType: 'dev-runner', schema: REQ, label: `analyze#${ISSUE}`, phase: 'Analyze' },
 ), 'Analyze')
 
-const triage = classifyTriviality(req)
-const TRIVIAL = triage.trivial
-log(`triviality: ${TRIVIAL ? 'TRIVIAL(最短経路)' : 'NON-TRIVIAL(フルパイプライン)'} — ${triage.reason}`)
+const triage = classifyShape(req)
+const SHAPE = triage.shape
+const TRIVIAL = SHAPE === 'micro'
+log(`shape: ${SHAPE} — ${triage.reason}`)
 
 // ============================================================
 // Phase Plan: dev-planner ⇄ plan-reviewer ループ。
@@ -688,6 +725,7 @@ return {
   eval_verdict: evalResult?.verdict ?? null,
   test_green: val?.green ?? null,
   iterate_status: iterate?.status ?? null,
+  shape: SHAPE,
   triviality: TRIVIAL,
   triviality_reason: triage.reason,
   ledger_blocking: blockingItems(ledger).length,

--- a/_lib/triviality.mjs
+++ b/_lib/triviality.mjs
@@ -1,34 +1,69 @@
-// classifyTriviality: REQ オブジェクトから trivial 判定を行う純粋関数。
-// dev-flow の triviality check に使用する。
+// classifyShape: REQ オブジェクトから shape 判定を行う純粋関数。
+// dev-flow の shape check に使用する。
 //
 // INLINE COPY POLICY: .claude/workflows/dev-flow.js は dynamic workflow ローダーが
 // 独自の VM コンテキストで評価するため、ESM の import 文は使用できない。
-// そのため dev-flow.js に classifyTriviality の関数本体を inline コピーしており、
+// そのため dev-flow.js に classifyShape の関数本体を inline コピーしており、
 // _lib/triviality.sync.test.mjs がその byte 一致を CI で保証する。
 // この関数を修正する際は、必ず dev-flow.js の inline コピーも同期すること。
-export function classifyTriviality(req) {
+export const SHAPE_RANK = { micro: 0, standard: 1, complex: 2 };
+
+function mergeShape(floor, llmShape) {
+  if (!(llmShape in SHAPE_RANK)) {
+    return floor;
+  }
+  return SHAPE_RANK[llmShape] > SHAPE_RANK[floor] ? llmShape : floor;
+}
+
+export function classifyShape(req) {
   const count = req.estimated_change_file_count;
   if (typeof count !== 'number' || count < 0) {
-    return { trivial: false, reason: 'estimated_change_file_count missing or invalid → safe non-trivial' };
+    const floor = 'complex';
+    const reason = `estimated_change_file_count missing or invalid → safe floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
-  if (count > 2) {
-    return { trivial: false, reason: `estimated ${count} files > 2 → non-trivial` };
-  }
+
   const ac = req.acceptance_criteria;
   if (!Array.isArray(ac)) {
-    return { trivial: false, reason: 'acceptance_criteria missing or not array → safe non-trivial' };
+    const floor = 'complex';
+    const reason = `acceptance_criteria missing or not array → safe floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
-  if (ac.length > 3) {
-    return { trivial: false, reason: `${ac.length} acceptance criteria > 3 → non-trivial` };
-  }
+
   const validTypes = ['feat', 'fix', 'docs', 'refactor'];
   if (!validTypes.includes(req.issue_type)) {
-    return { trivial: false, reason: `issue_type '${req.issue_type}' not in allowed set → non-trivial` };
+    const floor = 'complex';
+    const reason = `issue_type '${req.issue_type}' not in allowed set → floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
+
   const breakingPattern = /breaking|incompatible|migration|破壊的|非互換/i;
   const combined = `${req.scope ?? ''} ${req.summary ?? ''}`;
   if (breakingPattern.test(combined)) {
-    return { trivial: false, reason: 'breaking change detected in scope/summary → non-trivial' };
+    const floor = 'complex';
+    const reason = `breaking change detected in scope/summary → floor=complex`;
+    const shape = mergeShape(floor, req.shape);
+    return { shape, reason: shape !== floor ? `LLM raised ${floor}→${shape}` : reason };
   }
-  return { trivial: true, reason: `estimated ${count} file(s), ${ac.length} AC, type=${req.issue_type}, no breaking — trivial path` };
+
+  let floor;
+  if (count <= 2 && ac.length <= 3) {
+    floor = 'micro';
+  } else if (count <= 5 && ac.length <= 6) {
+    floor = 'standard';
+  } else {
+    floor = 'complex';
+  }
+
+  const shape = mergeShape(floor, req.shape);
+  let reason;
+  if (shape !== floor) {
+    reason = `LLM raised ${floor}→${shape}`;
+  } else {
+    reason = `estimated ${count} file(s), ${ac.length} AC, type=${req.issue_type} → floor=${floor}`;
+  }
+  return { shape, reason };
 }

--- a/_lib/triviality.sync.test.mjs
+++ b/_lib/triviality.sync.test.mjs
@@ -20,6 +20,13 @@ function extractFn(src) {
   return m[0].trim();
 }
 
+// canonical ソースおよび inline コピーから `function mergeShape ... }` ブロックを抽出
+function extractMergeShape(src) {
+  const m = src.match(/function mergeShape\([\s\S]*?\n}/);
+  if (!m) throw new Error('mergeShape が見つからない');
+  return m[0].trim();
+}
+
 // canonical ソースおよび inline コピーから `const SHAPE_RANK = {...};` を抽出
 function extractConst(src) {
   const m = src.match(/const SHAPE_RANK = \{[^}]+\};/);
@@ -27,13 +34,20 @@ function extractConst(src) {
   return m[0].trim();
 }
 
-const canonical = extractFn(readFileSync(join(repoRoot, '_lib/triviality.mjs'), 'utf8'));
-const canonicalRank = extractConst(readFileSync(join(repoRoot, '_lib/triviality.mjs'), 'utf8'));
+const canonicalSrc = readFileSync(join(repoRoot, '_lib/triviality.mjs'), 'utf8');
+const canonical = extractFn(canonicalSrc);
+const canonicalMerge = extractMergeShape(canonicalSrc);
+const canonicalRank = extractConst(canonicalSrc);
 
 for (const wf of ['.claude/workflows/dev-flow.js']) {
   test(`${wf} の inline コピーが canonical と byte 一致`, () => {
     const inlined = extractFn(readFileSync(join(repoRoot, wf), 'utf8'));
     assert.equal(inlined, canonical, `${wf} の inline コピーが _lib/triviality.mjs と乖離`);
+  });
+
+  test(`${wf} の mergeShape 定義が canonical と byte 一致`, () => {
+    const inlinedMerge = extractMergeShape(readFileSync(join(repoRoot, wf), 'utf8'));
+    assert.equal(inlinedMerge, canonicalMerge, `${wf} の mergeShape が _lib/triviality.mjs と乖離`);
   });
 
   test(`${wf} の SHAPE_RANK 定義が canonical と byte 一致`, () => {

--- a/_lib/triviality.sync.test.mjs
+++ b/_lib/triviality.sync.test.mjs
@@ -2,7 +2,7 @@
 //
 // 背景: .claude/workflows/dev-flow.js は dynamic workflow ローダーが独自の
 // VM コンテキストで評価する。ESM の import 文はそのコンテキストで使用できないため、
-// workflow VM が ESM import 不可のため classifyTriviality を inline コピーしており、
+// workflow VM が ESM import 不可のため classifyShape を inline コピーしており、
 // 本テストが手動同期漏れを CI で検出する安全網。
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -13,18 +13,31 @@ import { dirname, join } from 'node:path';
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..');
 
-// canonical ソースおよび inline コピーから `function classifyTriviality ... }` ブロックを抽出
+// canonical ソースおよび inline コピーから `function classifyShape ... }` ブロックを抽出
 function extractFn(src) {
-  const m = src.match(/function classifyTriviality\([\s\S]*?\n}/);
-  if (!m) throw new Error('classifyTriviality が見つからない');
+  const m = src.match(/function classifyShape\([\s\S]*?\n}/);
+  if (!m) throw new Error('classifyShape が見つからない');
+  return m[0].trim();
+}
+
+// canonical ソースおよび inline コピーから `const SHAPE_RANK = {...};` を抽出
+function extractConst(src) {
+  const m = src.match(/const SHAPE_RANK = \{[^}]+\};/);
+  if (!m) throw new Error('SHAPE_RANK が見つからない');
   return m[0].trim();
 }
 
 const canonical = extractFn(readFileSync(join(repoRoot, '_lib/triviality.mjs'), 'utf8'));
+const canonicalRank = extractConst(readFileSync(join(repoRoot, '_lib/triviality.mjs'), 'utf8'));
 
 for (const wf of ['.claude/workflows/dev-flow.js']) {
   test(`${wf} の inline コピーが canonical と byte 一致`, () => {
     const inlined = extractFn(readFileSync(join(repoRoot, wf), 'utf8'));
     assert.equal(inlined, canonical, `${wf} の inline コピーが _lib/triviality.mjs と乖離`);
+  });
+
+  test(`${wf} の SHAPE_RANK 定義が canonical と byte 一致`, () => {
+    const inlinedRank = extractConst(readFileSync(join(repoRoot, wf), 'utf8'));
+    assert.equal(inlinedRank, canonicalRank, `${wf} の SHAPE_RANK 定義が _lib/triviality.mjs と乖離`);
   });
 }

--- a/_lib/triviality.test.mjs
+++ b/_lib/triviality.test.mjs
@@ -1,86 +1,100 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyTriviality } from './triviality.mjs';
+import { classifyShape, SHAPE_RANK } from './triviality.mjs';
 
-// (a) trivial 適格: 全条件成立 → trivial:true
-test('trivial 適格: 全条件成立で trivial:true', () => {
-  const result = classifyTriviality({
+// (a) micro 適格: count<=2, ac<=3, type=fix, no breaking → shape='micro'
+test('micro 適格: count=1, ac=2, type=fix, no breaking → shape=micro', () => {
+  const result = classifyShape({
     estimated_change_file_count: 1,
     acceptance_criteria: ['x', 'y'],
     issue_type: 'fix',
     scope: 'src/foo.ts',
     summary: 'fix a bug in foo',
   });
-  assert.equal(result.trivial, true);
+  assert.equal(result.shape, 'micro');
   assert.equal(typeof result.reason, 'string');
   assert.ok(result.reason.length > 0, 'reason should not be empty');
 });
 
-// (b) estimated_change_file_count:3 → false
-test('estimated_change_file_count:3 → trivial:false', () => {
-  const result = classifyTriviality({
+// (b) count=3 の中規模 → shape='standard'
+test('count=3, ac=2, type=feat → shape=standard', () => {
+  const result = classifyShape({
     estimated_change_file_count: 3,
-    acceptance_criteria: ['x', 'y'],
-    issue_type: 'fix',
-    scope: 'src/foo.ts',
-    summary: 'fix a bug',
+    acceptance_criteria: ['a', 'b'],
+    issue_type: 'feat',
+    scope: 'src',
+    summary: 'add feature',
   });
-  assert.equal(result.trivial, false);
+  assert.equal(result.shape, 'standard');
   assert.equal(typeof result.reason, 'string');
   assert.ok(result.reason.length > 0);
 });
 
-// (c) acceptance_criteria 4 件 → false
-test('acceptance_criteria 4 件 → trivial:false', () => {
-  const result = classifyTriviality({
-    estimated_change_file_count: 1,
+// (c) ac=4 の中規模 → 'standard'
+test('count=2, ac=4, type=fix → shape=standard', () => {
+  const result = classifyShape({
+    estimated_change_file_count: 2,
     acceptance_criteria: ['a', 'b', 'c', 'd'],
     issue_type: 'fix',
-    scope: 'src/foo.ts',
-    summary: 'fix a bug',
+    scope: 'src',
+    summary: 'fix something',
   });
-  assert.equal(result.trivial, false);
+  assert.equal(result.shape, 'standard');
   assert.equal(typeof result.reason, 'string');
   assert.ok(result.reason.length > 0);
 });
 
-// (d) issue_type:'chore'(enum 外) → false
-test("issue_type:'chore' (enum 外) → trivial:false", () => {
-  const result = classifyTriviality({
+// (d) count 大 (>5) → 'complex'
+test('count=6, ac=2, type=feat → shape=complex', () => {
+  const result = classifyShape({
+    estimated_change_file_count: 6,
+    acceptance_criteria: ['a', 'b'],
+    issue_type: 'feat',
+    scope: 'src',
+    summary: 'big feature',
+  });
+  assert.equal(result.shape, 'complex');
+  assert.equal(typeof result.reason, 'string');
+  assert.ok(result.reason.length > 0);
+});
+
+// (e) issue_type='chore' (enum 外) → 'complex'
+test("issue_type='chore' (enum 外) → shape=complex", () => {
+  const result = classifyShape({
     estimated_change_file_count: 1,
     acceptance_criteria: ['x', 'y'],
     issue_type: 'chore',
     scope: 'src/foo.ts',
     summary: 'chore something',
   });
-  assert.equal(result.trivial, false);
+  assert.equal(result.shape, 'complex');
   assert.equal(typeof result.reason, 'string');
   assert.ok(result.reason.length > 0);
 });
 
-// (e) scope に 'breaking change' を含む → false
-test("scope に 'breaking change' を含む → trivial:false", () => {
-  const result = classifyTriviality({
+// (f) scope に 'breaking change' → 'complex'
+test("scope に 'breaking change' を含む → shape=complex", () => {
+  const result = classifyShape({
     estimated_change_file_count: 1,
     acceptance_criteria: ['x', 'y'],
     issue_type: 'fix',
     scope: 'breaking change in API',
     summary: 'fix a bug',
   });
-  assert.equal(result.trivial, false);
+  assert.equal(result.shape, 'complex');
   assert.equal(typeof result.reason, 'string');
   assert.ok(result.reason.length > 0);
 });
 
-// (f) estimated_change_file_count 欠落(undefined) → false かつ reason に 'missing'/'safe' 系文言
-test('estimated_change_file_count 欠落(undefined) → trivial:false, reason に missing/safe', () => {
-  const result = classifyTriviality({
+// (g) estimated_change_file_count 欠落(undefined) → 'complex' かつ reason に 'missing'/'safe'
+test('estimated_change_file_count 欠落 → shape=complex, reason に missing/safe', () => {
+  const result = classifyShape({
     acceptance_criteria: ['x', 'y'],
     issue_type: 'fix',
     scope: 'src/foo.ts',
     summary: 'fix a bug',
   });
-  assert.equal(result.trivial, false);
+  assert.equal(result.shape, 'complex');
   assert.equal(typeof result.reason, 'string');
   assert.ok(
     /missing|safe/i.test(result.reason),
@@ -88,16 +102,142 @@ test('estimated_change_file_count 欠落(undefined) → trivial:false, reason �
   );
 });
 
-// (g) estimated_change_file_count が文字列 '1'(型不正) → false
-test("estimated_change_file_count が文字列 '1' (型不正) → trivial:false", () => {
-  const result = classifyTriviality({
+// (h) estimated_change_file_count が文字列 '1' (型不正) → 'complex' かつ reason に 'missing'/'safe'
+test("estimated_change_file_count が文字列 '1' (型不正) → shape=complex, reason に missing/safe", () => {
+  const result = classifyShape({
     estimated_change_file_count: '1',
     acceptance_criteria: ['x', 'y'],
     issue_type: 'fix',
     scope: 'src/foo.ts',
     summary: 'fix a bug',
   });
-  assert.equal(result.trivial, false);
+  assert.equal(result.shape, 'complex');
+  assert.equal(typeof result.reason, 'string');
+  assert.ok(
+    /missing|safe/i.test(result.reason),
+    `reason should contain 'missing' or 'safe', got: ${result.reason}`
+  );
+});
+
+// (i) raise-only: floor='micro' だが req.shape='complex' → 'complex' (LLM raise 採用)
+test("raise-only: floor=micro, req.shape='complex' → shape=complex (LLM raise)", () => {
+  const result = classifyShape({
+    estimated_change_file_count: 1,
+    acceptance_criteria: ['x'],
+    issue_type: 'fix',
+    scope: 'src',
+    summary: 'fix a small bug',
+    shape: 'complex',
+  });
+  assert.equal(result.shape, 'complex');
   assert.equal(typeof result.reason, 'string');
   assert.ok(result.reason.length > 0);
+  assert.ok(
+    /raise|LLM/i.test(result.reason),
+    `reason should indicate LLM raise, got: ${result.reason}`
+  );
+});
+
+// (j) lower 禁止: floor='complex' だが req.shape='micro' → 'complex' のまま (LLM lower 無視)
+test("lower 禁止: floor=complex, req.shape='micro' → shape=complex (LLM lower 無視)", () => {
+  const result = classifyShape({
+    estimated_change_file_count: 6,
+    acceptance_criteria: ['a', 'b'],
+    issue_type: 'feat',
+    scope: 'src',
+    summary: 'big feature',
+    shape: 'micro',
+  });
+  assert.equal(result.shape, 'complex');
+  assert.equal(typeof result.reason, 'string');
+  assert.ok(result.reason.length > 0);
+});
+
+// (k) req.shape が不正キー 'huge' → floor をそのまま採用
+test("req.shape が不正キー 'huge' → floor をそのまま採用 (micro)", () => {
+  const result = classifyShape({
+    estimated_change_file_count: 1,
+    acceptance_criteria: ['x'],
+    issue_type: 'fix',
+    scope: 'src',
+    summary: 'tiny fix',
+    shape: 'huge',
+  });
+  assert.equal(result.shape, 'micro');
+  assert.equal(typeof result.reason, 'string');
+  assert.ok(result.reason.length > 0);
+});
+
+// SHAPE_RANK の値検証
+test('SHAPE_RANK は micro=0, standard=1, complex=2 の定数', () => {
+  assert.equal(SHAPE_RANK.micro, 0);
+  assert.equal(SHAPE_RANK.standard, 1);
+  assert.equal(SHAPE_RANK.complex, 2);
+});
+
+// ac=7 の大規模 → 'complex'
+test('count=3, ac=7, type=feat → shape=complex (ac>6)', () => {
+  const result = classifyShape({
+    estimated_change_file_count: 3,
+    acceptance_criteria: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+    issue_type: 'feat',
+    scope: 'src',
+    summary: 'complex feature',
+  });
+  assert.equal(result.shape, 'complex');
+  assert.equal(typeof result.reason, 'string');
+  assert.ok(result.reason.length > 0);
+});
+
+// count=2, ac=3 で boundary の micro 確認
+test('count=2, ac=3 → shape=micro (boundary)', () => {
+  const result = classifyShape({
+    estimated_change_file_count: 2,
+    acceptance_criteria: ['a', 'b', 'c'],
+    issue_type: 'refactor',
+    scope: 'src',
+    summary: 'clean up',
+  });
+  assert.equal(result.shape, 'micro');
+});
+
+// count=5, ac=6 → standard (boundary upper)
+test('count=5, ac=6, type=feat → shape=standard (boundary upper)', () => {
+  const result = classifyShape({
+    estimated_change_file_count: 5,
+    acceptance_criteria: ['a', 'b', 'c', 'd', 'e', 'f'],
+    issue_type: 'feat',
+    scope: 'src',
+    summary: 'medium feature',
+  });
+  assert.equal(result.shape, 'standard');
+});
+
+// raise-only: floor='standard', req.shape='standard' → 'standard' (同じ rank は OK)
+test("raise-only: floor=standard, req.shape='standard' → shape=standard (同 rank)", () => {
+  const result = classifyShape({
+    estimated_change_file_count: 3,
+    acceptance_criteria: ['a', 'b', 'c', 'd'],
+    issue_type: 'fix',
+    scope: 'src',
+    summary: 'medium fix',
+    shape: 'standard',
+  });
+  assert.equal(result.shape, 'standard');
+});
+
+// acceptance_criteria が配列でない → 'complex' かつ reason に 'missing'/'safe'
+test('acceptance_criteria が null → shape=complex, reason に missing/safe', () => {
+  const result = classifyShape({
+    estimated_change_file_count: 1,
+    acceptance_criteria: null,
+    issue_type: 'fix',
+    scope: 'src',
+    summary: 'fix',
+  });
+  assert.equal(result.shape, 'complex');
+  assert.ok(
+    /missing|safe/i.test(result.reason),
+    `reason should contain 'missing' or 'safe', got: ${result.reason}`
+  );
 });

--- a/_lib/workflow-load-smoke.test.mjs
+++ b/_lib/workflow-load-smoke.test.mjs
@@ -241,3 +241,85 @@ const x = await Promise.resolve('test');
     + ` caughtError=${JSON.stringify(caughtError?.name)} (${caughtError?.message})`,
   );
 });
+
+// ---- 4. REQ schema shape フィールド検証 ---------------------------------------------------
+//
+// dev-flow.js の REQ schema に shape enum フィールドが追加されていることを確認する。
+// shape は LLM が emit する optional フィールド（required に含めない）。
+
+test('[schema] dev-flow.js: REQ schema は valid object である', () => {
+  const devFlowPath = join(workflowDir, 'dev-flow.js');
+  const rawSrc = readFileSync(devFlowPath, 'utf8');
+
+  assert.ok(rawSrc.includes('const REQ ='), 'REQ schema が dev-flow.js に定義されていること');
+  assert.ok(
+    rawSrc.includes("'object'") || rawSrc.includes('"object"'),
+    'REQ schema が type: object を持つこと',
+  );
+});
+
+test('[schema] dev-flow.js: REQ schema に shape enum プロパティが存在する', () => {
+  const devFlowPath = join(workflowDir, 'dev-flow.js');
+  const rawSrc = readFileSync(devFlowPath, 'utf8');
+
+  assert.ok(
+    rawSrc.includes("shape:") && rawSrc.includes("'micro'") && rawSrc.includes("'standard'") && rawSrc.includes("'complex'"),
+    "REQ schema に shape: { type: string, enum: ['micro', 'standard', 'complex'] } が存在すること",
+  );
+});
+
+test('[schema] dev-flow.js: shape は required 配列に含まれない（optional フィールド）', () => {
+  const devFlowPath = join(workflowDir, 'dev-flow.js');
+  const rawSrc = readFileSync(devFlowPath, 'utf8');
+
+  const reqMatch = rawSrc.match(/const REQ\s*=\s*\{[\s\S]*?required:\s*\[([^\]]*)\]/);
+  assert.ok(reqMatch, 'REQ schema の required 配列が取得できること');
+  const requiredContent = reqMatch[1];
+  assert.ok(
+    !requiredContent.includes('shape'),
+    'REQ schema の required に shape が含まれていないこと',
+  );
+});
+
+// ---- 5. triage consume: classifyShape を使い TRIVIAL = (SHAPE==='micro') にマップ --------
+//
+// triage consume が classifyTriviality ではなく classifyShape を使っていることを確認する。
+// TRIVIAL = (SHAPE === 'micro') の式で micro が trivial 経路にマップされていることを確認。
+
+test('[triage] dev-flow.js: classifyShape を triage consume に使用している', () => {
+  const devFlowPath = join(workflowDir, 'dev-flow.js');
+  const rawSrc = readFileSync(devFlowPath, 'utf8');
+
+  assert.ok(
+    rawSrc.includes('classifyShape(req)'),
+    'triage consume で classifyShape(req) を呼び出していること',
+  );
+  assert.ok(
+    !rawSrc.includes('classifyTriviality'),
+    'classifyTriviality は削除され残存しないこと',
+  );
+});
+
+test('[triage] dev-flow.js: SHAPE 変数と TRIVIAL = (SHAPE === micro) が定義されている', () => {
+  const devFlowPath = join(workflowDir, 'dev-flow.js');
+  const rawSrc = readFileSync(devFlowPath, 'utf8');
+
+  assert.ok(
+    rawSrc.includes('const SHAPE =') || rawSrc.includes('const SHAPE='),
+    'SHAPE 変数が定義されていること',
+  );
+  assert.ok(
+    rawSrc.includes("SHAPE === 'micro'"),
+    "TRIVIAL = (SHAPE === 'micro') でマッピングされていること",
+  );
+});
+
+test('[triage] dev-flow.js: 最終 return に shape: SHAPE が含まれる', () => {
+  const devFlowPath = join(workflowDir, 'dev-flow.js');
+  const rawSrc = readFileSync(devFlowPath, 'utf8');
+
+  assert.ok(
+    rawSrc.includes('shape: SHAPE'),
+    '最終 return オブジェクトに shape: SHAPE が含まれること',
+  );
+});


### PR DESCRIPTION
## 概要

Closes #148

- `classifyTriviality` (boolean) を `classifyShape` (micro | standard | complex) に置き換え
- 決定論 floor (ファイル数 / AC 数 / issue_type / breaking 検出) + LLM raise-only マージで shape を算出
- `SHAPE === 'micro'` を既存の trivial 経路にマップし、回帰なし
- `REQ` schema に `shape: enum[micro, standard, complex]` を optional フィールドとして追加
- `_lib/triviality.mjs` と `dev-flow.js` の inline コピーを同期し、`triviality.sync.test.mjs` が byte 一致を保証

## 動機

現状 `count > 2` で即 non-trivial となり、軽微な変更にもフルパイプラインが稼働していた。
`shape` 三値化により scale 適応の前段を整備し、W5 の merge tiering でも同 classifier を再利用できるようにする。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/dev-flow.js` | `classifyTriviality` → `classifyShape`、`SHAPE_RANK` 定数追加、`REQ` schema に `shape` enum 追加、最終 return に `shape: SHAPE` 追加 |
| `_lib/triviality.mjs` | `classifyShape` + `SHAPE_RANK` + `mergeShape` に刷新 |
| `_lib/triviality.sync.test.mjs` | `classifyShape` / `SHAPE_RANK` の byte 一致検証に更新 |
| `_lib/triviality.test.mjs` | ケース (a)-(k) + boundary テスト追加（計 17 件） |
| `_lib/workflow-load-smoke.test.mjs` | schema / triage consume 検証テスト 6 件追加 |

## テスト計画

- [x] `node --test _lib/triviality.test.mjs` — 全 17 テストパス
- [x] `node --test _lib/triviality.sync.test.mjs` — inline コピー byte 一致確認
- [x] `node --test _lib/workflow-load-smoke.test.mjs` — schema / triage consume 検証 6 件パス
- [x] 全 34 テストパス、0 失敗