### PR TITLE
feat(_lib): 終端サマリー markdown 生成関数と sync/unit/VM テストを追加 (#162)

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -463,6 +463,148 @@ function diffDeclaredPaths(planTasks, changedFiles) {
 }
 // ---- /parallel-disjoint エンジン ----
 
+// ---- devflow-summary-format inline コピー (canonical: _lib/devflow-summary-format.mjs。修正時は両者を同期。byte 一致は _lib/devflow-summary-format.sync.test.mjs が保証) ----
+// bodySaveInstr: PR body 保存 + 投稿の共通指示文を組み立てるヘルパー（pr-iterate.js と同型）。
+function bodySaveInstr(body) {
+  return `## 本文の保存\n`
+    + `まず Bash で \`mktemp /tmp/dev-flow-XXXXXX.md\` を実行して一時ファイルを作成し、\n`
+    + `そのパスを <BODY_FILE> とする。次に **Write tool** を使い、下記 delimiter 内の本文を\n`
+    + `**一字一句そのまま** <BODY_FILE> へ書き出せ。本文は絶対に shell（echo/printf/heredoc 等）へ\n`
+    + `渡さず、必ず Write tool の content 引数として渡すこと。backtick やコードフェンスを\n`
+    + `エスケープ・改変しないこと。以降のコマンドの \`--body-file\` には <BODY_FILE> を指定する。\n`
+    + `<<<DEV_FLOW_BODY_BEGIN>>>\n${body}\n<<<DEV_FLOW_BODY_END>>>\n\n`
+}
+
+// POST_RESULT schema（dev-runner 経由の PR 投稿結果）
+const POST_RESULT = {
+  type: 'object',
+  required: ['posted'],
+  properties: {
+    posted: { type: 'boolean' },
+    method: { type: 'string' },
+    url: { type: 'string' },
+  },
+}
+
+function buildDevflowSummaryBody({
+  pr,
+  mergeTier,
+  mergeTierReasons,
+  gatePolicy,
+  blockingItems,
+  advisoryItems,
+  ledgerConverged,
+  acResults,
+  securityClearance,
+  planConcerns,
+  dangerHits,
+  shape,
+  testGreen,
+  evalVerdict,
+}) {
+  const lines = [];
+
+  // 1. 見出し
+  lines.push(`## dev-flow 終端サマリー — PR #${pr}`);
+  lines.push('');
+
+  // 2. Merge tier セクション
+  lines.push(`### Merge tier: ${mergeTier}`);
+  if (!mergeTierReasons || mergeTierReasons.length === 0) {
+    lines.push('- 理由記載なし');
+  } else {
+    for (const reason of mergeTierReasons) {
+      lines.push(`- ${reason}`);
+    }
+  }
+  lines.push('');
+
+  // 3. 実行結果サマリー（shape / test_green / eval_verdict）
+  lines.push('### 実行結果');
+  lines.push(`- shape: ${shape != null ? shape : '不明'}`);
+  lines.push(`- test_green: ${testGreen != null ? String(testGreen) : '不明'}`);
+  lines.push(`- eval_verdict: ${evalVerdict != null ? evalVerdict : '不明'}`);
+  lines.push('');
+
+  // 4. Goal Ledger セクション
+  lines.push('### Goal Ledger');
+  lines.push(`- gate_policy: ${gatePolicy}`);
+  lines.push(`- 収束: ${ledgerConverged ? '済' : '未収束'}`);
+
+  // blocking items
+  if (!blockingItems || blockingItems.length === 0) {
+    lines.push('- blocking item なし');
+  } else {
+    for (const item of blockingItems) {
+      const status = item.checked ? 'checked' : '未解消';
+      const dimension = item.dimension ? ` [${item.dimension}]` : '';
+      const evidence = item.evidence ? ': ' + item.evidence : '';
+      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}`);
+    }
+  }
+
+  // advisory items
+  if (!advisoryItems || advisoryItems.length === 0) {
+    lines.push('- advisory item なし');
+  } else {
+    for (const item of advisoryItems) {
+      const status = item.checked ? 'checked' : '未解消';
+      const escalateSuffix = item.escalate ? ' (ESCALATE)' : '';
+      const dimension = item.dimension ? ` [${item.dimension}]` : '';
+      const evidence = item.evidence ? ': ' + item.evidence : '';
+      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}${escalateSuffix}`);
+    }
+  }
+  lines.push('');
+
+  // 5. AC evidence セクション
+  lines.push('### Acceptance Criteria');
+  if (!acResults || acResults.length === 0) {
+    lines.push('AC 判定なし（evaluator 未実行 or AC 欠落）');
+  } else {
+    for (const ac of acResults) {
+      const satisfiedLabel = ac.satisfied ? 'satisfied' : '未達';
+      const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
+      const evidenceSuffix = ac.evidence ? ': ' + ac.evidence : '';
+      lines.push(`- AC#${ac.ac_index + 1}: ${satisfiedLabel}（${verifiedBy}）${evidenceSuffix}`);
+    }
+  }
+  lines.push('');
+
+  // 6. Security clearance セクション
+  lines.push('### Security clearance');
+  if (!securityClearance || securityClearance.length === 0) {
+    lines.push('- danger-grep clean（clearance 不要）');
+  } else {
+    for (const sc of securityClearance) {
+      const clearedLabel = sc.cleared ? 'cleared' : '未確認';
+      const evidenceSuffix = sc.evidence ? ': ' + sc.evidence : '';
+      lines.push(`- ${sc.danger_class}: ${clearedLabel}${evidenceSuffix}`);
+    }
+  }
+  if (dangerHits && dangerHits.length > 0) {
+    lines.push(`- 検出クラス: ${dangerHits.join(', ')}`);
+  }
+  lines.push('');
+
+  // 7. Plan concerns セクション（空なら省略）
+  if (planConcerns && planConcerns.length > 0) {
+    lines.push('### Plan 未解消 concerns');
+    for (const concern of planConcerns) {
+      lines.push(`- ${concern}`);
+    }
+    lines.push('');
+  }
+
+  // 8. 末尾
+  lines.push('---');
+  lines.push('*このコメントは dev-flow により自動生成されました。*');
+  lines.push(`<!-- dev-flow:${mergeTier} -->`);
+
+  return lines.join('\n');
+}
+// ---- /devflow-summary-format inline コピー ----
+
 function applyDisjoint(p, label) {
   const { plan: np, demoted } = enforceDisjointParallel(p);
   if (demoted.length) log(`⚠️ ${label}: file_changes 衝突 ${demoted.length} task を parallel→serial 降格: ${demoted.map((d) => `${d.id}(vs ${d.conflictsWith})`).join(', ')}`);
@@ -1187,6 +1329,44 @@ const mergeTier = classifyMergeTier({
   unsatisfiedAc,
 })
 log(`merge tier: ${mergeTier.tier} — ${mergeTier.reasons.join(' / ')}`)
+
+// ============================================================
+// Post-summary: Merge tier 算出後に終端サマリーを PR にコメント投稿する。
+// 投稿失敗は log 警告のみで workflow は正常 return（issue #162 AC#4）。
+// ============================================================
+const summaryBody = buildDevflowSummaryBody({
+  pr: pr.pr_number,
+  mergeTier: mergeTier.tier,
+  mergeTierReasons: mergeTier.reasons,
+  gatePolicy: GATE_POLICY,
+  blockingItems: policyBlockingItems(ledger, GATE_POLICY),
+  advisoryItems: policyAdvisoryItems(ledger, GATE_POLICY),
+  ledgerConverged: isConvergedUnderPolicy(ledger, GATE_POLICY),
+  acResults: evalResult?.ac_results ?? null,
+  securityClearance: evalResult?.security_clearance ?? null,
+  planConcerns: planConcerns ?? [],
+  dangerHits: dangerHitsFinal,
+  shape: EFFECTIVE_SHAPE,
+  testGreen: val?.green ?? null,
+  evalVerdict: evalResult?.verdict ?? null,
+})
+const summaryPost = await agent(
+  `## Objective\nPR #${pr.pr_number} に dev-flow の終端サマリーコメントを投稿する（merge tier: ${mergeTier.tier}）。\n\n`
+  + bodySaveInstr(summaryBody)
+  + `## Instructions\n`
+  + `保存した <BODY_FILE> を使い、以下のコマンドをそのまま実行せよ: \`gh pr comment ${pr.pr_number} --body-file <BODY_FILE>\`\n`
+  + `投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
+  + `投稿失敗時でも posted:false を返し throw しないこと。\n`
+  + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`
+  + `\n## Tools\n使用可: Bash, Write\n`
+  + `\n## Boundary\n<BODY_FILE>（一時ファイル）以外のファイルを変更しない。git commit 禁止。\n`
+  + `\n## Token cap\n200 語以内で完結すること。`,
+  { agentType: 'dev-runner', schema: POST_RESULT, label: 'post-summary', phase: 'Merge tier' },
+)
+if (!summaryPost?.posted) {
+  log(`⚠️ post-summary の投稿に失敗しました（posted=${summaryPost?.posted ?? 'null'}）。ワークフローは継続します。`)
+}
+
 
 return {
   issue: ISSUE,

--- a/_lib/devflow-summary-format.mjs
+++ b/_lib/devflow-summary-format.mjs
@@ -15,13 +15,16 @@
  * @param {string} opts.mergeTier - 'HOLD'|'REVIEW'|'AUTO'
  * @param {string[]} opts.mergeTierReasons - 理由文字列の配列
  * @param {string} opts.gatePolicy - gate policy 文字列（例 'llm-major-advisory'）
- * @param {Array<{id,text,severity,checked,dimension}>} opts.blockingItems - blocking items
- * @param {Array<{id,text,severity,checked,dimension,escalate}>} opts.advisoryItems - advisory items
+ * @param {Array<{id,text,severity,checked,dimension,evidence}>} opts.blockingItems - blocking items
+ * @param {Array<{id,text,severity,checked,dimension,evidence,escalate}>} opts.advisoryItems - advisory items
  * @param {boolean} opts.ledgerConverged - ledger 収束フラグ
  * @param {Array<{ac_index,satisfied,evidence,verified_by}>|null|undefined} opts.acResults - AC 判定結果
  * @param {Array<{danger_class,cleared,evidence}>|null|undefined} opts.securityClearance - security clearance
  * @param {string[]} opts.planConcerns - Plan phase 未解消 concerns
  * @param {string[]} opts.dangerHits - danger-grep で検出したクラス名
+ * @param {string|null|undefined} opts.shape - 実効 shape（'micro'|'standard'|'complex'）
+ * @param {boolean|null|undefined} opts.testGreen - test green フラグ
+ * @param {string|null|undefined} opts.evalVerdict - evaluator verdict（'pass'|'fail' 等）
  * @returns {string}
  */
 export function buildDevflowSummaryBody({
@@ -36,6 +39,9 @@ export function buildDevflowSummaryBody({
   securityClearance,
   planConcerns,
   dangerHits,
+  shape,
+  testGreen,
+  evalVerdict,
 }) {
   const lines = [];
 
@@ -54,7 +60,14 @@ export function buildDevflowSummaryBody({
   }
   lines.push('');
 
-  // 3. Goal Ledger セクション
+  // 3. 実行結果サマリー（shape / test_green / eval_verdict）
+  lines.push('### 実行結果');
+  lines.push(`- shape: ${shape != null ? shape : '不明'}`);
+  lines.push(`- test_green: ${testGreen != null ? String(testGreen) : '不明'}`);
+  lines.push(`- eval_verdict: ${evalVerdict != null ? evalVerdict : '不明'}`);
+  lines.push('');
+
+  // 4. Goal Ledger セクション
   lines.push('### Goal Ledger');
   lines.push(`- gate_policy: ${gatePolicy}`);
   lines.push(`- 収束: ${ledgerConverged ? '済' : '未収束'}`);
@@ -65,7 +78,9 @@ export function buildDevflowSummaryBody({
   } else {
     for (const item of blockingItems) {
       const status = item.checked ? 'checked' : '未解消';
-      lines.push(`- [${status}] ${item.id} ${item.text}`);
+      const dimension = item.dimension ? ` [${item.dimension}]` : '';
+      const evidence = item.evidence ? ': ' + item.evidence : '';
+      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}`);
     }
   }
 
@@ -76,12 +91,14 @@ export function buildDevflowSummaryBody({
     for (const item of advisoryItems) {
       const status = item.checked ? 'checked' : '未解消';
       const escalateSuffix = item.escalate ? ' (ESCALATE)' : '';
-      lines.push(`- [${status}] ${item.id} ${item.text}${escalateSuffix}`);
+      const dimension = item.dimension ? ` [${item.dimension}]` : '';
+      const evidence = item.evidence ? ': ' + item.evidence : '';
+      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}${escalateSuffix}`);
     }
   }
   lines.push('');
 
-  // 4. AC evidence セクション
+  // 5. AC evidence セクション
   lines.push('### Acceptance Criteria');
   if (!acResults || acResults.length === 0) {
     lines.push('AC 判定なし（evaluator 未実行 or AC 欠落）');
@@ -95,7 +112,7 @@ export function buildDevflowSummaryBody({
   }
   lines.push('');
 
-  // 5. Security clearance セクション
+  // 6. Security clearance セクション
   lines.push('### Security clearance');
   if (!securityClearance || securityClearance.length === 0) {
     lines.push('- danger-grep clean（clearance 不要）');
@@ -111,7 +128,7 @@ export function buildDevflowSummaryBody({
   }
   lines.push('');
 
-  // 6. Plan concerns セクション（空なら省略）
+  // 7. Plan concerns セクション（空なら省略）
   if (planConcerns && planConcerns.length > 0) {
     lines.push('### Plan 未解消 concerns');
     for (const concern of planConcerns) {
@@ -120,7 +137,7 @@ export function buildDevflowSummaryBody({
     lines.push('');
   }
 
-  // 7. 末尾
+  // 8. 末尾
   lines.push('---');
   lines.push('*このコメントは dev-flow により自動生成されました。*');
   lines.push(`<!-- dev-flow:${mergeTier} -->`);

--- a/_lib/devflow-summary-format.mjs
+++ b/_lib/devflow-summary-format.mjs
@@ -1,0 +1,129 @@
+// buildDevflowSummaryBody: dev-flow の終端サマリー markdown を生成する純粋関数。
+// I/O なし、gh なし、Date.now() 等の非決定性なし。同入力 -> byte 一致。
+//
+// INLINE COPY POLICY: .claude/workflows/dev-flow.js は Claude Code の
+// dynamic workflow ローダーが独自の VM コンテキストで評価するため、ESM の
+// import 文（`import { buildDevflowSummaryBody } from '../../_lib/devflow-summary-format.mjs'` 等）
+// は使用できない。そのため dev-flow.js にこの関数本体を inline コピーしており、
+// _lib/devflow-summary-format.sync.test.mjs がその byte 一致を CI で保証する。
+// この関数を修正する際は、必ず dev-flow.js の inline コピーも同期すること。
+
+/**
+ * dev-flow 終端サマリー markdown を生成する。
+ * @param {object} opts
+ * @param {number|string} opts.pr - PR 番号
+ * @param {string} opts.mergeTier - 'HOLD'|'REVIEW'|'AUTO'
+ * @param {string[]} opts.mergeTierReasons - 理由文字列の配列
+ * @param {string} opts.gatePolicy - gate policy 文字列（例 'llm-major-advisory'）
+ * @param {Array<{id,text,severity,checked,dimension}>} opts.blockingItems - blocking items
+ * @param {Array<{id,text,severity,checked,dimension,escalate}>} opts.advisoryItems - advisory items
+ * @param {boolean} opts.ledgerConverged - ledger 収束フラグ
+ * @param {Array<{ac_index,satisfied,evidence,verified_by}>|null|undefined} opts.acResults - AC 判定結果
+ * @param {Array<{danger_class,cleared,evidence}>|null|undefined} opts.securityClearance - security clearance
+ * @param {string[]} opts.planConcerns - Plan phase 未解消 concerns
+ * @param {string[]} opts.dangerHits - danger-grep で検出したクラス名
+ * @returns {string}
+ */
+export function buildDevflowSummaryBody({
+  pr,
+  mergeTier,
+  mergeTierReasons,
+  gatePolicy,
+  blockingItems,
+  advisoryItems,
+  ledgerConverged,
+  acResults,
+  securityClearance,
+  planConcerns,
+  dangerHits,
+}) {
+  const lines = [];
+
+  // 1. 見出し
+  lines.push(`## dev-flow 終端サマリー — PR #${pr}`);
+  lines.push('');
+
+  // 2. Merge tier セクション
+  lines.push(`### Merge tier: ${mergeTier}`);
+  if (!mergeTierReasons || mergeTierReasons.length === 0) {
+    lines.push('- 理由記載なし');
+  } else {
+    for (const reason of mergeTierReasons) {
+      lines.push(`- ${reason}`);
+    }
+  }
+  lines.push('');
+
+  // 3. Goal Ledger セクション
+  lines.push('### Goal Ledger');
+  lines.push(`- gate_policy: ${gatePolicy}`);
+  lines.push(`- 収束: ${ledgerConverged ? '済' : '未収束'}`);
+
+  // blocking items
+  if (!blockingItems || blockingItems.length === 0) {
+    lines.push('- blocking item なし');
+  } else {
+    for (const item of blockingItems) {
+      const status = item.checked ? 'checked' : '未解消';
+      lines.push(`- [${status}] ${item.id} ${item.text}`);
+    }
+  }
+
+  // advisory items
+  if (!advisoryItems || advisoryItems.length === 0) {
+    lines.push('- advisory item なし');
+  } else {
+    for (const item of advisoryItems) {
+      const status = item.checked ? 'checked' : '未解消';
+      const escalateSuffix = item.escalate ? ' (ESCALATE)' : '';
+      lines.push(`- [${status}] ${item.id} ${item.text}${escalateSuffix}`);
+    }
+  }
+  lines.push('');
+
+  // 4. AC evidence セクション
+  lines.push('### Acceptance Criteria');
+  if (!acResults || acResults.length === 0) {
+    lines.push('AC 判定なし（evaluator 未実行 or AC 欠落）');
+  } else {
+    for (const ac of acResults) {
+      const satisfiedLabel = ac.satisfied ? 'satisfied' : '未達';
+      const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
+      const evidenceSuffix = ac.evidence ? ': ' + ac.evidence : '';
+      lines.push(`- AC#${ac.ac_index + 1}: ${satisfiedLabel}（${verifiedBy}）${evidenceSuffix}`);
+    }
+  }
+  lines.push('');
+
+  // 5. Security clearance セクション
+  lines.push('### Security clearance');
+  if (!securityClearance || securityClearance.length === 0) {
+    lines.push('- danger-grep clean（clearance 不要）');
+  } else {
+    for (const sc of securityClearance) {
+      const clearedLabel = sc.cleared ? 'cleared' : '未確認';
+      const evidenceSuffix = sc.evidence ? ': ' + sc.evidence : '';
+      lines.push(`- ${sc.danger_class}: ${clearedLabel}${evidenceSuffix}`);
+    }
+  }
+  if (dangerHits && dangerHits.length > 0) {
+    lines.push(`- 検出クラス: ${dangerHits.join(', ')}`);
+  }
+  lines.push('');
+
+  // 6. Plan concerns セクション（空なら省略）
+  if (planConcerns && planConcerns.length > 0) {
+    lines.push('### Plan 未解消 concerns');
+    for (const concern of planConcerns) {
+      lines.push(`- ${concern}`);
+    }
+    lines.push('');
+  }
+
+  // 7. 末尾
+  lines.push('---');
+  lines.push('*このコメントは dev-flow により自動生成されました。*');
+  lines.push(`<!-- dev-flow:${mergeTier} -->`);
+
+  return lines.join('\n');
+}

--- a/_lib/devflow-summary-format.sync.test.mjs
+++ b/_lib/devflow-summary-format.sync.test.mjs
@@ -1,0 +1,30 @@
+// Sync test: workflow inline コピーが canonical と byte 一致することを保証する。
+//
+// 背景: .claude/workflows/dev-flow.js は Claude Code の dynamic workflow ローダーが
+// 独自の VM コンテキストで評価する。ESM の import 文はそのコンテキストで使用できないため、
+// buildDevflowSummaryBody の関数本体を dev-flow.js に inline コピーしている。
+// このテストはその手動同期の漏れを CI で検出するための安全網である。
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+
+function extractFn(src, fnName) {
+  const m = src.match(new RegExp(`function ${fnName}\\([\\s\\S]*?\\n}`));
+  if (!m) throw new Error(`${fnName} が見つからない`);
+  return m[0].trim();
+}
+
+const fnName = 'buildDevflowSummaryBody';
+const canonicalSrc = readFileSync(join(repoRoot, '_lib/devflow-summary-format.mjs'), 'utf8');
+const canonical = extractFn(canonicalSrc, fnName);
+
+test(`.claude/workflows/dev-flow.js の inline ${fnName} が canonical と byte 一致`, () => {
+  const inlinedSrc = readFileSync(join(repoRoot, '.claude/workflows/dev-flow.js'), 'utf8');
+  const inlined = extractFn(inlinedSrc, fnName);
+  assert.equal(inlined, canonical, `.claude/workflows/dev-flow.js の inline コピー ${fnName} が _lib/devflow-summary-format.mjs と乖離している`);
+});

--- a/_lib/devflow-summary-format.test.mjs
+++ b/_lib/devflow-summary-format.test.mjs
@@ -373,3 +373,94 @@ test('箇条書きは「- 」始まりで「・」を使わない', () => {
   const bulletLines = lines.filter(l => l.trim().startsWith('- '));
   assert.ok(bulletLines.length > 0, '「- 」始まりの箇条書き行が存在する');
 });
+
+// ─── shape / testGreen / evalVerdict ─────────────────────────────────────────
+
+test('shape が渡されると「実行結果」セクションに shape 値を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    shape: 'standard',
+  });
+  assert.ok(body.includes('### 実行結果'), '実行結果セクションを含む');
+  assert.ok(body.includes('shape: standard'), 'shape 値を含む');
+});
+
+test('shape が null -> 「不明」を表示', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    shape: null,
+  });
+  assert.ok(body.includes('shape: 不明'), 'shape null -> 不明');
+});
+
+test('testGreen: true -> 「test_green: true」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    testGreen: true,
+  });
+  assert.ok(body.includes('test_green: true'), 'testGreen true を含む');
+});
+
+test('testGreen: false -> 「test_green: false」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    testGreen: false,
+  });
+  assert.ok(body.includes('test_green: false'), 'testGreen false を含む');
+});
+
+test('testGreen: null -> 「不明」を表示', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    testGreen: null,
+  });
+  assert.ok(body.includes('test_green: 不明'), 'testGreen null -> 不明');
+});
+
+test('evalVerdict: pass -> 「eval_verdict: pass」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    evalVerdict: 'pass',
+  });
+  assert.ok(body.includes('eval_verdict: pass'), 'evalVerdict pass を含む');
+});
+
+test('evalVerdict: null -> 「不明」を表示', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    evalVerdict: null,
+  });
+  assert.ok(body.includes('eval_verdict: 不明'), 'evalVerdict null -> 不明');
+});
+
+// ─── dimension (lane) 表示 ────────────────────────────────────────────────────
+
+test('blockingItems の行に dimension を [lane] 形式で含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'sec issue', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  assert.ok(body.includes('[security]'), 'dimension を [security] 形式で含む');
+});
+
+test('advisoryItems の行に dimension を [lane] 形式で含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'style concern', severity: 'minor', checked: false, dimension: 'style', escalate: false },
+    ],
+  });
+  assert.ok(body.includes('[style]'), 'dimension を [style] 形式で含む');
+});
+
+test('blockingItems の checked 項目に evidence を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'resolved', severity: 'major', checked: true, dimension: 'quality', evidence: 'test passed' },
+    ],
+  });
+  assert.ok(body.includes('test passed'), 'evidence を含む');
+});

