### PR TITLE
feat(dev-flow): W2-followup standard 経路（評価1パス）の wiring — shape 別ループ段階化

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -597,6 +597,8 @@ const triage = classifyShape(req)
 const SHAPE = triage.shape
 const TRIVIAL = SHAPE === 'micro'
 log(`shape: ${SHAPE} — ${triage.reason}`)
+const PLAN_SOLO = !TRIVIAL && SHAPE === 'standard'   // standard: plan 1発・reviewer 0回
+const EVAL_PASSES = SHAPE === 'standard' ? 1 : EVAL_MAX  // standard: evaluate 1パス・差し戻しなし
 
 // ============================================================
 // Phase Plan: dev-planner ⇄ plan-reviewer ループ。
@@ -618,6 +620,15 @@ if (TRIVIAL) {
     { agentType: 'dev-planner', schema: PLAN, label: 'plan#trivial', phase: 'Plan' },
   ), 'Plan(planner#trivial)')
   log('triviality gate: plan-review ループを skip(reviewer 0 回起動)')
+} else if (PLAN_SOLO) {
+  plan = need(await agent(
+    `cd ${WT} で作業。issue 要件に基づき実装計画を立てよ。\n`
+    + `requirements: ${JSON.stringify(req)}\n`
+    + `testing: ${TESTING}\n`
+    + `serial（依存あり）と parallel（独立かつ file_changes が disjoint）に分解し、各 task は self-contained に書け。`,
+    { agentType: 'dev-planner', schema: PLAN, label: 'plan#standard', phase: 'Plan' },
+  ), 'Plan(planner#standard)')
+  log('standard 経路: plan 1発（plan-reviewer 0 回起動）')
 } else {
 for (let i = 1; i <= PLAN_MAX; i++) {
   const prior = Object.values(planSeen).map((s) => s.finding)   // 前 iteration までの累積 findings
@@ -792,7 +803,7 @@ for (const [i, c] of concerns.entries()) {
 }
 log(`ledger 初期化: blocking ${blockingItems(ledger).length} / advisory ${advisoryItems(ledger).length} 件`)
 const evalSeen = {}        // topic → { feedback, count }（feedback 累積 & stuck 検出。issue #125）
-for (let i = 1; i <= EVAL_MAX; i++) {
+for (let i = 1; i <= EVAL_PASSES; i++) {
   const priorFeedback = Object.values(evalSeen).map((s) => s.feedback)   // 前 iteration までの累積 feedback
   const ev = need(await agent(
     `cd ${WT} で作業。実装品質を独立評価せよ（base は origin/${BASE}。`
@@ -899,6 +910,10 @@ for (let i = 1; i <= EVAL_MAX; i++) {
   if (i === EVAL_MAX) {
     log(`⚠️ evaluate は ${EVAL_MAX} iteration で pass せず（verdict=${ev.verdict}）— `
       + `throw せず現状で PR へ進む（human review に委ねる）`)
+    break
+  }
+  if (SHAPE === 'standard') {
+    log('standard 経路: 1 パス評価のみ（差し戻しなし仕様）。未解消 critical があれば merge tier HOLD + human review で担保')
     break
   }
   if (ev.feedback_level === 'design') {

--- a/_lib/shape-loop-routing.test.mjs
+++ b/_lib/shape-loop-routing.test.mjs
@@ -1,0 +1,272 @@
+// AC#7 は plan-reviewer 呼び出し0回・evaluator 呼び出し1回の実カウントで検証する（string-pattern ではなく挙動を pin）
+//
+// このテストファイルは TDD red として作成された。
+// F1 時点では dev-flow.js に PLAN_SOLO / plan#standard / EVAL_PASSES が未実装のため、
+// (A) のカウント assert（plan-reviewer=0 / evaluator=1）および (B) の構造 assert が fail する（= 赤）。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const devFlowPath = join(repoRoot, '.claude/workflows/dev-flow.js');
+
+// ---- VM sandbox helpers（workflow-load-smoke.test.mjs の makeWorkflowSandbox / runWorkflowInSandbox と同型）----
+
+/**
+ * shape-loop-routing 専用の VM sandbox を組む。
+ * agent() を呼び出しカウンタ stub にし、calls 配列を expose する。
+ * analyzeReq を注入して classify 結果を制御する（shape 別ルーティング検証用）。
+ *
+ * @param {object} analyzeReq - analyze フェーズの agent が返す req オブジェクト（SHAPE を決定する）
+ * @returns {{ ctx: vm.Context, calls: Array<{label: string, agentType: string}> }}
+ */
+function makeCountingSandbox(analyzeReq) {
+  const calls = [];
+
+  // agent() stub: opts.label / opts.agentType を見て phase 別に最小スキーマを返す
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+    calls.push({ label, agentType });
+
+    // Setup(worktree)
+    if (label === 'worktree') {
+      return { worktree: '/tmp/wt', branch: 'feature/issue-1' };
+    }
+    // Analyze: label が 'analyze' で始まる
+    if (label.startsWith('analyze')) {
+      return analyzeReq;
+    }
+    // Plan: dev-planner (plan#trivial / plan#standard / plan#N / replan 系)
+    if (agentType === 'dev-planner') {
+      return { summary: 'p', serial: [], parallel: [] };
+    }
+    // Plan reviewer
+    if (agentType === 'plan-reviewer') {
+      return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
+    }
+    // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
+    if (label.startsWith('danger-grep')) {
+      return { hits: [] };
+    }
+    // Validate: test runner（label が 'test' で始まる）
+    if (label.startsWith('test')) {
+      return { tests: 'no_tests', green: true, summary: '' };
+    }
+    // Evaluate: evaluator
+    if (agentType === 'evaluator') {
+      return {
+        verdict: 'pass',
+        total: 100,
+        threshold: 80,
+        feedback: [],
+        feedback_level: 'implementation',
+        ac_results: [],
+        security_clearance: [],
+      };
+    }
+    // PR: label が 'pr' で始まる
+    if (label.startsWith('pr')) {
+      return { pr_url: 'http://x', pr_number: 1, committed: true };
+    }
+    // Merge tier: changed-files
+    if (label === 'changed-files') {
+      return { files: ['src/foo.ts'] };
+    }
+    // implementer その他
+    if (agentType === 'implementer') {
+      return { status: 'DONE', task_id: 't', files: [], summary: '', concerns: [] };
+    }
+    // デフォルト
+    return null;
+  };
+
+  // parallel() stub: runImplement が parallel(par) を呼ぶため（par が空なら []）
+  const parallelStub = async (fns) => Promise.all((fns || []).map((f) => f()));
+
+  const sandbox = {
+    // workflow 制御関数
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: parallelStub,
+    workflow: async () => ({ status: 'LGTM' }),
+    // 引数（ISSUE 解決用）
+    args: '1',
+    // JS 組み込み（makeWorkflowSandbox と同一セット）
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+
+  const ctx = vm.createContext(sandbox);
+  return { ctx, calls };
+}
+
+/**
+ * dev-flow.js ソースを strip して async IIFE でラップし vm sandbox で実行する。
+ * workflow-load-smoke.test.mjs の runWorkflowInSandbox と同型。
+ *
+ * @param {string} src - dev-flow.js の raw ソース
+ * @param {vm.Context} ctx - vm コンテキスト
+ * @returns {Promise<Error|null>} エラーがあれば Error、無ければ null
+ */
+async function runDevFlowInSandbox(src, ctx) {
+  const stripped = src
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = `(async () => {\n${stripped}\n})();`;
+
+  let caughtError = null;
+  try {
+    const result = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/dev-flow.js' });
+    if (result && typeof result.then === 'function') {
+      await result.catch((e) => {
+        caughtError = e;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return caughtError;
+}
+
+// ============================================================
+// A. 振る舞いカウント検証（AC#7 主検証）
+// ============================================================
+
+test('[shape-loop] SHAPE=standard: plan-reviewer 呼び出し 0 回・evaluator 呼び出し 1 回', async () => {
+  // standard に落ちる req（count=3 ≤ 5, ac.length=4 ≤ 6, type=feat → floor='standard'）
+  const standardReq = {
+    summary: 's',
+    acceptance_criteria: ['a', 'b', 'c', 'd'],
+    issue_type: 'feat',
+    scope: 'src',
+    estimated_change_file_count: 3,
+    shape: 'standard',
+  };
+
+  const src = readFileSync(devFlowPath, 'utf8');
+  const { ctx, calls } = makeCountingSandbox(standardReq);
+  const err = await runDevFlowInSandbox(src, ctx);
+
+  // ReferenceError / SyntaxError は構造的に壊れているので即 fail させる
+  if (err && (err.name === 'ReferenceError' || err.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${err.name}: ${err.message}`);
+  }
+
+  const reviewerCalls = calls.filter((c) => c.agentType === 'plan-reviewer');
+  const evaluatorCalls = calls.filter((c) => c.agentType === 'evaluator');
+
+  // AC#7 主検証: standard では plan-reviewer を呼ばない（PLAN_SOLO 経路）
+  assert.equal(
+    reviewerCalls.length,
+    0,
+    `SHAPE=standard: plan-reviewer は 0 回呼ばれるべきだが ${reviewerCalls.length} 回呼ばれた`
+      + ` (labels: ${reviewerCalls.map((c) => c.label).join(', ')})`,
+  );
+
+  // AC#7 主検証: standard では evaluator を 1 回だけ呼ぶ（EVAL_PASSES=1）
+  assert.equal(
+    evaluatorCalls.length,
+    1,
+    `SHAPE=standard: evaluator は 1 回呼ばれるべきだが ${evaluatorCalls.length} 回呼ばれた`,
+  );
+});
+
+test('[shape-loop] SHAPE=complex: plan-reviewer 呼び出し >= 1（制御群）', async () => {
+  // complex に落ちる req（count=8 > 5 → floor='complex', ac=7件）
+  const complexReq = {
+    summary: 's',
+    acceptance_criteria: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+    issue_type: 'feat',
+    scope: 'src',
+    estimated_change_file_count: 8,
+    shape: 'complex',
+  };
+
+  const src = readFileSync(devFlowPath, 'utf8');
+  const { ctx, calls } = makeCountingSandbox(complexReq);
+  const err = await runDevFlowInSandbox(src, ctx);
+
+  if (err && (err.name === 'ReferenceError' || err.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${err.name}: ${err.message}`);
+  }
+
+  const reviewerCalls = calls.filter((c) => c.agentType === 'plan-reviewer');
+
+  // 制御群: complex では plan-reviewer が起動する経路（>= 1）
+  // standard の 0 と対比し「standard のみ reviewer をスキップする」経路を pin する
+  assert.ok(
+    reviewerCalls.length >= 1,
+    `SHAPE=complex: plan-reviewer は >= 1 回呼ばれるべきだが ${reviewerCalls.length} 回だった`,
+  );
+});
+
+// ============================================================
+// B. 構造テスト（正負ペア + 正規表現、脆い multiline literal 禁止）
+// ============================================================
+
+test('[shape-loop][struct] dev-flow.js に PLAN_SOLO 定数定義が存在する', () => {
+  const src = readFileSync(devFlowPath, 'utf8');
+  assert.ok(
+    src.includes('const PLAN_SOLO ='),
+    'dev-flow.js に `const PLAN_SOLO =` が存在すること',
+  );
+});
+
+test('[shape-loop][struct] plan#standard と plan#trivial が両方存在する（正の対）', () => {
+  const src = readFileSync(devFlowPath, 'utf8');
+  assert.ok(
+    src.includes('plan#standard'),
+    'dev-flow.js に standard 専用 planner label `plan#standard` が存在すること',
+  );
+  assert.ok(
+    src.includes('plan#trivial'),
+    'dev-flow.js に micro 経路 planner label `plan#trivial` が存在すること（micro 経路温存）',
+  );
+});
+
+test('[shape-loop][struct] EVAL ループヘッダが EVAL_PASSES 変数経由である（正規表現）', () => {
+  const src = readFileSync(devFlowPath, 'utf8');
+  const evalPassesLoop = /for\s*\(\s*let\s+i\s*=\s*1\s*;\s*i\s*<=\s*EVAL_PASSES/.test(src);
+  assert.ok(
+    evalPassesLoop,
+    'dev-flow.js の Evaluate ループが `for (let i = 1; i <= EVAL_PASSES ...` 形式であること',
+  );
+});
+
+test('[shape-loop][struct] EVAL ループに EVAL_MAX 直書きヘッダが存在しない（正規表現・負）', () => {
+  const src = readFileSync(devFlowPath, 'utf8');
+  // EVAL_MAX 直書きのループヘッダが消えていること（定義行 `const EVAL_MAX = 10` 自体は残る）
+  const evalMaxLoop = /for\s*\(\s*let\s+i\s*=\s*1\s*;\s*i\s*<=\s*EVAL_MAX/.test(src);
+  assert.ok(
+    !evalMaxLoop,
+    'dev-flow.js の Evaluate ループヘッダに `i <= EVAL_MAX` 直書き形式が存在しないこと（EVAL_PASSES 変数経由であること）',
+  );
+});
+
+test('[shape-loop][struct] dev-flow.js に EVAL_PASSES 定数定義が存在する', () => {
+  const src = readFileSync(devFlowPath, 'utf8');
+  assert.ok(
+    src.includes('const EVAL_PASSES ='),
+    'dev-flow.js に `const EVAL_PASSES =` が存在すること',
+  );
+});


### PR DESCRIPTION
## 概要

Closes #157

- `PLAN_SOLO` 定数を追加し、`SHAPE=standard` では plan-reviewer を 0 回・plan 1発のみの軽量経路を実装
- `EVAL_PASSES` 定数を追加し、`SHAPE=standard` では evaluator を 1 パスのみ実行（差し戻しループなし）
- `shape === 'complex'` の既存フルループ（plan-review ≤PLAN_MAX・evaluate 差し戻し ≤EVAL_MAX）は維持
- `shape === 'micro'` の TRIVIAL 経路も回帰なし
- AC#7 検証用の `_lib/shape-loop-routing.test.mjs` を追加（VM sandbox でカウント検証）

## 動機

W2（#148/PR #149）で shape 三値分類（micro/standard/complex）を実装したが、standard と complex は両方フルパイプラインのままだった。本 PR でその残りを実装し、standard を中間経路（plan 1発・評価1パス）に分岐させる。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/dev-flow.js` | `PLAN_SOLO` / `EVAL_PASSES` 定数追加、standard 専用 `plan#standard` 経路、EVAL ループヘッダを `EVAL_PASSES` 経由に変更 |
| `_lib/shape-loop-routing.test.mjs` | AC#7 shape ループルーティング検証テスト（VM sandbox, plan-reviewer=0 / evaluator=1 カウント検証） |

## テスト計画

- [x] `SHAPE=standard`: plan-reviewer 呼び出し 0 回・evaluator 呼び出し 1 回（AC#7 主検証）
- [x] `SHAPE=complex`: plan-reviewer 呼び出し >= 1（制御群）
- [x] 構造テスト: `PLAN_SOLO` / `EVAL_PASSES` 定数定義の存在確認
- [x] EVAL ループヘッダが `EVAL_PASSES` 変数経由であること（`EVAL_MAX` 直書きなし）