### PR TITLE
feat(_lib): AC 未達時に merge_tier を HOLD へ昇格させる unsatisfiedAc フラグを実装

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -195,6 +195,7 @@ function classifyMergeTier(s) {
   if (s.unresolvedDanger) reasons.push('danger-grep hit 未解消（security 要確認）');
   if (s.breaking) reasons.push('breaking/migration 検出');
   if (s.escalateCount > 0) reasons.push(`ESCALATE-TO-HUMAN 項目 ${s.escalateCount} 件`);
+  if (s.unsatisfiedAc) reasons.push('AC 未達（acceptance_criteria が satisfied:false — gate_policy に依らず人間確認必須）');
   if (reasons.length) return { tier: 'HOLD', reasons };
   if (s.shape === 'micro' && s.docsOrTestOnly) {
     return { tier: 'AUTO', reasons: ['micro + docs/test-only + danger clean + 収束済 — 推奨ラベル（merge は人間）'] };
@@ -784,6 +785,7 @@ if (TRIVIAL && dangerHits.length > 0) {
 // 初回は implement で出た concerns / 未解消 BLOCKED を focus_areas として重点監査させる。
 // ============================================================
 let evalResult = null
+let unsatisfiedAc = false
 if (runEval) {
 phase('Evaluate')
 // Security floor で build 済みの ledger(SEC seed + danger 反映済)に AC + concerns を足す。
@@ -824,6 +826,7 @@ for (let i = 1; i <= EVAL_PASSES; i++) {
     { agentType: 'evaluator', schema: EVAL, label: `eval#${i}`, phase: 'Evaluate' },
   ), `Evaluate(eval#${i})`)
   evalResult = ev
+  unsatisfiedAc = (ev.ac_results ?? []).some((r) => r && r.satisfied === false)
 
   // feedback を topic 単位で累積し出現回数を数える（stuck 検出 fingerprint）
   for (const f of (ev.feedback ?? [])) {
@@ -987,6 +990,7 @@ const mergeTier = classifyMergeTier({
   breaking,
   docsOrTestOnly: isDocsOrTestOnly(changed.files ?? []),
   escalateCount,
+  unsatisfiedAc,
 })
 log(`merge tier: ${mergeTier.tier} — ${mergeTier.reasons.join(' / ')}`)
 

--- a/_lib/merge-tier-unsatisfied-ac.test.mjs
+++ b/_lib/merge-tier-unsatisfied-ac.test.mjs
@@ -1,0 +1,250 @@
+// AC#4: VM カウントテスト（shape-loop-routing.test.mjs と同型）
+// standard 経路で evaluator stub が satisfied:false を返すと merge_tier === 'HOLD' になることを検証する。
+//
+// このテストファイルは TDD red として作成された。
+// F3 実装（AC 未達時に unsatisfiedAc フラグを立て classifyMergeTier に渡す）完了後に green になる。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const devFlowPath = join(repoRoot, '.claude/workflows/dev-flow.js');
+
+// ---- VM sandbox helpers（shape-loop-routing.test.mjs の makeCountingSandbox / runDevFlowInSandbox と同型）----
+
+/**
+ * AC 未達検証専用の VM sandbox を組む。
+ * evaluator stub が引数 evaluatorResponse を返すように改変。
+ * resolved 値（return object）を捕捉できるよう runner も改変している。
+ *
+ * @param {object} analyzeReq - analyze フェーズの agent が返す req オブジェクト（SHAPE を決定する）
+ * @param {object} evaluatorResponse - evaluator stub が返すレスポンス
+ * @returns {{ ctx: vm.Context }}
+ */
+function makeSandbox(analyzeReq, evaluatorResponse) {
+  // agent() stub: opts.label / opts.agentType を見て phase 別に最小スキーマを返す
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+
+    // Setup(worktree)
+    if (label === 'worktree') {
+      return { worktree: '/tmp/wt', branch: 'feature/issue-1' };
+    }
+    // Analyze: label が 'analyze' で始まる
+    if (label.startsWith('analyze')) {
+      return analyzeReq;
+    }
+    // Plan: dev-planner (plan#trivial / plan#standard / plan#N / replan 系)
+    if (agentType === 'dev-planner') {
+      return { summary: 'p', serial: [], parallel: [] };
+    }
+    // Plan reviewer
+    if (agentType === 'plan-reviewer') {
+      return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
+    }
+    // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
+    // → danger clean にして HOLD 要因を AC のみに絞る
+    if (label.startsWith('danger-grep')) {
+      return { hits: [] };
+    }
+    // Validate: test runner（label が 'test' で始まる）
+    if (label.startsWith('test')) {
+      return { tests: 'no_tests', green: true, summary: '' };
+    }
+    // Evaluate: evaluator stub が引数 evaluatorResponse を返す
+    if (agentType === 'evaluator') {
+      return evaluatorResponse;
+    }
+    // redgreen-verify は呼ばれないはずだが念のため（verified_by:'inspection' で回避）
+    if (agentType === 'dev-runner-haiku' && label.startsWith('redgreen')) {
+      return { red: false, green: false, reason: 'stub' };
+    }
+    // PR: label が 'pr' で始まる
+    if (label.startsWith('pr')) {
+      return { pr_url: 'http://x', pr_number: 1, committed: true };
+    }
+    // Merge tier: changed-files
+    // → docs/test-only でないファイルを返す（AUTO 除外。HOLD 要因を AC のみに絞る）
+    if (label === 'changed-files') {
+      return { files: ['src/foo.ts'] };
+    }
+    // implementer その他
+    if (agentType === 'implementer') {
+      return { status: 'DONE', task_id: 't', files: [], summary: '', concerns: [] };
+    }
+    // デフォルト
+    return null;
+  };
+
+  // parallel() stub: runImplement が parallel(par) を呼ぶため（par が空なら []）
+  const parallelStub = async (fns) => Promise.all((fns || []).map((f) => f()));
+
+  // pr-iterate stub: workflow() の呼び出し
+  const workflowStub = async () => ({ status: 'LGTM' });
+
+  const sandbox = {
+    // workflow 制御関数
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: parallelStub,
+    workflow: workflowStub,
+    // 引数（ISSUE 解決用）
+    args: '1',
+    // JS 組み込み（shape-loop-routing.test.mjs と同一セット）
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+
+  const ctx = vm.createContext(sandbox);
+  return { ctx };
+}
+
+/**
+ * dev-flow.js ソースを strip して async IIFE でラップし vm sandbox で実行する。
+ * shape-loop-routing.test.mjs の runDevFlowInSandbox と異なり、
+ * IIFE の **resolved 値（return object）を捕捉して返す**。
+ *
+ * @param {string} src - dev-flow.js の raw ソース
+ * @param {vm.Context} ctx - vm コンテキスト
+ * @returns {Promise<{ result: object|null, error: Error|null }>}
+ */
+async function runDevFlowCapture(src, ctx) {
+  const stripped = src
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = `(async () => {\n${stripped}\n})();`;
+
+  let caughtError = null;
+  let resolvedResult = null;
+  try {
+    const resultPromise = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/dev-flow.js' });
+    if (resultPromise && typeof resultPromise.then === 'function') {
+      resolvedResult = await resultPromise.catch((e) => {
+        caughtError = e;
+        return null;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return { result: resolvedResult, error: caughtError };
+}
+
+// ============================================================
+// テストケース
+// ============================================================
+
+test('[unsatisfied-ac] standard 経路: evaluator が satisfied:false → merge_tier === HOLD', async () => {
+  // standard に落ちる req（count=3, ac=4件, type='feat' → floor='standard'）
+  // AC は最低1件必須（dev-flow.js L793 で acceptance_criteria を ledger に積む）
+  const analyzeReq = {
+    summary: 's',
+    acceptance_criteria: ['a', 'b', 'c', 'd'],
+    issue_type: 'feat',
+    scope: 'src',
+    estimated_change_file_count: 3,
+    shape: 'standard',
+  };
+
+  // evaluatorResponse: AC#1（ac_index:0）を satisfied:false にする。
+  // verified_by を 'inspection'（test 以外）にして redgreen-verify 分岐を回避し、
+  // L880 の `else if (r.satisfied)` 経路に入る（satisfied:false → checkItem されず blocking のまま残る）。
+  const evaluatorResponse = {
+    verdict: 'pass',
+    total: 100,
+    threshold: 80,
+    feedback: [],
+    feedback_level: 'implementation',
+    ac_results: [
+      { ac_index: 0, satisfied: false, verified_by: 'inspection', evidence: '未達' },
+    ],
+    security_clearance: [],
+  };
+
+  const src = readFileSync(devFlowPath, 'utf8');
+  const { ctx } = makeSandbox(analyzeReq, evaluatorResponse);
+  const { result, error } = await runDevFlowCapture(src, ctx);
+
+  // ReferenceError / SyntaxError は構造的に壊れているので即 fail させる
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  // merge_tier が HOLD であることを assert
+  assert.equal(
+    result?.merge_tier,
+    'HOLD',
+    `standard 経路で evaluator が satisfied:false を返した場合、merge_tier は 'HOLD' であるべきだが '${result?.merge_tier}' だった`,
+  );
+
+  // merge_tier_reasons に AC 未達が含まれることを assert（挙動 pin）
+  assert.ok(
+    Array.isArray(result?.merge_tier_reasons) && result.merge_tier_reasons.some((x) => /AC 未達/.test(x)),
+    `merge_tier_reasons に 'AC 未達' が含まれるべきだが含まれなかった: ${JSON.stringify(result?.merge_tier_reasons)}`,
+  );
+});
+
+test('[unsatisfied-ac] standard 経路: 全 AC satisfied:true → merge_tier \!== HOLD（回帰防止・挙動不変）', async () => {
+  // 同じ analyzeReq（standard 落ち）
+  const analyzeReq = {
+    summary: 's',
+    acceptance_criteria: ['a', 'b', 'c', 'd'],
+    issue_type: 'feat',
+    scope: 'src',
+    estimated_change_file_count: 3,
+    shape: 'standard',
+  };
+
+  // evaluatorResponse: 全 AC に対し satisfied:true。AC 未達フラグが false の時に不要な HOLD を出さないことを pin。
+  // verified_by:'inspection' で redgreen-verify 分岐を回避し L883 の `else if (r.satisfied)` → checkItem 経路に入る。
+  const evaluatorResponse = {
+    verdict: 'pass',
+    total: 100,
+    threshold: 80,
+    feedback: [],
+    feedback_level: 'implementation',
+    ac_results: [
+      { ac_index: 0, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+      { ac_index: 1, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+      { ac_index: 2, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+      { ac_index: 3, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+    ],
+    security_clearance: [],
+  };
+
+  const src = readFileSync(devFlowPath, 'utf8');
+  const { ctx } = makeSandbox(analyzeReq, evaluatorResponse);
+  const { result, error } = await runDevFlowCapture(src, ctx);
+
+  // ReferenceError / SyntaxError は構造的に壊れているので即 fail させる
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  // 全 AC satisfied:true + danger clean + docsOrTestOnly でない standard → REVIEW を期待
+  assert.equal(
+    result?.merge_tier,
+    'REVIEW',
+    `全 AC satisfied:true の場合、merge_tier は 'REVIEW' であるべきだが '${result?.merge_tier}' だった`,
+  );
+});

--- a/_lib/merge-tier.mjs
+++ b/_lib/merge-tier.mjs
@@ -84,6 +84,7 @@ export function classifyMergeTier(s) {
   if (s.unresolvedDanger) reasons.push('danger-grep hit 未解消（security 要確認）');
   if (s.breaking) reasons.push('breaking/migration 検出');
   if (s.escalateCount > 0) reasons.push(`ESCALATE-TO-HUMAN 項目 ${s.escalateCount} 件`);
+  if (s.unsatisfiedAc) reasons.push('AC 未達（acceptance_criteria が satisfied:false — gate_policy に依らず人間確認必須）');
   if (reasons.length) return { tier: 'HOLD', reasons };
   if (s.shape === 'micro' && s.docsOrTestOnly) {
     return { tier: 'AUTO', reasons: ['micro + docs/test-only + danger clean + 収束済 — 推奨ラベル（merge は人間）'] };

--- a/_lib/merge-tier.test.mjs
+++ b/_lib/merge-tier.test.mjs
@@ -156,3 +156,25 @@ test('classifyMergeTier: micro だが docs/test-only でない → REVIEW', () =
   const r = classifyMergeTier({ shape: 'micro', converged: true, unresolvedDanger: false, breaking: false, docsOrTestOnly: false, escalateCount: 0 });
   assert.equal(r.tier, 'REVIEW');
 });
+
+
+test('classifyMergeTier: AC 未達(unsatisfiedAc:true) → HOLD', () => {
+  const r = classifyMergeTier({ shape: 'standard', converged: true, unresolvedDanger: false, breaking: false, docsOrTestOnly: false, escalateCount: 0, unsatisfiedAc: true });
+  assert.equal(r.tier, 'HOLD');
+  assert.ok(r.reasons.some((x) => /AC 未達/.test(x)));
+});
+
+test('classifyMergeTier: unsatisfiedAc:false は既存 REVIEW 挙動不変', () => {
+  const r = classifyMergeTier({ shape: 'standard', converged: true, unresolvedDanger: false, breaking: false, docsOrTestOnly: false, escalateCount: 0, unsatisfiedAc: false });
+  assert.equal(r.tier, 'REVIEW');
+});
+
+test('classifyMergeTier: unsatisfiedAc 未指定でも REVIEW(後方互換 — フラグ省略時は false 扱い)', () => {
+  const r = classifyMergeTier({ shape: 'standard', converged: true, unresolvedDanger: false, breaking: false, docsOrTestOnly: false, escalateCount: 0 });
+  assert.equal(r.tier, 'REVIEW');
+});
+
+test('classifyMergeTier: unsatisfiedAc:true は AUTO 条件(micro+docs/test-only)でも HOLD に勝つ', () => {
+  const r = classifyMergeTier({ shape: 'micro', converged: true, unresolvedDanger: false, breaking: false, docsOrTestOnly: true, escalateCount: 0, unsatisfiedAc: true });
+  assert.equal(r.tier, 'HOLD');
+});


### PR DESCRIPTION
## 概要

Closes #159

- evaluator の `ac_results` に `satisfied:false` が 1 件以上ある場合に `unsatisfiedAc=true` を立てる
- `classifyMergeTier` に `unsatisfiedAc` を渡し、`gate_policy` に依らず HOLD 理由として記録
- `dev-flow.js` と `_lib/merge-tier.mjs` の両方に同一ロジックを追加（inline コピー同期）
- AC 未達 HOLD 経路を検証する VM カウントテスト (`_lib/merge-tier-unsatisfied-ac.test.mjs`) を追加

## 動機

evaluator が AC 未達と判定した場合でも `merge_tier` が `HOLD` に昇格しないバグがあった。
AC の充足状態は `gate_policy` の如何に関わらず人間確認が必須であるため、
`incentive-structural` クラスの distrust 機構として常時 blocking にする必要がある。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/dev-flow.js` | `unsatisfiedAc` フラグの算出と `classifyMergeTier` への引き渡しを追加 |
| `_lib/merge-tier.mjs` | `unsatisfiedAc` 条件を `classifyMergeTier` に追加（dev-flow.js のインラインコピー） |
| `_lib/merge-tier-unsatisfied-ac.test.mjs` | AC 未達時の HOLD 経路を検証する VM テスト（新規追加） |
| `_lib/merge-tier.test.mjs` | 既存テストに `unsatisfiedAc` ケースを追加 |

## テスト計画

- [x] `_lib/merge-tier-unsatisfied-ac.test.mjs`: `satisfied:false` が含まれる evaluator 応答で `merge_tier === 'HOLD'` を検証
- [x] `_lib/merge-tier.test.mjs`: `unsatisfiedAc: true` を渡した場合の HOLD 昇格テストを追加