--- a/_lib/devflow-summary-format.test.mjs
+++ b/_lib/devflow-summary-format.test.mjs
@@ -1,0 +1,375 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildDevflowSummaryBody } from './devflow-summary-format.mjs';
+
+// ─── 共通テストデータ ───────────────────────────────────────────────────────────
+
+const BASE_INPUT = {
+  pr: 42,
+  mergeTier: 'REVIEW',
+  mergeTierReasons: ['LLM judge advisory'],
+  gatePolicy: 'llm-major-advisory',
+  blockingItems: [],
+  advisoryItems: [],
+  ledgerConverged: true,
+  acResults: undefined,
+  securityClearance: undefined,
+  planConcerns: [],
+  dangerHits: [],
+};
+
+// ─── mergeTier ────────────────────────────────────────────────────────────────
+
+test('mergeTier=HOLD -> 見出しに HOLD を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'HOLD',
+    mergeTierReasons: ['danger hit detected'],
+  });
+  assert.ok(typeof body === 'string', 'string を返す');
+  assert.ok(body.includes('HOLD'), 'HOLD を含む');
+  assert.ok(body.includes('danger hit detected'), 'reason を含む');
+});
+
+test('mergeTier=REVIEW -> 見出しに REVIEW を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'REVIEW',
+    mergeTierReasons: ['advisory item present'],
+  });
+  assert.ok(body.includes('REVIEW'), 'REVIEW を含む');
+  assert.ok(body.includes('advisory item present'), 'reason を含む');
+});
+
+test('mergeTier=AUTO -> 見出しに AUTO を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'AUTO',
+    mergeTierReasons: [],
+  });
+  assert.ok(body.includes('AUTO'), 'AUTO を含む');
+});
+
+test('mergeTierReasons が空の場合は「理由記載なし」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'AUTO',
+    mergeTierReasons: [],
+  });
+  assert.ok(body.includes('理由記載なし'), 'reasons 空時の表示');
+});
+
+test('mergeTierReasons が複数件の場合はすべてを含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'HOLD',
+    mergeTierReasons: ['reason A', 'reason B', 'reason C'],
+  });
+  assert.ok(body.includes('reason A'), '1件目を含む');
+  assert.ok(body.includes('reason B'), '2件目を含む');
+  assert.ok(body.includes('reason C'), '3件目を含む');
+});
+
+// ─── Goal Ledger (blockingItems / advisoryItems) ──────────────────────────────
+
+test('blockingItems / advisoryItems 0件 -> 「blocking item なし」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [],
+    advisoryItems: [],
+  });
+  assert.ok(body.includes('blocking item なし'), 'blocking 空時の表示');
+  // undefined が文字列に展開されていないこと
+  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
+});
+
+test('blockingItems 複数件 -> 各 id/text を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'security unresolved', severity: 'critical', checked: false, dimension: 'security' },
+      { id: 'B2', text: 'AC unsatisfied', severity: 'major', checked: true, dimension: 'quality' },
+    ],
+  });
+  assert.ok(body.includes('B1'), 'B1 id を含む');
+  assert.ok(body.includes('security unresolved'), 'B1 text を含む');
+  assert.ok(body.includes('B2'), 'B2 id を含む');
+  assert.ok(body.includes('AC unsatisfied'), 'B2 text を含む');
+});
+
+test('blockingItems checked:true -> "checked" を表示', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'resolved item', severity: 'major', checked: true, dimension: 'quality' },
+    ],
+  });
+  assert.ok(body.includes('checked'), 'checked ラベルを含む');
+});
+
+test('blockingItems checked:false -> "未解消" を表示', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'unresolved item', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  assert.ok(body.includes('未解消'), '未解消ラベルを含む');
+});
+
+test('advisoryItems 複数件 -> 各 id/text を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'style concern', severity: 'minor', checked: false, dimension: 'style', escalate: false },
+      { id: 'A2', text: 'perf concern', severity: 'major', checked: false, dimension: 'perf', escalate: false },
+    ],
+  });
+  assert.ok(body.includes('A1'), 'A1 id を含む');
+  assert.ok(body.includes('style concern'), 'A1 text を含む');
+  assert.ok(body.includes('A2'), 'A2 id を含む');
+  assert.ok(body.includes('perf concern'), 'A2 text を含む');
+});
+
+test('advisoryItems escalate:true -> "(ESCALATE)" を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'urgent advisory', severity: 'major', checked: false, dimension: 'security', escalate: true },
+    ],
+  });
+  assert.ok(body.includes('ESCALATE'), 'ESCALATE を含む');
+});
+
+test('advisoryItems escalate:false -> "(ESCALATE)" を含まない', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'normal advisory', severity: 'minor', checked: false, dimension: 'style', escalate: false },
+    ],
+  });
+  assert.ok(!body.includes('ESCALATE'), 'ESCALATE を含まない');
+});
+
+test('gatePolicy と ledgerConverged を Goal Ledger セクションに含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    gatePolicy: 'llm-major-advisory',
+    ledgerConverged: false,
+  });
+  assert.ok(body.includes('llm-major-advisory'), 'gatePolicy を含む');
+  assert.ok(body.includes('未収束'), 'ledgerConverged false を示す');
+});
+
+test('ledgerConverged:true -> "済" を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    ledgerConverged: true,
+  });
+  assert.ok(body.includes('済'), 'converged 済を含む');
+});
+
+// ─── acResults ────────────────────────────────────────────────────────────────
+
+test('acResults が undefined -> 例外を投げず「AC 判定なし」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: undefined,
+  });
+  assert.ok(body.includes('AC 判定なし'), 'AC 判定なし を含む');
+  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
+});
+
+test('acResults が null -> 「AC 判定なし」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: null,
+  });
+  assert.ok(body.includes('AC 判定なし'), 'AC 判定なし を含む');
+});
+
+test('acResults が空配列 -> 「AC 判定なし」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [],
+  });
+  assert.ok(body.includes('AC 判定なし'), '空配列時も AC 判定なし を含む');
+});
+
+test('acResults 複数件（satisfied true/false 混在）-> 各 AC index と evidence を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'test passed', verified_by: 'evaluator' },
+      { ac_index: 1, satisfied: false, evidence: 'test failed', verified_by: 'evaluator' },
+      { ac_index: 2, satisfied: true, evidence: '', verified_by: undefined },
+    ],
+  });
+  assert.ok(body.includes('AC#1'), 'AC#1 を含む (0-indexed+1)');
+  assert.ok(body.includes('AC#2'), 'AC#2 を含む');
+  assert.ok(body.includes('AC#3'), 'AC#3 を含む');
+  assert.ok(body.includes('satisfied'), 'satisfied を含む');
+  assert.ok(body.includes('未達'), '未達を含む');
+  assert.ok(body.includes('test passed'), 'evidence を含む');
+  assert.ok(body.includes('test failed'), 'evidence を含む');
+  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
+});
+
+test('acResults の verified_by が undefined -> デフォルト "inspection" を表示', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'ok', verified_by: undefined },
+    ],
+  });
+  assert.ok(body.includes('inspection'), 'verified_by undefined -> inspection');
+});
+
+// ─── securityClearance ────────────────────────────────────────────────────────
+
+test('securityClearance が undefined -> 「danger-grep clean」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    securityClearance: undefined,
+  });
+  assert.ok(body.includes('danger-grep clean'), 'clearance なし -> clean');
+});
+
+test('securityClearance が空配列 -> 「danger-grep clean」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    securityClearance: [],
+  });
+  assert.ok(body.includes('danger-grep clean'), '空配列 -> clean');
+});
+
+test('securityClearance 複数件（cleared true/false）-> danger_class と cleared 状態を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    securityClearance: [
+      { danger_class: 'SQL_INJECTION', cleared: true, evidence: 'parameterized queries' },
+      { danger_class: 'XSS', cleared: false, evidence: '' },
+    ],
+  });
+  assert.ok(body.includes('SQL_INJECTION'), 'SQL_INJECTION を含む');
+  assert.ok(body.includes('cleared'), 'cleared を含む');
+  assert.ok(body.includes('XSS'), 'XSS を含む');
+  assert.ok(body.includes('未確認'), '未確認を含む');
+  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
+});
+
+test('dangerHits があれば検出クラス情報を補足表示', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    dangerHits: ['SQL_INJECTION', 'PATH_TRAVERSAL'],
+    securityClearance: [
+      { danger_class: 'SQL_INJECTION', cleared: true, evidence: 'ok' },
+    ],
+  });
+  assert.ok(body.includes('SQL_INJECTION'), 'dangerHits クラスを含む');
+});
+
+// ─── planConcerns ─────────────────────────────────────────────────────────────
+
+test('planConcerns あり -> concern 文字列を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    planConcerns: ['concern A', 'concern B'],
+  });
+  assert.ok(body.includes('concern A'), 'concern A を含む');
+  assert.ok(body.includes('concern B'), 'concern B を含む');
+});
+
+test('planConcerns 空 -> concern セクション見出しを含まない', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    planConcerns: [],
+  });
+  assert.ok(!body.includes('Plan 未解消 concerns'), 'plan concerns 見出しを含まない');
+});
+
+// ─── 末尾マーカー ──────────────────────────────────────────────────────────────
+
+test('末尾に安定マーカー <!-- dev-flow:TIER --> を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'HOLD',
+  });
+  assert.ok(body.includes('<!-- dev-flow:HOLD -->'), '安定マーカーを含む');
+});
+
+test('末尾に自動生成コメントを含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+  });
+  assert.ok(body.includes('dev-flow により自動生成'), '自動生成コメントを含む');
+});
+
+test('末尾に --- 区切り線を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+  });
+  assert.ok(body.includes('---'), '区切り線を含む');
+});
+
+// ─── 見出し ────────────────────────────────────────────────────────────────────
+
+test('見出しに PR 番号を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    pr: 99,
+  });
+  assert.ok(body.includes('PR #99'), 'PR 番号を含む');
+});
+
+// ─── 決定性 ───────────────────────────────────────────────────────────────────
+
+test('決定性: 同入力 -> 2回呼んで byte 完全一致', () => {
+  const input = {
+    pr: 77,
+    mergeTier: 'HOLD',
+    mergeTierReasons: ['danger hit', 'security unresolved'],
+    gatePolicy: 'llm-major-advisory',
+    blockingItems: [
+      { id: 'B1', text: 'critical issue', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+    advisoryItems: [
+      { id: 'A1', text: 'style', severity: 'minor', checked: false, dimension: 'style', escalate: false },
+      { id: 'A2', text: 'perf', severity: 'major', checked: true, dimension: 'perf', escalate: true },
+    ],
+    ledgerConverged: false,
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'passed', verified_by: 'evaluator' },
+      { ac_index: 1, satisfied: false, evidence: '', verified_by: undefined },
+    ],
+    securityClearance: [
+      { danger_class: 'SQL_INJECTION', cleared: true, evidence: 'parameterized' },
+    ],
+    planConcerns: ['concern 1', 'concern 2'],
+    dangerHits: ['SQL_INJECTION'],
+  };
+  const first = buildDevflowSummaryBody(input);
+  const second = buildDevflowSummaryBody(input);
+  assert.equal(first, second, '同入力 -> バイト完全一致');
+});
+
+// ─── 箇条書きスタイル ──────────────────────────────────────────────────────────
+
+test('箇条書きは「- 」始まりで「・」を使わない', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTierReasons: ['reason X'],
+    blockingItems: [
+      { id: 'B1', text: 'some item', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+    advisoryItems: [
+      { id: 'A1', text: 'advisory item', severity: 'minor', checked: false, dimension: 'style', escalate: false },
+    ],
+    planConcerns: ['plan concern'],
+  });
+  assert.ok(!body.includes('・'), '「・」を使わない');
+  // 箇条書き行の存在確認
+  const lines = body.split('\n');
+  const bulletLines = lines.filter(l => l.trim().startsWith('- '));
+  assert.ok(bulletLines.length > 0, '「- 」始まりの箇条書き行が存在する');
+});

