### PR TITLE
✨ fix(dev-flow): Security floor の danger-grep が commit 前は空 diff になり常に clean を返す（三点 diff 盲点） (#170)

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -1054,7 +1054,7 @@ for (const seed of seedSecurityLedger()) {
 const risk = need(await agent(
   `cd ${WT} で作業。次を実行し **stdout の JSON 配列をそのまま** \`{"hits": <配列>}\` に包んで返せ`
   + `（判定や脚色をしない。空配列なら hits:[]）:\n`
-  + `bash ${WT}/_shared/scripts/diff-risk-classify.sh origin/${BASE}`,
+  + `bash ${WT}/_shared/scripts/diff-risk-classify.sh --working-tree origin/${BASE}`,
   { agentType: 'dev-runner-haiku', schema: RISK, label: 'danger-grep', phase: 'Security floor' },
 ), 'Security floor(danger-grep)')
 const dangerHits = [...new Set((risk.hits ?? []).map((h) => h.class))]
@@ -1065,11 +1065,11 @@ log(`danger-grep: ${dangerHits.length ? 'HIT ' + dangerHits.join(',') : 'clean'}
 // realized が null（agent drop／skip）のときは NaN を refloorShape へ渡し complex 安全弁へ流す。
 // ?? [] は取得失敗と空 diff（正常な 0 ファイル）を同じ 0 に潰すため使わない。
 // 注: この時点で implementer はコミットしていない（git add / commit 禁止）ため、
-//     三点 diff（origin/${BASE}...HEAD）は HEAD==origin/BASE で空を返す。
-//     代わりに git status --porcelain でステージ済み・未ステージを含む作業ツリー変更を取得する
-//     （declared-path-check と同方式）。
+//     --working-tree モード（worktree 変更を merge-base 基点の二点 diff + untracked -uall で分類）
+//     を使う。commit 後の三点 diff（origin/${BASE}...HEAD）は HEAD==origin/BASE で空を返すため
+//     Merge tier 側はフラグなしのまま（通常の三点 diff が正しい）。
 const realized = await agent(
-  `cd ${WT} で作業。\`git -C ${WT} status --porcelain\` を実行し、`
+  `cd ${WT} で作業。\`git -C ${WT} status --porcelain --untracked-files=all\` を実行し、`
   + `変更ファイル一覧を取得せよ（ステージ済み・未ステージどちらも含む）。`
   + `各行の先頭2文字はステータスコードなので除去し、パス部分のみ取り出すこと。`
   + `リネームは -> の右側（新ファイル名）を使え。空白行は除く。`
@@ -1093,7 +1093,7 @@ if (TRIVIAL && dangerHits.length > 0) {
 {
   const planAllTasks = [...(plan.serial ?? []), ...(plan.parallel ?? [])]
   const gitStat = await agent(
-    `cd ${WT} で作業。\`git -C ${WT} status --porcelain\` を実行し、`
+    `cd ${WT} で作業。\`git -C ${WT} status --porcelain --untracked-files=all\` を実行し、`
     + `変更ファイル一覧を取得せよ（ステージ・未ステージどちらも含む）。`
     + `各行の先頭2文字はステータスコードなので除去し、パス部分のみ取り出すこと。`
     + `リネームは -> の右側（新ファイル名）を使え。空白行は除く。`

--- a/_lib/workflow-load-smoke.test.mjs
+++ b/_lib/workflow-load-smoke.test.mjs
@@ -330,6 +330,15 @@ test('[W5] dev-flow.js: RISK schema と diff-risk-classify 呼び出しが存在
   const src = readFileSync(join(workflowDir, 'dev-flow.js'), 'utf8');
   assert.ok(src.includes('const RISK ='), 'RISK schema があること');
   assert.ok(src.includes('diff-risk-classify.sh'), 'diff-risk-classify.sh を呼ぶこと');
+  assert.ok(
+    src.includes('diff-risk-classify.sh --working-tree origin/${' + 'BASE}'),
+    'Security floor は --working-tree モードで呼ぶこと',
+  );
+  assert.ok(
+    src.includes('diff-risk-classify.sh origin/${' + 'BASE}'),
+    'Merge tier はフラグなし（commit 後三点 diff）で呼ぶこと',
+  );
+  assert.ok(src.includes('--untracked-files=all'), 'porcelain は -uall で untracked dir を展開すること');
 });
 
 test('[W5] dev-flow.js: 常時 SEC seed と runEval gate が存在', () => {

--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -1,4 +1,4 @@
-#\!/usr/bin/env bats
+#!/usr/bin/env bats
 # Tests for _shared/scripts/diff-risk-classify.sh
 #
 # Strategy: mktemp -d で隔離 git repo を作成し、各 danger class の陽性/陰性 diff を
@@ -336,4 +336,257 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"auth"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# [WT-1] working-tree POSITIVE: 未コミット (git add なし) の export function が hit する
+# AC#1: --working-tree フラグが worktree の変更を三点 diff ではなく status ベースで分類する
+# ---------------------------------------------------------------------------
+@test "WT-1 working-tree POSITIVE: 未コミット export function -> class public-api / severity critical が hit" {
+    mkdir -p "$REPO/src"
+    printf 'export function getUser(id) {\n  return db.find(id);\n}\n' \
+        > "$REPO/src/api.ts"
+    # git add も commit もしない
+    run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"public-api"'* ]]
+    [[ "$output" == *'"severity":"critical"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# [WT-2] working-tree staged-only: git add のみ (commit なし) の auth が hit する
+# ---------------------------------------------------------------------------
+@test "WT-2 working-tree staged-only: git add した requireAuth -> class auth が hit" {
+    mkdir -p "$REPO/src"
+    printf 'function requireAuth(user) { return user.isAuthenticated; }\n' \
+        > "$REPO/src/auth.ts"
+    git -C "$REPO" add "$REPO/src/auth.ts"
+    # commit はしない
+    run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"auth"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "auth")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# [WT-3] working-tree untracked dir: 未追跡サブディレクトリのファイルが hit する
+# porcelain -uall なしだと `?? newskill/` に折り畳まれ素通りする regression を pin
+# ---------------------------------------------------------------------------
+@test "WT-3 working-tree untracked dir: 未追跡サブディレクトリの export function -> class public-api が hit" {
+    mkdir -p "$REPO/newskill/scripts"
+    printf 'export function build(opts) {\n  return opts;\n}\n' \
+        > "$REPO/newskill/scripts/gen.ts"
+    # add も commit もしない
+    run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"public-api"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# [WT-4] working-tree clean: 変更ゼロの worktree で --working-tree -> [] かつ exit 0
+# ---------------------------------------------------------------------------
+@test "WT-4 working-tree clean: 変更なし -> 出力 [] かつ exit 0" {
+    # 何も変更しない
+    run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# [WT-5] working-tree BASE-ahead (merge-base pin):
+# main に fork 後の commit (auth-helper.ts) を積み、feature branch では
+# 無害な変更のみ。BASE=main HEAD を渡して --working-tree 実行 ->
+# auth-helper が含まれない (merge-base を取らず git diff $BASE 直接比較だと
+# 逆方向差分に混入する regression を pin)
+# ---------------------------------------------------------------------------
+@test "WT-5 working-tree BASE-ahead merge-base pin: main-ahead commit は --working-tree に混入しない" {
+    # fork 点 = 現在の BASE (empty commit)
+    FORK_SHA="$BASE"
+
+    # main branch に auth-helper.ts を追加コミット
+    mkdir -p "$REPO/other-pr"
+    printf 'function authHelper(token) { return token; }\n' \
+        > "$REPO/other-pr/auth-helper.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m "main: add auth-helper"
+    MAIN_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+    # feature branch を fork 点から切る
+    git -C "$REPO" checkout -q -b feature "$FORK_SHA"
+
+    # feature worktree に無害な未コミット変更のみ
+    printf 'const x = 1;\n' > "$REPO/notes-internal.js"
+
+    # BASE=MAIN_SHA で --working-tree 実行
+    run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$MAIN_SHA'"
+    [ "$status" -eq 0 ]
+    # auth-helper が含まれないこと
+    printf '%s\n' "$output" | jq -e '[.[] | .file | test("auth-helper")] | any | not'
+}
+
+# ---------------------------------------------------------------------------
+# [WT-6] default-mode 不変: --working-tree なしの通常モードは未コミット変更を無視する
+# AC#2: 三点 diff の従来挙動が壊れていないことを pin
+# ---------------------------------------------------------------------------
+@test "WT-6 default-mode 不変: 未コミット export function のみ -> フラグなしでは []" {
+    mkdir -p "$REPO/src"
+    printf 'export function getUser(id) {\n  return db.find(id);\n}\n' \
+        > "$REPO/src/api.ts"
+    # git add も commit もしない
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# [WT-7] working-tree NON-ASCII: 日本語ファイル名の未追跡ファイルが hit する
+# core.quotepath=false on status の pin
+# ---------------------------------------------------------------------------
+@test "WT-7 working-tree NON-ASCII: 日本語ファイル名の未追跡 export function -> public-api hit, file 値が正しい" {
+    mkdir -p "$REPO/src"
+    printf 'export function 認証処理(user) {\n  return user.id;\n}\n' \
+        > "$REPO/src/認証処理.ts"
+    # add も commit もしない
+    run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"public-api"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    # file 値が壊れたエスケープシーケンスでないことを確認
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")][0].file | test("認証処理\\.ts$")'
+}
+
+# ---------------------------------------------------------------------------
+# [STALE-1] stale-base fetch: file:// remote で stale な origin/main を fetch で最新化し
+# merged-auth が --working-tree 出力に含まれないことを pin (AC#7)
+# ---------------------------------------------------------------------------
+@test "STALE-1 stale-base fetch: fetch で origin/main を最新化 -> merged-auth は含まれない" {
+    # origin となる bare-ish リポジトリを作成
+    R="$(mktemp -d)"
+    git -C "$R" init -q -b main
+    git -C "$R" config user.email t@t
+    git -C "$R" config user.name t
+    git -C "$R" commit -q --allow-empty -m "init"
+    COMMIT_A="$(git -C "$R" rev-parse HEAD)"
+
+    # origin に merged-auth.ts を追加 (commit B)
+    mkdir -p "$R/merged"
+    printf 'function authHelper(token) { return token; }\n' > "$R/merged/merged-auth.ts"
+    git -C "$R" add -A
+    git -C "$R" commit -q -m "add merged-auth"
+    COMMIT_B="$(git -C "$R" rev-parse HEAD)"
+
+    # clone して feature branch を B から切る
+    C="$(mktemp -d)"
+    git clone -q "file://$R" "$C"
+    git -C "$C" config user.email t@t
+    git -C "$C" config user.name t
+    git -C "$C" checkout -q -b feature origin/main  # fork 点 = B
+
+    # origin/main を人工的に A に後退させ stale を作る
+    git -C "$C" update-ref refs/remotes/origin/main "$COMMIT_A"
+
+    # 無害な未コミット変更のみ
+    printf 'const x = 1;\n' > "$C/harmless.js"
+
+    # --working-tree origin/main で実行 (fetch が ref を B に戻し MB=B になる)
+    run bash -c "cd '$C' && '$SCRIPT' --working-tree origin/main"
+    [ "$status" -eq 0 ]
+    # merged-auth が含まれないこと
+    printf '%s\n' "$output" | jq -e '[.[] | .file | test("merged-auth")] | any | not'
+
+    rm -rf "$R" "$C"
+}
+
+# ---------------------------------------------------------------------------
+# [STALE-2] fetch 不能 fail-safe: remote 未設定リポジトリで origin/main ref だけ存在する場合
+# fetch 失敗は警告のみで分類続行 -> exit 0 かつ public-api hit
+# ---------------------------------------------------------------------------
+@test "STALE-2 fetch 不能 fail-safe: fetch 失敗でも exit 0 かつ分類は続行" {
+    # remote 未設定の隔離 repo (= $REPO) に origin/main ref を人工的に作成
+    git -C "$REPO" update-ref refs/remotes/origin/main "$BASE"
+
+    # 未コミットの export function を置く
+    mkdir -p "$REPO/src"
+    printf 'export function build(opts) {\n  return opts;\n}\n' \
+        > "$REPO/src/build.ts"
+
+    run bash -c "cd '$REPO' && '$SCRIPT' --working-tree origin/main"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# [CRYPTO-1] boundary NEGATIVE: PATH_TRAVERSAL 定数 (rsa 部分一致 false positive の解消 pin)
+# AC#5: crypto パターンから不要な rsa 部分一致が取り除かれていることを pin
+# ---------------------------------------------------------------------------
+@test "CRYPTO-1 boundary NEGATIVE: PATH_TRAVERSAL 定数 -> crypto は hit しない (rsa 部分一致 FP 解消 pin)" {
+    mkdir -p "$REPO/src"
+    printf 'const PATH_TRAVERSAL = "../";\n' > "$REPO/src/path.js"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# [CRYPTO-2] boundary POSITIVE: bare createHmac 呼び出し (crypto. prefix なし) が hit する
+# 両側 boundary 化により createHmac regression が救済されることを pin
+# ---------------------------------------------------------------------------
+@test "CRYPTO-2 boundary POSITIVE: bare createHmac 呼び出し -> class crypto が hit" {
+    mkdir -p "$REPO/src"
+    printf 'const mac = createHmac("sha256", key);\n' > "$REPO/src/sign.js"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"crypto"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "crypto")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# [CRYPTO-3] boundary POSITIVE: 単独トークン hmac が hit する
+# ---------------------------------------------------------------------------
+@test "CRYPTO-3 boundary POSITIVE: 単独トークン hmac -> class crypto が hit" {
+    mkdir -p "$REPO/src"
+    printf 'const sig = hmac(key, msg);\n' > "$REPO/src/token.js"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"crypto"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "crypto")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# [LIB-1] _lib 緩和: _lib/ 配下の export function は public-api に hit しない
+# AC#6: _lib パスは public-api クラスから除外されることを pin
+# ---------------------------------------------------------------------------
+@test "LIB-1 _lib 緩和: _lib/ 配下の export function -> public-api が含まれない" {
+    mkdir -p "$REPO/_lib"
+    printf 'export function makeSummary(data) {\n  return data.summary;\n}\n' \
+        > "$REPO/_lib/devflow-summary-format.test.mjs"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length == 0'
+}
+
+# ---------------------------------------------------------------------------
+# [LIB-2] _lib 緩和の狭さ: _lib/ 配下でも exec-sink は hit する
+# 緩和は public-api クラス限定であることを pin
+# ---------------------------------------------------------------------------
+@test "LIB-2 _lib 緩和の狭さ: _lib/ 配下の eval -> exec-sink は hit する (緩和は public-api 限定)" {
+    mkdir -p "$REPO/_lib"
+    printf 'function run(input) { return eval(input); }\n' \
+        > "$REPO/_lib/runner.mjs"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"exec-sink"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
 }

--- a/_shared/scripts/diff-risk-classify.sh
+++ b/_shared/scripts/diff-risk-classify.sh
@@ -6,7 +6,10 @@
 # to stdout. Called directly from workflow JS. Ungameable critical floor -- severity is
 # ALWAYS "critical" and cannot be lowered by any flag or input.
 #
-# Usage: diff-risk-classify.sh <base-ref>
+# Usage: diff-risk-classify.sh [--working-tree] <base-ref>
+#   --working-tree  Classify worktree changes (staged + untracked) instead of committed
+#                   diff. Uses merge-base($BASE, HEAD) as anchor so BASE-ahead commits
+#                   from other branches do not bleed into the result.
 # Output: JSON array of {file, class, severity:"critical"} objects (stdout)
 # Exit: 0 on success (even with empty hits), non-zero via die_json on error.
 
@@ -21,6 +24,22 @@ source "$SCRIPT_DIR/../../_lib/common.sh"
 # Args
 # ============================================================================
 
+MODE="default"
+
+# Parse flags; reject unknown -- flags so callers get a clear error instead of
+# silently treating them as a base-ref (dual-path/legacy fallback is prohibited).
+while [[ "${1:-}" == --* ]]; do
+    case "$1" in
+        --working-tree)
+            MODE="working-tree"
+            shift
+            ;;
+        *)
+            die_json "unknown flag: $1" 2
+            ;;
+    esac
+done
+
 BASE="${1:-}"
 if [[ -z "$BASE" ]]; then
     die_json "<base-ref> required" 2
@@ -33,6 +52,32 @@ require_git_repo
 # the script is invoked from a repo subdirectory (content-based classes would
 # silently return [] because the per-file diff pathspec missed the file).
 GIT_ROOT="$(git rev-parse --show-toplevel)"
+
+# ============================================================================
+# Stale-base fetch (both modes, before BASE validation)
+# ============================================================================
+# If BASE looks like origin/<branch>, attempt a best-effort fetch to refresh
+# the remote-tracking ref before validation. This prevents false-positives
+# caused by a stale (behind-actual) remote ref: a stale origin/main that
+# predates merged commits would make those merged changes appear as "new" in
+# the diff, producing spurious hits.
+#
+# Failure policy: fail-open (warn and continue), NOT fail-closed (die). A
+# fetch failure means we use the existing local ref which may be stale, but
+# that is strictly a false-positive direction, never a false-negative. The
+# security invariant (danger must block) is preserved even with a stale ref.
+if [[ "$BASE" =~ ^origin/(.+)$ ]]; then
+    _BRANCH="${BASH_REMATCH[1]}"
+    if git -C "$GIT_ROOT" remote get-url origin >/dev/null 2>&1; then
+        set +e
+        git -C "$GIT_ROOT" fetch --quiet origin "$_BRANCH" 2>/dev/null
+        _FETCH_RC=$?
+        set -e
+        if [[ "$_FETCH_RC" -ne 0 ]]; then
+            echo "warn: fetch origin failed; using local ref (may be stale)" >&2
+        fi
+    fi
+fi
 
 # Validate the base ref resolves to a commit.
 # Use set +e / RC capture instead of "if \!" to avoid history-expansion issues
@@ -49,7 +94,44 @@ fi
 # Collect changed files
 # ============================================================================
 
-files="$(git -C "$GIT_ROOT" -c core.quotepath=false diff --name-only "${BASE}...HEAD" 2>/dev/null)" || files=""
+if [[ "$MODE" == "working-tree" ]]; then
+    # working-tree mode: classify uncommitted changes (staged + untracked).
+    # Use merge-base($BASE, HEAD) as the diff anchor so that commits already
+    # present in BASE (from other merged PRs) do NOT bleed into the file list.
+    # This is the key invariant: even if BASE is ahead of the current branch's
+    # fork point, only changes introduced in this worktree are classified.
+    set +e
+    MB="$(git -C "$GIT_ROOT" merge-base "$BASE" HEAD 2>/dev/null)"
+    _MB_RC=$?
+    set -e
+    if [[ "$_MB_RC" -ne 0 || -z "$MB" ]]; then
+        die_json "no merge-base between $BASE and HEAD" 2
+    fi
+
+    # tracked: MB vs working-tree (two-point diff). This captures both staged
+    # and unstaged modifications to already-tracked files (files present in the
+    # working tree are diffed against MB regardless of index state).
+    tracked_files="$(git -C "$GIT_ROOT" -c core.quotepath=false diff --name-only "$MB" 2>/dev/null)" || tracked_files=""
+
+    # untracked: git status --porcelain --untracked-files=all lists ALL untracked
+    # files including those nested under untracked directories (without -uall,
+    # a new directory like "newskill/" would appear as a single "?? newskill/"
+    # entry, causing its contents to be silently skipped).
+    untracked_files="$(git -C "$GIT_ROOT" -c core.quotepath=false status --porcelain --untracked-files=all 2>/dev/null \
+        | grep '^??' | cut -c4-)" || untracked_files=""
+
+    # Build untracked set for per-file lookup (newline-separated paths).
+    UNTRACKED_SET="$untracked_files"
+
+    # Union of tracked + untracked, deduplicated.
+    files="$(printf '%s\n%s\n' "$tracked_files" "$untracked_files" | sort -u | grep -v '^$')" || files=""
+else
+    # Default mode: committed diff only (three-dot diff BASE...HEAD).
+    # 1 byte of existing behavior unchanged.
+    files="$(git -C "$GIT_ROOT" -c core.quotepath=false diff --name-only "${BASE}...HEAD" 2>/dev/null)" || files=""
+    UNTRACKED_SET=""
+    MB=""
+fi
 
 if [[ -z "$files" ]]; then
     printf '%s\n' "[]"
@@ -77,9 +159,46 @@ while IFS= read -r file; do
     fi
 
     # Get added lines for this file (^+ lines, excluding +++ header).
-    # Use git -C "$GIT_ROOT" so the pathspec is always root-relative and
-    # correctly resolves even when the script is run from a subdirectory.
-    added="$(git -C "$GIT_ROOT" -c core.quotepath=false diff "${BASE}...HEAD" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+    if [[ "$MODE" == "working-tree" ]]; then
+        # Check if this file is untracked (in UNTRACKED_SET).
+        # Strategy: if the path is in UNTRACKED_SET, treat the whole file content
+        # as "added". Otherwise use two-point diff from merge-base.
+        _is_untracked=false
+        if [[ -n "$UNTRACKED_SET" ]] && printf '%s\n' "$UNTRACKED_SET" | grep -qxF "$file"; then
+            _is_untracked=true
+        fi
+
+        if [[ "$_is_untracked" == true ]]; then
+            # Untracked file: entire content is new, use cat as added lines.
+            # Prefix with "+" so downstream grep patterns (which expect ^+ lines)
+            # still work uniformly.
+            if [[ -f "$GIT_ROOT/$file" ]]; then
+                added="$(sed 's/^/+/' < "$GIT_ROOT/$file" 2>/dev/null || true)"
+            else
+                added=""
+            fi
+        else
+            # Tracked file: two-point diff from merge-base vs working tree.
+            added="$(git -C "$GIT_ROOT" -c core.quotepath=false diff "$MB" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+            # If diff is empty but file is in worktree and untracked by git,
+            # fall back to cat (handles edge case where file was just created
+            # but not yet in the untracked list due to race conditions).
+            if [[ -z "$added" && -f "$GIT_ROOT/$file" ]]; then
+                set +e
+                git -C "$GIT_ROOT" ls-files --error-unmatch "$file" >/dev/null 2>&1
+                _ls_rc=$?
+                set -e
+                if [[ "$_ls_rc" -ne 0 ]]; then
+                    added="$(sed 's/^/+/' < "$GIT_ROOT/$file" 2>/dev/null || true)"
+                fi
+            fi
+        fi
+    else
+        # Default mode: three-dot diff (committed changes only).
+        # Use git -C "$GIT_ROOT" so the pathspec is always root-relative and
+        # correctly resolves even when the script is run from a subdirectory.
+        added="$(git -C "$GIT_ROOT" -c core.quotepath=false diff "${BASE}...HEAD" -- "$file" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+    fi
 
     # 1. auth
     if echo "$file" | grep -Eiq 'auth' || \
@@ -88,7 +207,14 @@ while IFS= read -r file; do
     fi
 
     # 2. crypto
-    if echo "$added" | grep -Eiq 'crypto\.|createHash|createCipher|bcrypt|scrypt|randomBytes|pbkdf2|hmac|aes-|rsa'; then
+    # P1: left-boundary group (tokens that are typically prefixed: createHmac included
+    #     here to rescue from the hmac both-sides boundary tightening below).
+    # P2: both-sides boundary group (hmac, rsa bare token to avoid PATH_TRAVERSAL FP),
+    #     plus aes- (hyphen already acts as right boundary).
+    # createHmac is in P1 (left boundary) to ensure `createHmac(` is caught even after
+    # bare `hmac` is boundary-tightened in P2.
+    if echo "$added" | grep -Eiq '(^|[^[:alnum:]_])(crypto\.|createHash|createCipher|createHmac|bcrypt|scrypt|randomBytes|pbkdf2)' || \
+       echo "$added" | grep -Eiq '(^|[^[:alnum:]_])(hmac|rsa)([^[:alnum:]_]|$)|(^|[^[:alnum:]_])aes-'; then
         hits="${hits}${file}"$'\t'"crypto"$'\n'
     fi
 
@@ -106,7 +232,11 @@ while IFS= read -r file; do
     fi
 
     # 5. public-api
-    if echo "$added" | grep -Eiq 'export (default |async )?(function|class|const)|module\.exports|@(Get|Post|Put|Delete|Patch)\(|openapi|paths:'; then
+    # _lib/ 配下は repo 内部専用ライブラリで外部 API surface ではないため public-api critical
+    # の構造的 false positive を除外する。緩和はこのクラス限定（他 6 クラスは _lib でも従来どおり判定する）。
+    if echo "$file" | grep -Eq '(^|/)_lib/'; then
+        : # _lib is repo-internal library; skip public-api check only
+    elif echo "$added" | grep -Eiq 'export (default |async )?(function|class|const)|module\.exports|@(Get|Post|Put|Delete|Patch)\(|openapi|paths:'; then
         hits="${hits}${file}"$'\t'"public-api"$'\n'
     fi
 


### PR DESCRIPTION
## 概要

Closes #170

- `diff-risk-classify.sh` に `--working-tree` モードを追加し、commit 前のワークツリー変更を正確に分類できるようにした
- dev-flow の Security floor（danger-grep）を `--working-tree` モードで呼び出すよう修正（commit 前は三点 diff が空を返すため常に clean になる盲点を解消）
- `git status --porcelain` を `--untracked-files=all` 付きに統一し、untracked ディレクトリ配下のファイルも漏れなく列挙
- origin/<branch> の stale ref を防ぐ best-effort fetch を追加（fail-open ポリシー）
- smoke テストおよび bats テストにアサーションを追加し動作を保証

## 動機

dev-flow の implementer は `git commit` 禁止のため、Security floor が呼ばれる時点では HEAD == origin/BASE。
従来の `diff-risk-classify.sh origin/${BASE}` は三点 diff（`origin/${BASE}...HEAD`）を使っており、
この状態では空 diff を返し danger-grep が常に clean を報告してしまうという根本的な欠陥があった。

`--working-tree` モードは merge-base($BASE, HEAD) を起点にした二点 diff（tracked files）と
`git status --porcelain --untracked-files=all`（untracked files）を組み合わせることで、
未コミット状態でも実際の変更ファイルを正確に取得・分類する。

Merge tier 側はコミット後に三点 diff を使うため、フラグなしのままが正しい挙動。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `_shared/scripts/diff-risk-classify.sh` | `--working-tree` フラグ追加、merge-base 二点 diff + untracked -uall 実装、stale fetch 追加、不明フラグは即 `die_json` |
| `.claude/workflows/dev-flow.js` | Security floor の呼び出しを `--working-tree origin/${BASE}` に変更、`git status --porcelain` を `--untracked-files=all` 付きに修正 |
| `_lib/workflow-load-smoke.test.mjs` | `--working-tree` 呼び出し・フラグなし Merge tier 呼び出し・`-uall` の存在を検証するアサーション追加 |
| `_shared/scripts/diff-risk-classify.bats` | `--working-tree` モードの動作を検証する bats テスト追加 |

## テスト計画

- [x] `bats _shared/scripts/diff-risk-classify.bats` — 全ケース pass
- [x] `node --test _lib/workflow-load-smoke.test.mjs` — smoke テスト pass
- [x] `bash tests/run-all-bats.sh` — 全 bats 一括 pass