### PR TITLE
🐛 fix(_shared): diff-risk-classify が docs の security 語彙で誤 HIT する false-positive を修正

### DIFF
--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -305,3 +305,35 @@ teardown() {
     rm -rf "$NON_GIT"
     [ "$status" -ne 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# docs EXCLUSION: docs ファイルは security 語彙を含んでも HIT しない (issue #155)
+# ---------------------------------------------------------------------------
+@test "docs EXCLUSION: .md に auth/exec 語彙 -> 除外され [] (false-positive 防止)" {
+    printf 'requireAuth と child_process と eval( を解説する docs\n' > "$REPO/AGENTS.md"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "docs EXCLUSION: docs/ 配下の .txt に auth 語彙 -> 除外され []" {
+    mkdir -p "$REPO/docs"
+    printf 'authenticate jwt bearer session を説明\n' > "$REPO/docs/guide.txt"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "docs EXCLUSION regression: 同じ auth 語彙でも .ts は HIT のまま (非 docs は不変)" {
+    mkdir -p "$REPO/src"
+    printf 'function requireAuth(u) { return u.jwt; }\n' > "$REPO/src/x.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"auth"'* ]]
+}

--- a/_shared/scripts/diff-risk-classify.sh
+++ b/_shared/scripts/diff-risk-classify.sh
@@ -68,6 +68,14 @@ hits=""
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue
 
+    # docs ファイル(.md/.mdx/.txt, docs/ 配下)は inert(実行されない)= realized danger
+    # ではないため danger-grep 対象から除外する。docs 本文に含まれる "auth"/"exec" 等の
+    # security 語彙による content-based class の false-positive を防ぐ(issue #155)。
+    # filename-based class(config/dependency/data-migration)も docs には該当しない。
+    if echo "$file" | grep -Eiq '\.(md|mdx|txt)$|(^|/)docs/'; then
+        continue
+    fi
+
     # Get added lines for this file (^+ lines, excluding +++ header).
     # Use git -C "$GIT_ROOT" so the pathspec is always root-relative and
     # correctly resolves even when the script is run from a subdirectory.


### PR DESCRIPTION
Closes #155

## 概要
W1 `diff-risk-classify.sh` が docs ファイル(.md/.mdx/.txt, docs/ 配下)本文の security 語彙(auth/exec/eval 等)を danger class として誤 HIT する false-positive を修正。docs は inert(実行されない)= realized danger ではないため除外する。W7(AGENTS.md distrust docs)で実観測。

## 変更
- `diff-risk-classify.sh`: 変更ファイルループで docs ファイルを skip(`\.(md|mdx|txt)$|(^|/)docs/`)。filename-based class(config/dependency/data-migration)も docs に該当しないため非 docs の挙動は完全不変。
- `diff-risk-classify.bats`: docs 除外の陽性3テスト追加(.md/.txt の auth/exec 語彙→[]、同語彙の .ts→HIT のまま=regression guard)。

## 検証
- grep パターンを代表パスで確認: AGENTS.md/docs/guide.txt/x.mdx/README.md→SKIP、src/auth.ts/package.json/migrations/→scan、docs-helper.ts→scan(誤除外なし)
- 既存17ケース + 新3ケースは CI(bats --strict)で green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)