--- a/_lib/devflow-summary-post.test.mjs
+++ b/_lib/devflow-summary-post.test.mjs
@@ -1,0 +1,239 @@
+// AC#4 (F4): VM カウントテスト（merge-tier-unsatisfied-ac.test.mjs と同型）
+// Merge tier phase 後に投稿用 dev-runner 呼び出しが 1 回発生すること、
+// および投稿失敗 stub でも workflow が正常 return することを検証する。
+//
+// このテストファイルは TDD red として作成された。
+// F2 実装（post-summary dev-runner 呼び出し）完了後に green になる。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const devFlowPath = join(repoRoot, '.claude/workflows/dev-flow.js');
+
+// ---- VM sandbox helpers（merge-tier-unsatisfied-ac.test.mjs の makeSandbox / runDevFlowCapture と同型）----
+
+/**
+ * post-summary 投稿検証専用の VM sandbox を組む。
+ * agentStub は opts.label / opts.agentType を見て phase 別に最小スキーマを返す。
+ * post-summary stub の戻り値は引数 postResult で切り替え可能。
+ * resolved 値（return object）を捕捉できるよう runner も同型にしている。
+ *
+ * @param {object} analyzeReq - analyze フェーズの agent が返す req オブジェクト（SHAPE を決定する）
+ * @param {object} postResult - post-summary stub が返すレスポンス（投稿成功/失敗を切り替え）
+ * @returns {{ ctx: vm.Context, getPostSummaryCallCount: () => number }}
+ */
+function makeSandbox(analyzeReq, postResult) {
+  // post-summary 呼び出しカウンタ
+  let postSummaryCallCount = 0;
+
+  // agent() stub: opts.label / opts.agentType を見て phase 別に最小スキーマを返す
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+
+    // Setup(worktree)
+    if (label === 'worktree') {
+      return { worktree: '/tmp/wt', branch: 'feature/issue-1' };
+    }
+    // Analyze: label が 'analyze' で始まる
+    if (label.startsWith('analyze')) {
+      return analyzeReq;
+    }
+    // Plan: dev-planner (plan#trivial / plan#standard / plan#N / replan 系)
+    if (agentType === 'dev-planner') {
+      return { summary: 'p', serial: [], parallel: [] };
+    }
+    // Plan reviewer
+    if (agentType === 'plan-reviewer') {
+      return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
+    }
+    // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
+    // → danger clean にして HOLD 要因を発生させない
+    if (label.startsWith('danger-grep')) {
+      return { hits: [] };
+    }
+    // Validate: test runner（label が 'test' で始まる）
+    if (label.startsWith('test')) {
+      return { tests: 'no_tests', green: true, summary: '' };
+    }
+    // Evaluate: evaluator stub（最小 pass レスポンス）
+    if (agentType === 'evaluator') {
+      return {
+        verdict: 'pass',
+        total: 100,
+        threshold: 80,
+        feedback: [],
+        feedback_level: 'implementation',
+        ac_results: [
+          { ac_index: 0, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+          { ac_index: 1, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+          { ac_index: 2, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+          { ac_index: 3, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+        ],
+        security_clearance: [],
+      };
+    }
+    // redgreen-verify は呼ばれないはずだが念のため（verified_by:'inspection' で回避）
+    if (agentType === 'dev-runner-haiku' && label.startsWith('redgreen')) {
+      return { red: false, green: false };
+    }
+    // PR: label が 'pr' で始まる
+    if (label.startsWith('pr')) {
+      return { pr_url: 'http://x', pr_number: 1, committed: true };
+    }
+    // Merge tier: changed-files
+    // → docs/test-only でないファイルを返す（AUTO 除外）
+    if (label === 'changed-files') {
+      return { files: ['src/foo.ts'] };
+    }
+    // post-summary: 呼び出しカウンタをインクリメントし postResult を返す
+    if (label === 'post-summary' && agentType === 'dev-runner') {
+      postSummaryCallCount += 1;
+      return postResult;
+    }
+    // implementer その他
+    if (agentType === 'implementer') {
+      return { status: 'DONE', task_id: 't', files: [], summary: '', concerns: [] };
+    }
+    // デフォルト
+    return null;
+  };
+
+  // parallel() stub: runImplement が parallel(par) を呼ぶため（par が空なら []）
+  const parallelStub = async (fns) => Promise.all((fns || []).map((f) => f()));
+
+  // pr-iterate stub: workflow() の呼び出し
+  const workflowStub = async () => ({ status: 'LGTM' });
+
+  // sandbox object（merge-tier-unsatisfied-ac.test.mjs と同一セット）
+  const sandbox = {
+    // workflow 制御関数
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: parallelStub,
+    workflow: workflowStub,
+    // 引数（ISSUE 解決用）
+    args: '1',
+    // JS 組み込み（merge-tier-unsatisfied-ac.test.mjs と同一セット）
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+
+  const ctx = vm.createContext(sandbox);
+  return {
+    ctx,
+    getPostSummaryCallCount: () => postSummaryCallCount,
+  };
+}
+
+/**
+ * dev-flow.js ソースを strip して async IIFE でラップし vm sandbox で実行する。
+ * merge-tier-unsatisfied-ac.test.mjs の runDevFlowCapture と同型：
+ * IIFE の **resolved 値（return object）を捕捉して返す**。
+ *
+ * @param {string} src - dev-flow.js の raw ソース
+ * @param {vm.Context} ctx - vm コンテキスト
+ * @returns {Promise<{ result: object|null, error: Error|null }>}
+ */
+async function runDevFlowCapture(src, ctx) {
+  const stripped = src
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = `(async () => {\n${stripped}\n})();`;
+
+  let caughtError = null;
+  let resolvedResult = null;
+  try {
+    const resultPromise = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/dev-flow.js' });
+    if (resultPromise && typeof resultPromise.then === 'function') {
+      resolvedResult = await resultPromise.catch((e) => {
+        caughtError = e;
+        return null;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return { result: resolvedResult, error: caughtError };
+}
+
+// ============================================================
+// テストケース
+// ============================================================
+
+// standard 経路に落ちる req（count=3, ac=4件, type='feat' → floor='standard'）
+// Merge tier phase まで到達させる
+const ANALYZE_REQ = {
+  summary: 's',
+  acceptance_criteria: ['a', 'b', 'c', 'd'],
+  issue_type: 'feat',
+  scope: 'src',
+  estimated_change_file_count: 3,
+  shape: 'standard',
+};
+
+const src = readFileSync(devFlowPath, 'utf8');
+
+test('[summary-post] Merge tier phase 後に post-summary dev-runner 呼び出しが 1 回発生すること', async () => {
+  const postResult = { posted: true, method: 'gh pr comment', url: 'http://x' };
+  const { ctx, getPostSummaryCallCount } = makeSandbox(ANALYZE_REQ, postResult);
+
+  const { result, error } = await runDevFlowCapture(src, ctx);
+
+  // ReferenceError / SyntaxError は構造的に壊れているので即 fail させる（sandbox クラッシュ検出）
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  // post-summary 呼び出しカウント === 1
+  assert.equal(
+    getPostSummaryCallCount(),
+    1,
+    `post-summary dev-runner の呼び出しは 1 回であるべきだが ${getPostSummaryCallCount()} 回だった`,
+  );
+});
+
+test('[summary-post] post-summary stub が posted:false を返しても result.merge_tier が正常 return されること', async () => {
+  // 投稿失敗をシミュレート: posted:false（F2 の「投稿失敗でも継続」仕様の回帰検出）
+  const postResult = { posted: false };
+  const { ctx } = makeSandbox(ANALYZE_REQ, postResult);
+
+  const { result, error } = await runDevFlowCapture(src, ctx);
+
+  // ReferenceError / SyntaxError は構造的に壊れているので即 fail させる（sandbox クラッシュ検出）
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  // result が null でなく、throw されていない
+  assert.ok(
+    result !== null && result !== undefined,
+    `投稿失敗（posted:false）でも workflow は return object を解決するべきだが null/undefined だった`,
+  );
+
+  // result.merge_tier が文字列（'HOLD'|'REVIEW'|'AUTO' のいずれか）として返ること
+  assert.ok(
+    typeof result?.merge_tier === 'string' && ['HOLD', 'REVIEW', 'AUTO'].includes(result.merge_tier),
+    `投稿失敗でも result.merge_tier は 'HOLD'|'REVIEW'|'AUTO' のいずれかであるべきだが '${result?.merge_tier}' だった`,
+  );
+});


### PR DESCRIPTION
## 概要

Closes #162

- \`_lib/devflow-summary-format.mjs\` に dev-flow 終端サマリー markdown を組む純関数 \`buildDevflowSummaryBody\` を追加
  - \`shape\`（re-floor 有無）/ \`testGreen\` / \`evalVerdict\` フィールドを含む実行結果セクション
  - blocking/advisory 項目に \`dimension\`（lane）と \`evidence\` を表示
- ユニットテスト（HOLD/REVIEW/AUTO tier・advisory 件数・acResults 欠落・securityClearance・planConcerns・shape/testGreen/evalVerdict・dimension/evidence・決定性 など 41 ケース）を追加
- \`.claude/workflows/dev-flow.js\` に inline コピーを追加し byte-sync test green
- Merge tier phase 後に post-summary dev-runner 呼び出しを実装（AC#3）
- 投稿失敗でも workflow が正常 return（AC#4）

## 動機

dev-flow の成果物（ledger 状態・AC 判定・security_clearance・merge tier と reasons）は従来 workflow の return object にしか出ず、merge 判断者が PR 上で evidence を確認できなかった。人間ゲートの品質確保のため、終端サマリーを PR コメントへ投稿するフォーマット関数と対応テストを用意する（issue #162 受入条件 AC#1〜AC#4）。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `_lib/devflow-summary-format.mjs` | `buildDevflowSummaryBody` 純関数（shape/testGreen/evalVerdict 追加、dimension/evidence 表示） |
| `_lib/devflow-summary-format.test.mjs` | フォーマット純関数のユニットテスト（41 ケース） |
| `_lib/devflow-summary-format.sync.test.mjs` | dev-flow.js inline コピーとの byte-sync テスト |
| `_lib/devflow-summary-post.test.mjs` | VM カウントテスト（AC#3・AC#4 相当） |
| `.claude/workflows/dev-flow.js` | inline コピー追加 + Merge tier 後の post-summary 呼び出し実装 |

## テスト計画

- [x] ユニットテスト: mergeTier 各値・reasons 空/複数・blockingItems checked/unchecked・advisoryItems escalate・acResults null/空/複数・securityClearance・dangerHits・planConcerns・shape/testGreen/evalVerdict・dimension/evidence・決定性（byte 一致）・箇条書きスタイル
- [x] sync テスト: `_lib/devflow-summary-format.mjs` と `dev-flow.js` inline コピーの byte 一致保証
- [x] VM テスト: Merge tier phase 後に post-summary dev-runner 呼び出しが 1 回発生すること（AC#3）
- [x] VM テスト: posted:false でも result.merge_tier が正常 return されること（AC#4）