### PR TITLE
feat(dev-flow): telemetry 記録を workflow から決定論実行 — journal.sh 呼び出しの配線

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -491,6 +491,9 @@ const POST_RESULT = {
   },
 }
 
+// JOURNAL_RESULT schema（dev-runner-haiku 経由の journal.sh log 記録結果）
+const JOURNAL_RESULT = { type: 'object', required: ['logged'], properties: { logged: { type: 'boolean' }, summary: { type: 'string' } } }
+
 function buildDevflowSummaryBody({
   pr,
   mergeTier,
@@ -898,6 +901,7 @@ let plan = null
 let planVerdict = null
 const planSeen = {}        // topic → { finding, count }（findings 累積 & stuck 検出。issue #123）
 let planConcerns = []      // 収束時に残った未解消 findings（Evaluate の focus_areas へ）
+let planIters = 0            // plan iteration カウンタ（telemetry 用）
 if (TRIVIAL) {
   plan = need(await agent(
     `cd ${WT} で作業。issue 要件に基づき実装計画を立てよ。\n`
@@ -907,6 +911,7 @@ if (TRIVIAL) {
     { agentType: 'dev-planner', model: QUALITY_MODEL, schema: PLAN, label: 'plan#trivial', phase: 'Plan' },
   ), 'Plan(planner#trivial)')
   plan = applyDisjoint(plan, 'plan#trivial')
+  planIters = 1
   log('triviality gate: plan-review ループを skip(reviewer 0 回起動)')
 } else if (PLAN_SOLO) {
   plan = need(await agent(
@@ -917,9 +922,11 @@ if (TRIVIAL) {
     { agentType: 'dev-planner', model: QUALITY_MODEL, schema: PLAN, label: 'plan#standard', phase: 'Plan' },
   ), 'Plan(planner#standard)')
   plan = applyDisjoint(plan, 'plan#standard')
+  planIters = 1
   log('standard 経路: plan 1発（plan-reviewer 0 回起動）')
 } else {
 for (let i = 1; i <= PLAN_MAX; i++) {
+  planIters = i
   const prior = Object.values(planSeen).map((s) => s.finding)   // 前 iteration までの累積 findings
   plan = need(await agent(
     `cd ${WT} で作業。issue 要件と${prior.length ? 'レビュー指摘' : '初回計画'}に基づき実装計画を立てよ。\n`
@@ -1125,6 +1132,7 @@ if (TRIVIAL && dangerHits.length > 0) {
 // 初回は implement で出た concerns / 未解消 BLOCKED を focus_areas として重点監査させる。
 // ============================================================
 let evalResult = null
+let evalIters = 0            // eval iteration カウンタ（telemetry 用）
 let unsatisfiedAc = false
 if (runEval) {
 phase('Evaluate')
@@ -1146,6 +1154,7 @@ for (const [i, c] of concerns.entries()) {
 log(`ledger 初期化: blocking ${blockingItems(ledger).length} / advisory ${advisoryItems(ledger).length} 件`)
 const evalSeen = {}        // topic → { feedback, count }（feedback 累積 & stuck 検出。issue #125）
 for (let i = 1; i <= EVAL_PASSES; i++) {
+  evalIters = i
   const priorFeedback = Object.values(evalSeen).map((s) => s.feedback)   // 前 iteration までの累積 feedback
   const ev = need(await agent(
     `cd ${WT} で作業。実装品質を独立評価せよ（base は origin/${BASE}。`
@@ -1371,6 +1380,40 @@ const summaryPost = await agent(
 if (!summaryPost?.posted) {
   log(`⚠️ post-summary の投稿に失敗しました（posted=${summaryPost?.posted ?? 'null'}）。ワークフローは継続します。`)
 }
+
+// ============================================================
+// journal-log: dev-flow 完走の telemetry を journal.sh log に記録する（W6）。
+// 失敗は log 警告のみで workflow は継続（telemetry 欠損 > ワークフロー中断）。
+// need() で包まない — null 容認が必須。
+// ============================================================
+const journalCmd = [
+  `bash ${WT}/skill-retrospective/scripts/journal.sh log dev-flow success`,
+  `--issue ${ISSUE}`,
+  `--merge-tier ${mergeTier.tier}`,
+  `--gate-policy ${GATE_POLICY}`,
+  `--danger-hits '${JSON.stringify(dangerHitsFinal)}'`,
+  `--shape ${EFFECTIVE_SHAPE}`,
+  `--shape-refloored ${refloor.refloored}`,
+  `--plan-iter ${planIters}`,
+  `--eval-iter ${evalIters}`,
+  ...(evalResult?.verdict ? [`--eval-verdict ${evalResult.verdict}`] : []),
+  ...(iterate?.status ? [`--iterate-status ${iterate.status}`] : []),
+].join(' ')
+const journalPost = await agent(
+  `## Objective\ndev-flow 完走の telemetry を journal に記録する。\n\n`
+  + `## Instructions\n`
+  + `次のコマンドをそのまま実行せよ: \`${journalCmd}\`\n`
+  + `exit 0 なら logged:true、失敗しても throw せず logged:false を返すこと。\n`
+  + `\n## Output format\n{ "logged": boolean, "summary": string }\n`
+  + `\n## Tools\n使用可: Bash のみ\n`
+  + `\n## Boundary\n~/.claude/journal 以外のファイルを変更しない。git 操作禁止。\n`
+  + `\n## Token cap\n100 語以内で完結すること。`,
+  { agentType: 'dev-runner-haiku', schema: JOURNAL_RESULT, label: 'journal-log', phase: 'Merge tier' },
+)
+if (!journalPost?.logged) {
+  log(`⚠️ journal-log の記録に失敗しました（logged=${journalPost?.logged ?? 'null'}）。ワークフローは継続します。`)
+}
+
 
 
 return {

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -164,6 +164,15 @@ const POST_RESULT = {
   },
 }
 
+const JOURNAL_RESULT = {
+  type: 'object',
+  required: ['logged'],
+  properties: {
+    logged: { type: 'boolean' },
+    summary: { type: 'string' },
+  },
+}
+
 const REVIEW = {
   type: 'object',
   required: ['decision', 'issues', 'summary'],
@@ -478,6 +487,21 @@ const summaryPost = await agent(
 )
 if (!summaryPost?.posted) {
   log(`⚠️ post-summary の投稿に失敗しました（posted=${summaryPost?.posted ?? 'null'}）。ワークフローは継続します。`)
+}
+
+const journalCmd = `bash ~/.claude/skills/skill-retrospective/scripts/journal.sh log pr-iterate success --iterate-status ${status} --args "pr=${PR}"`
+const journalPost = await agent(
+  `## Objective\npr-iterate 終端 status の telemetry を journal に記録する。\n\n`
+  + `## Instructions\n次のコマンドをそのまま実行せよ。exit 0 なら logged:true、失敗時も throw せず logged:false を返すこと。\n`
+  + `\`\`\`\n${journalCmd}\n\`\`\`\n\n`
+  + `## Output format\n{ "logged": boolean, "summary": string }\n\n`
+  + `## Tools\n- 使用可: Bash のみ\n- 禁止: Write, Edit, git 操作\n\n`
+  + `## Boundary\n~/.claude/journal 以外のファイル変更禁止。git 操作禁止。\n\n`
+  + `## Token cap\n100 語以内で完結すること。`,
+  { agentType: 'dev-runner-haiku', schema: JOURNAL_RESULT, label: 'journal-log', phase: 'Iterate' },
+)
+if (!journalPost?.logged) {
+  log(`⚠️ journal-log の記録に失敗しました（logged=${journalPost?.logged ?? 'null'}）。ワークフローは継続します。`)
 }
 
 return {

--- a/_lib/devflow-journal-log.test.mjs
+++ b/_lib/devflow-journal-log.test.mjs
@@ -1,0 +1,264 @@
+// AC#1 / AC#3 (F2): journal-log VM カウントテスト
+// Merge tier phase 末尾に journal.sh log の dev-runner-haiku 呼び出しが 1 回発生すること、
+// および logged:false stub でも workflow が正常 return することを検証する。
+//
+// このテストファイルは TDD red として作成された。
+// F2 実装（journal-log dev-runner-haiku 呼び出し）完了後に green になる。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const devFlowPath = join(repoRoot, '.claude/workflows/dev-flow.js');
+
+// ---- VM sandbox helpers（devflow-summary-post.test.mjs の makeSandbox / runDevFlowCapture と同型）----
+
+/**
+ * journal-log 呼び出し検証専用の VM sandbox を組む。
+ * agentStub は opts.label / opts.agentType を見て phase 別に最小スキーマを返す。
+ * journal-log stub の戻り値は引数 journalResult で切り替え可能。
+ * resolved 値（return object）を捕捉できるよう runner も同型にしている。
+ *
+ * @param {object} analyzeReq - analyze フェーズの agent が返す req オブジェクト（SHAPE を決定する）
+ * @param {object} journalResult - journal-log stub が返すレスポンス（ログ成功/失敗を切り替え）
+ * @returns {{ ctx: vm.Context, getJournalCallCount: () => number, getJournalPrompts: () => string[] }}
+ */
+function makeSandbox(analyzeReq, journalResult) {
+  // journal-log 呼び出しカウンタ
+  let journalCallCount = 0;
+  const journalPrompts = [];
+
+  // agent() stub: opts.label / opts.agentType を見て phase 別に最小スキーマを返す
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+
+    // Setup(worktree)
+    if (label === 'worktree') {
+      return { worktree: '/tmp/wt', branch: 'feature/issue-1' };
+    }
+    // Analyze: label が 'analyze' で始まる
+    if (label.startsWith('analyze')) {
+      return analyzeReq;
+    }
+    // Plan: dev-planner (plan#trivial / plan#standard / plan#N / replan 系)
+    if (agentType === 'dev-planner') {
+      return { summary: 'p', serial: [], parallel: [] };
+    }
+    // Plan reviewer
+    if (agentType === 'plan-reviewer') {
+      return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
+    }
+    // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
+    // → danger clean にして HOLD 要因を発生させない
+    if (label.startsWith('danger-grep')) {
+      return { hits: [] };
+    }
+    // Validate: test runner（label が 'test' で始まる）
+    if (label.startsWith('test')) {
+      return { tests: 'no_tests', green: true, summary: '' };
+    }
+    // Evaluate: evaluator stub（最小 pass レスポンス）
+    if (agentType === 'evaluator') {
+      return {
+        verdict: 'pass',
+        total: 100,
+        threshold: 80,
+        feedback: [],
+        feedback_level: 'implementation',
+        ac_results: [
+          { ac_index: 0, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+          { ac_index: 1, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+          { ac_index: 2, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+          { ac_index: 3, satisfied: true, verified_by: 'inspection', evidence: 'ok' },
+        ],
+        security_clearance: [],
+      };
+    }
+    // redgreen-verify は呼ばれないはずだが念のため（verified_by:'inspection' で回避）
+    if (agentType === 'dev-runner-haiku' && label.startsWith('redgreen')) {
+      return { red: false, green: false };
+    }
+    // PR: label が 'pr' で始まる
+    if (label.startsWith('pr')) {
+      return { pr_url: 'http://x', pr_number: 1, committed: true };
+    }
+    // Merge tier: changed-files
+    // → docs/test-only でないファイルを返す（AUTO 除外）
+    if (label === 'changed-files') {
+      return { files: ['src/foo.ts'] };
+    }
+    // post-summary: posted:true 固定
+    if (label === 'post-summary' && agentType === 'dev-runner') {
+      return { posted: true, method: 'gh pr comment', url: 'http://x' };
+    }
+    // journal-log: 呼び出しカウンタをインクリメントし journalResult を返す
+    if (label === 'journal-log' && agentType === 'dev-runner-haiku') {
+      journalCallCount += 1;
+      journalPrompts.push(prompt);
+      return journalResult;
+    }
+    // implementer その他
+    if (agentType === 'implementer') {
+      return { status: 'DONE', task_id: 't', files: [], summary: '', concerns: [] };
+    }
+    // デフォルト: 未知の label は null を返す（journal-log が need() で包まれないことを前提）
+    return null;
+  };
+
+  // parallel() stub: runImplement が parallel(par) を呼ぶため（par が空なら []）
+  const parallelStub = async (fns) => Promise.all((fns || []).map((f) => f()));
+
+  // pr-iterate stub: workflow() の呼び出し
+  const workflowStub = async () => ({ status: 'LGTM' });
+
+  // sandbox object（devflow-summary-post.test.mjs と同一セット）
+  const sandbox = {
+    // workflow 制御関数
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: parallelStub,
+    workflow: workflowStub,
+    // 引数（ISSUE 解決用）
+    args: '1',
+    // JS 組み込み（devflow-summary-post.test.mjs と同一セット）
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+
+  const ctx = vm.createContext(sandbox);
+  return {
+    ctx,
+    getJournalCallCount: () => journalCallCount,
+    getJournalPrompts: () => journalPrompts,
+  };
+}
+
+/**
+ * dev-flow.js ソースを strip して async IIFE でラップし vm sandbox で実行する。
+ * devflow-summary-post.test.mjs の runDevFlowCapture と同型：
+ * IIFE の **resolved 値（return object）を捕捉して返す**。
+ *
+ * @param {string} src - dev-flow.js の raw ソース
+ * @param {vm.Context} ctx - vm コンテキスト
+ * @returns {Promise<{ result: object|null, error: Error|null }>}
+ */
+async function runDevFlowCapture(src, ctx) {
+  const stripped = src
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = `(async () => {\n${stripped}\n})();`;
+
+  let caughtError = null;
+  let resolvedResult = null;
+  try {
+    const resultPromise = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/dev-flow.js' });
+    if (resultPromise && typeof resultPromise.then === 'function') {
+      resolvedResult = await resultPromise.catch((e) => {
+        caughtError = e;
+        return null;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return { result: resolvedResult, error: caughtError };
+}
+
+// ============================================================
+// テストケース
+// ============================================================
+
+// standard 経路に落ちる req（count=3, ac=4件, type='feat' → floor='standard'）
+// Merge tier phase まで到達させる
+const ANALYZE_REQ = {
+  summary: 's',
+  acceptance_criteria: ['a', 'b', 'c', 'd'],
+  issue_type: 'feat',
+  scope: 'src',
+  estimated_change_file_count: 3,
+  shape: 'standard',
+};
+
+const src = readFileSync(devFlowPath, 'utf8');
+
+test('[journal-log] AC#1: Merge tier phase 後に journal-log dev-runner-haiku 呼び出しが 1 回発生し、prompt に必須フラグが含まれること', async () => {
+  const journalResult = { logged: true, summary: 'ok' };
+  const { ctx, getJournalCallCount, getJournalPrompts } = makeSandbox(ANALYZE_REQ, journalResult);
+
+  const { result, error } = await runDevFlowCapture(src, ctx);
+
+  // ReferenceError / SyntaxError は構造的に壊れているので即 fail させる（sandbox クラッシュ検出）
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  // journal-log 呼び出しカウント === 1
+  assert.equal(
+    getJournalCallCount(),
+    1,
+    `journal-log dev-runner-haiku の呼び出しは 1 回であるべきだが ${getJournalCallCount()} 回だった`,
+  );
+
+  // 捕捉した prompt に必須フラグが含まれること
+  const capturedPrompt = getJournalPrompts()[0] ?? '';
+  const requiredFlags = [
+    '--merge-tier',
+    '--gate-policy',
+    '--danger-hits',
+    '--shape ',
+    '--shape-refloored',
+    '--plan-iter',
+    '--eval-iter',
+  ];
+  for (const flag of requiredFlags) {
+    assert.ok(
+      capturedPrompt.includes(flag),
+      `journal-log prompt に '${flag}' が含まれるべきだが含まれていなかった。prompt:\n${capturedPrompt}`,
+    );
+  }
+});
+
+test('[journal-log] AC#3: journal-log stub が logged:false を返しても result.merge_tier が正常 return されること', async () => {
+  // ログ失敗をシミュレート: logged:false（「記録失敗でも workflow return 成功」仕様の回帰検出）
+  const journalResult = { logged: false, summary: 'failed' };
+  const { ctx } = makeSandbox(ANALYZE_REQ, journalResult);
+
+  const { result, error } = await runDevFlowCapture(src, ctx);
+
+  // ReferenceError / SyntaxError は構造的に壊れているので即 fail させる（sandbox クラッシュ検出）
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`dev-flow.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  // result が null でなく、throw されていない
+  assert.ok(
+    result !== null && result !== undefined,
+    `ログ失敗（logged:false）でも workflow は return object を解決するべきだが null/undefined だった`,
+  );
+
+  // result.merge_tier が文字列（'HOLD'|'REVIEW'|'AUTO' のいずれか）として返ること
+  assert.ok(
+    typeof result?.merge_tier === 'string' && ['HOLD', 'REVIEW', 'AUTO'].includes(result.merge_tier),
+    `ログ失敗でも result.merge_tier は 'HOLD'|'REVIEW'|'AUTO' のいずれかであるべきだが '${result?.merge_tier}' だった`,
+  );
+});

--- a/_lib/priterate-journal-log.test.mjs
+++ b/_lib/priterate-journal-log.test.mjs
@@ -1,0 +1,166 @@
+// F3: pr-iterate 終端の journal-log 呼び出し検証テスト（TDD）
+// 終端サマリー投稿の後・return の前に journal-log (dev-runner-haiku) が
+// 1 回呼び出されること、および logged:false でも正常 return することを検証する。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const prIteratePath = join(repoRoot, '.claude/workflows/pr-iterate.js');
+
+function makeSandbox(journalResult) {
+  let journalCallCount = 0;
+  let capturedPrompt = null;
+
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+
+    // pr-reviewer: 1 round で LGTM へ
+    if (agentType === 'pr-reviewer') {
+      return { decision: 'approve', issues: [], summary: 'ok' };
+    }
+
+    // CI チェック: agentType 'dev-runner' かつ prompt に 'check-ci.sh' を含む
+    if (agentType === 'dev-runner' && typeof prompt === 'string' && prompt.includes('check-ci.sh')) {
+      return { status: 'passed', failed_checks: [] };
+    }
+
+    // 投稿系: label が 'post-' で始まる
+    if (label.startsWith('post-')) {
+      return { posted: true, method: 'gh', url: 'http://x' };
+    }
+
+    // journal-log: label === 'journal-log' && agentType === 'dev-runner-haiku'
+    if (label === 'journal-log' && agentType === 'dev-runner-haiku') {
+      journalCallCount += 1;
+      capturedPrompt = typeof prompt === 'string' ? prompt : null;
+      return journalResult;
+    }
+
+    // デフォルト
+    return null;
+  };
+
+  // parallel() stub（pr-iterate では不要だが入れても無害）
+  const parallelStub = async (fns) => Promise.all((fns || []).map((f) => f()));
+
+  // workflow() stub（pr-iterate では不要だが入れても無害）
+  const workflowStub = async () => ({ status: 'lgtm' });
+
+  const sandbox = {
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: parallelStub,
+    workflow: workflowStub,
+    args: '5',
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+
+  const ctx = vm.createContext(sandbox);
+  return {
+    ctx,
+    getJournalCallCount: () => journalCallCount,
+    getCapturedPrompt: () => capturedPrompt,
+  };
+}
+
+async function runPrIterateCapture(src, ctx) {
+  const stripped = src
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = `(async () => {\n${stripped}\n})();`;
+
+  let caughtError = null;
+  let resolvedResult = null;
+  try {
+    const resultPromise = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/pr-iterate.js' });
+    if (resultPromise && typeof resultPromise.then === 'function') {
+      resolvedResult = await resultPromise.catch((e) => {
+        caughtError = e;
+        return null;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return { result: resolvedResult, error: caughtError };
+}
+
+const src = readFileSync(prIteratePath, 'utf8');
+
+test('[journal-log] journalResult={logged:true} で完走 → journal-log 呼び出し 1 回、prompt に正しいコマンドが含まれ、result.status === lgtm', async () => {
+  const journalResult = { logged: true, summary: 'ok' };
+  const { ctx, getJournalCallCount, getCapturedPrompt } = makeSandbox(journalResult);
+
+  const { result, error } = await runPrIterateCapture(src, ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`pr-iterate.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  assert.equal(
+    getJournalCallCount(),
+    1,
+    `journal-log dev-runner-haiku の呼び出しは 1 回であるべきだが ${getJournalCallCount()} 回だった`,
+  );
+
+  const capturedPrompt = getCapturedPrompt();
+  assert.ok(
+    typeof capturedPrompt === 'string' && capturedPrompt.includes('--iterate-status'),
+    `journal-log prompt に '--iterate-status' が含まれるべきだが含まれない。prompt=${capturedPrompt}`,
+  );
+
+  assert.ok(
+    typeof capturedPrompt === 'string' && capturedPrompt.includes('journal.sh log pr-iterate'),
+    `journal-log prompt に 'journal.sh log pr-iterate' が含まれるべきだが含まれない。prompt=${capturedPrompt}`,
+  );
+
+  assert.equal(
+    result?.status,
+    'lgtm',
+    `result.status は 'lgtm' であるべきだが '${result?.status}' だった`,
+  );
+});
+
+test('[journal-log] journalResult={logged:false} → result が non-null で result.status === lgtm（記録失敗でも正常 return）', async () => {
+  const journalResult = { logged: false, summary: 'failed' };
+  const { ctx } = makeSandbox(journalResult);
+
+  const { result, error } = await runPrIterateCapture(src, ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`pr-iterate.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  assert.ok(
+    result !== null && result !== undefined,
+    `journal 記録失敗（logged:false）でも workflow は return object を解決するべきだが null/undefined だった`,
+  );
+
+  assert.equal(
+    result?.status,
+    'lgtm',
+    `journal 記録失敗でも result.status は 'lgtm' であるべきだが '${result?.status}' だった`,
+  );
+});

--- a/skill-retrospective/scripts/journal.bats
+++ b/skill-retrospective/scripts/journal.bats
@@ -78,3 +78,137 @@ latest_entry() {
     [ "$has_gate_policy" = "false" ]
     [ "$has_danger_hits" = "false" ]
 }
+
+# ---------------------------------------------------------------------------
+# Test 4: All 6 new telemetry fields recorded with correct types
+# ---------------------------------------------------------------------------
+@test "all 6 new telemetry fields recorded with correct types" {
+    run "$SCRIPT" log dev-flow success \
+        --merge-tier REVIEW \
+        --shape standard \
+        --shape-refloored false \
+        --eval-verdict pass \
+        --iterate-status lgtm \
+        --plan-iter 2 \
+        --eval-iter 1
+    [ "$status" -eq 0 ]
+
+    entry_file=$(latest_entry)
+    [ -n "$entry_file" ]
+
+    shape=$(jq -r '.telemetry.shape' "$entry_file")
+    eval_verdict=$(jq -r '.telemetry.eval_verdict' "$entry_file")
+    iterate_status=$(jq -r '.telemetry.iterate_status' "$entry_file")
+
+    [ "$shape" = "standard" ]
+    [ "$eval_verdict" = "pass" ]
+    [ "$iterate_status" = "lgtm" ]
+
+    # shape_refloored must be boolean false (not string "false")
+    shape_refloored_type=$(jq '.telemetry.shape_refloored | type' "$entry_file")
+    [ "$shape_refloored_type" = '"boolean"' ]
+
+    shape_refloored_val=$(jq '.telemetry.shape_refloored' "$entry_file")
+    [ "$shape_refloored_val" = "false" ]
+
+    # plan_iter and eval_iter must be numbers
+    plan_iter_type=$(jq '.telemetry.plan_iter | type' "$entry_file")
+    [ "$plan_iter_type" = '"number"' ]
+
+    eval_iter_type=$(jq '.telemetry.eval_iter | type' "$entry_file")
+    [ "$eval_iter_type" = '"number"' ]
+
+    plan_iter_val=$(jq '.telemetry.plan_iter' "$entry_file")
+    [ "$plan_iter_val" = "2" ]
+
+    eval_iter_val=$(jq '.telemetry.eval_iter' "$entry_file")
+    [ "$eval_iter_val" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: --shape-refloored false is recorded as boolean false, not string
+# ---------------------------------------------------------------------------
+@test "--shape-refloored false is boolean false not string" {
+    run "$SCRIPT" log dev-flow success --shape-refloored false
+    [ "$status" -eq 0 ]
+
+    entry_file=$(latest_entry)
+    [ -n "$entry_file" ]
+
+    shape_refloored_type=$(jq '.telemetry.shape_refloored | type' "$entry_file")
+    [ "$shape_refloored_type" = '"boolean"' ]
+
+    shape_refloored_val=$(jq '.telemetry.shape_refloored' "$entry_file")
+    [ "$shape_refloored_val" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: --shape-refloored with invalid value exits non-zero
+# ---------------------------------------------------------------------------
+@test "--shape-refloored yes exits non-zero" {
+    run "$SCRIPT" log dev-flow success --shape-refloored yes
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: --plan-iter with non-numeric value exits non-zero
+# ---------------------------------------------------------------------------
+@test "--plan-iter abc exits non-zero" {
+    run "$SCRIPT" log dev-flow success --plan-iter abc
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: Partial new flags - only specified keys present, others absent
+# ---------------------------------------------------------------------------
+@test "only --iterate-status specified -> only that key present among new 6" {
+    run "$SCRIPT" log dev-flow success --iterate-status lgtm
+    [ "$status" -eq 0 ]
+
+    entry_file=$(latest_entry)
+    [ -n "$entry_file" ]
+
+    iterate_status=$(jq -r '.telemetry.iterate_status' "$entry_file")
+    [ "$iterate_status" = "lgtm" ]
+
+    # The other 5 new keys must be absent
+    has_shape=$(jq '.telemetry | has("shape")' "$entry_file")
+    has_shape_refloored=$(jq '.telemetry | has("shape_refloored")' "$entry_file")
+    has_eval_verdict=$(jq '.telemetry | has("eval_verdict")' "$entry_file")
+    has_plan_iter=$(jq '.telemetry | has("plan_iter")' "$entry_file")
+    has_eval_iter=$(jq '.telemetry | has("eval_iter")' "$entry_file")
+
+    [ "$has_shape" = "false" ]
+    [ "$has_shape_refloored" = "false" ]
+    [ "$has_eval_verdict" = "false" ]
+    [ "$has_plan_iter" = "false" ]
+    [ "$has_eval_iter" = "false" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: Existing 3 flags only -> new 6 keys absent
+# ---------------------------------------------------------------------------
+@test "existing 3 telemetry flags only -> new 6 keys absent" {
+    run "$SCRIPT" log dev-flow success \
+        --merge-tier REVIEW \
+        --gate-policy llm-major-advisory \
+        --danger-hits '[]'
+    [ "$status" -eq 0 ]
+
+    entry_file=$(latest_entry)
+    [ -n "$entry_file" ]
+
+    has_shape=$(jq '.telemetry | has("shape")' "$entry_file")
+    has_shape_refloored=$(jq '.telemetry | has("shape_refloored")' "$entry_file")
+    has_eval_verdict=$(jq '.telemetry | has("eval_verdict")' "$entry_file")
+    has_iterate_status=$(jq '.telemetry | has("iterate_status")' "$entry_file")
+    has_plan_iter=$(jq '.telemetry | has("plan_iter")' "$entry_file")
+    has_eval_iter=$(jq '.telemetry | has("eval_iter")' "$entry_file")
+
+    [ "$has_shape" = "false" ]
+    [ "$has_shape_refloored" = "false" ]
+    [ "$has_eval_verdict" = "false" ]
+    [ "$has_iterate_status" = "false" ]
+    [ "$has_plan_iter" = "false" ]
+    [ "$has_eval_iter" = "false" ]
+}

--- a/skill-retrospective/scripts/journal.sh
+++ b/skill-retrospective/scripts/journal.sh
@@ -66,6 +66,7 @@ cmd_log() {
     local issue="" duration_turns="" context_extra=""
     local project="" worktree="" mode=""
     local merge_tier="" gate_policy="" danger_hits=""
+    local shape="" shape_refloored="" eval_verdict="" iterate_status="" plan_iter="" eval_iter=""
 
     # Parse positional args
     if [[ $# -lt 2 ]]; then
@@ -98,6 +99,12 @@ cmd_log() {
             --merge-tier) merge_tier="$2"; shift 2 ;;
             --gate-policy) gate_policy="$2"; shift 2 ;;
             --danger-hits) danger_hits="$2"; shift 2 ;;
+            --shape) shape="$2"; shift 2 ;;
+            --shape-refloored) shape_refloored="$2"; shift 2 ;;
+            --eval-verdict) eval_verdict="$2"; shift 2 ;;
+            --iterate-status) iterate_status="$2"; shift 2 ;;
+            --plan-iter) plan_iter="$2"; shift 2 ;;
+            --eval-iter) eval_iter="$2"; shift 2 ;;
             *) die_json "Unknown option: $1" 1 ;;
         esac
     done
@@ -116,6 +123,24 @@ cmd_log() {
             lint|test|build|runtime|config|env|merge|type-check) ;;
             *) die_json "Invalid error category: $error_category" 1 ;;
         esac
+    fi
+
+    # Validate new telemetry fields
+    if [[ -n "$shape_refloored" ]]; then
+        case "$shape_refloored" in
+            true|false) ;;
+            *) die_json "Invalid --shape-refloored: $shape_refloored. Must be true|false" 1 ;;
+        esac
+    fi
+    if [[ -n "$plan_iter" ]]; then
+        if ! [[ "$plan_iter" =~ ^[0-9]+$ ]]; then
+            die_json "Invalid --plan-iter: $plan_iter. Must be a non-negative integer" 1
+        fi
+    fi
+    if [[ -n "$eval_iter" ]]; then
+        if ! [[ "$eval_iter" =~ ^[0-9]+$ ]]; then
+            die_json "Invalid --eval-iter: $eval_iter. Must be a non-negative integer" 1
+        fi
     fi
 
     ensure_journal_dir
@@ -184,6 +209,30 @@ cmd_log() {
     fi
     if [[ -n "$danger_hits" ]]; then
         telemetry=$(echo "$telemetry" | jq --argjson v "$danger_hits" '. + {danger_hits: $v}')
+        has_telemetry=true
+    fi
+    if [[ -n "$shape" ]]; then
+        telemetry=$(echo "$telemetry" | jq --arg v "$shape" '. + {shape: $v}')
+        has_telemetry=true
+    fi
+    if [[ -n "$shape_refloored" ]]; then
+        telemetry=$(echo "$telemetry" | jq --argjson v "$shape_refloored" '. + {shape_refloored: $v}')
+        has_telemetry=true
+    fi
+    if [[ -n "$eval_verdict" ]]; then
+        telemetry=$(echo "$telemetry" | jq --arg v "$eval_verdict" '. + {eval_verdict: $v}')
+        has_telemetry=true
+    fi
+    if [[ -n "$iterate_status" ]]; then
+        telemetry=$(echo "$telemetry" | jq --arg v "$iterate_status" '. + {iterate_status: $v}')
+        has_telemetry=true
+    fi
+    if [[ -n "$plan_iter" ]]; then
+        telemetry=$(echo "$telemetry" | jq --argjson v "$plan_iter" '. + {plan_iter: $v}')
+        has_telemetry=true
+    fi
+    if [[ -n "$eval_iter" ]]; then
+        telemetry=$(echo "$telemetry" | jq --argjson v "$eval_iter" '. + {eval_iter: $v}')
         has_telemetry=true
     fi
     if [[ "$has_telemetry" == true ]]; then
@@ -506,6 +555,7 @@ Subcommands:
 
 Examples:
   journal.sh log dev-kickoff success --issue 42 --duration-turns 15
+  journal.sh log dev-flow success --merge-tier REVIEW --shape standard --shape-refloored false --plan-iter 2 --eval-iter 1 --iterate-status lgtm --eval-verdict pass
   journal.sh log dev-kickoff failure --error-category env --error-msg "node_modules not found"
   journal.sh hook-capture < posttooluse.json
   journal.sh query --since 7d --skill dev-kickoff


### PR DESCRIPTION
## 概要

Closes #163

- `dev-flow.js` 完走末尾に `journal.sh log dev-flow success` の決定論実行を追加（dev-runner-haiku 経由）
- `pr-iterate.js` 終端でも `journal.sh log pr-iterate success` を記録するエージェント呼び出しを追加
- `journal.sh` に `--shape` / `--shape-refloored` / `--eval-verdict` / `--iterate-status` / `--plan-iter` / `--eval-iter` フラグを追加
- 記録失敗は log 警告のみで workflow は正常終了する（telemetry 欠損 > ワークフロー中断）
- 新フラグのバリデーションと bats テストを追加
- `_lib/devflow-journal-log.test.mjs` / `_lib/priterate-journal-log.test.mjs` 統合テストを追加

## 動機

W6（#151）で `journal.sh log` に telemetry を記録する**能力**は入ったが、`dev-flow.js` / `pr-iterate.js` のどこにも journal 呼び出しは存在しなかった。
記録はメインセッションの裁量に依存しており、リポ規約 8「毎回確定実行したい挙動は LLM の判断を介さず実装する」に反する。

W6b（#154）の calibration 判断に必要な実データ（shape 別 outcome・eval 取りこぼし proxy・iterate 回数等）を
確実に蓄積するため、workflow 末尾から決定論的に journal を記録する配線を追加する。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/dev-flow.js` | Merge tier phase 末尾に `journalCmd` 組み立て + dev-runner-haiku 経由の journal 記録呼び出し、`planIters` / `evalIters` カウンタ追加 |
| `.claude/workflows/pr-iterate.js` | `JOURNAL_RESULT` schema 追加、終端で iterate status を journal 記録するエージェント呼び出しを追加 |
| `skill-retrospective/scripts/journal.sh` | `--shape` / `--shape-refloored` / `--eval-verdict` / `--iterate-status` / `--plan-iter` / `--eval-iter` フラグ追加、バリデーションと telemetry 書き込みを実装 |
| `skill-retrospective/scripts/journal.bats` | 新フラグのユニットテストを追加 |
| `_lib/devflow-journal-log.test.mjs` | dev-flow journal 呼び出しの統合テスト |
| `_lib/priterate-journal-log.test.mjs` | pr-iterate journal 呼び出しの統合テスト |

## テスト計画

- [x] `journal.sh` 新フラグの bats テスト追加済み
- [x] dev-flow / pr-iterate journal 呼び出しの統合テスト（`.test.mjs`）追加済み
- [ ] dev-flow 完走 stub で journal agent 呼び出しが 1 回発生し prompt に `--merge-tier` / `--gate-policy` / `--danger-hits` が含まれることを確認
- [ ] 記録失敗 stub でも workflow return が成功することを確認