### PR TITLE
fix(pr-iterate): check-ci.sh の transient gh エラーに決定論的リトライを追加

### DIFF
--- a/pr-iterate/scripts/check-ci.bats
+++ b/pr-iterate/scripts/check-ci.bats
@@ -19,13 +19,26 @@ setup() {
 
     # Default gh stub: responds to `pr checks` with canned JSON stored in
     # $GH_CHECKS_OUTPUT (exit code from $GH_EXIT_CODE, default 0).
+    # Supports call-count tracking via GH_CALL_COUNT_FILE.
+    # GH_FAIL_TIMES controls how many initial attempts fail with exit 1.
+    GH_CALL_COUNT_FILE="$BATS_TMPDIR/gh-call-count"
+    rm -f "$GH_CALL_COUNT_FILE"
+    GH_FAIL_TIMES=0
+    CHECK_CI_RETRY_DELAYS="0 0"
     GH_CHECKS_OUTPUT="[]"
     GH_EXIT_CODE=0
+    export GH_CALL_COUNT_FILE GH_FAIL_TIMES CHECK_CI_RETRY_DELAYS
     export GH_CHECKS_OUTPUT GH_EXIT_CODE
 
     cat > "$STUB_DIR/gh" << 'EOF'
 #!/usr/bin/env bash
 if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    count=$(( $(cat "$GH_CALL_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+    echo "$count" > "$GH_CALL_COUNT_FILE"
+    if (( count <= ${GH_FAIL_TIMES:-0} )); then
+        echo "transient network error" >&2
+        exit 1
+    fi
     echo "$GH_CHECKS_OUTPUT"
     exit "${GH_EXIT_CODE:-0}"
 fi
@@ -161,4 +174,70 @@ GHEOF
     # Output must contain status=error, NOT no_checks
     result=$(echo "$output" | tail -1)
     [ "$(echo "$result" | jq -r '.status')" = "error" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: gh fails once then succeeds -> status passed (retry path)
+# ---------------------------------------------------------------------------
+@test "gh fails once then succeeds -> status passed (retry path)" {
+    export GH_FAIL_TIMES=1
+    export GH_CHECKS_OUTPUT='[
+      {"name":"lint","state":"SUCCESS","bucket":"pass"},
+      {"name":"test","state":"SUCCESS","bucket":"pass"}
+    ]'
+    export GH_EXIT_CODE=0
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "passed" ]
+    call_count=$(cat "$GH_CALL_COUNT_FILE")
+    [ "$call_count" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: gh fails all attempts -> status error, exits 1
+# With CHECK_CI_RETRY_DELAYS="0 0", max attempts = 1 initial + 2 retries = 3
+# ---------------------------------------------------------------------------
+@test "gh fails all attempts -> status error, exits 1, call count 3" {
+    export GH_FAIL_TIMES=10
+    run "$SCRIPT" 42
+    [ "$status" -eq 1 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "error" ]
+    call_count=$(cat "$GH_CALL_COUNT_FILE")
+    [ "$call_count" -eq 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: failed status does not trigger retry (gh called exactly once)
+# ---------------------------------------------------------------------------
+@test "failed status does not trigger retry (gh called exactly once)" {
+    export GH_FAIL_TIMES=0
+    export GH_CHECKS_OUTPUT='[
+      {"name":"test","state":"FAILURE","bucket":"fail"}
+    ]'
+    export GH_EXIT_CODE=0
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "failed" ]
+    call_count=$(cat "$GH_CALL_COUNT_FILE")
+    [ "$call_count" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: pending (gh exit 8) does not trigger retry (gh called exactly once)
+# ---------------------------------------------------------------------------
+@test "pending (gh exit 8) does not trigger retry (gh called exactly once)" {
+    export GH_FAIL_TIMES=0
+    export GH_CHECKS_OUTPUT='[
+      {"name":"build","state":"IN_PROGRESS","bucket":"pending"}
+    ]'
+    export GH_EXIT_CODE=8
+    run "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    result=$(echo "$output" | tail -1)
+    [ "$(echo "$result" | jq -r '.status')" = "pending" ]
+    call_count=$(cat "$GH_CALL_COUNT_FILE")
+    [ "$call_count" -eq 1 ]
 }

--- a/pr-iterate/scripts/check-ci.bats
+++ b/pr-iterate/scripts/check-ci.bats
@@ -186,12 +186,14 @@ GHEOF
       {"name":"test","state":"SUCCESS","bucket":"pass"}
     ]'
     export GH_EXIT_CODE=0
-    run "$SCRIPT" 42
+    run --separate-stderr "$SCRIPT" 42
     [ "$status" -eq 0 ]
     result=$(echo "$output" | tail -1)
     [ "$(echo "$result" | jq -r '.status')" = "passed" ]
     call_count=$(cat "$GH_CALL_COUNT_FILE")
     [ "$call_count" -eq 2 ]
+    # stderr must contain retry log (attempt number + failure reason)
+    [[ "$stderr" == *"check-ci: gh pr checks failed"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/pr-iterate/scripts/check-ci.sh
+++ b/pr-iterate/scripts/check-ci.sh
@@ -61,6 +61,7 @@ while :; do
     if (( attempt >= ${#RETRY_DELAYS[@]} )); then
         break
     fi
+    echo "check-ci: gh pr checks failed (exit $gh_exit), retry $((attempt + 1))/${#RETRY_DELAYS[@]} in ${RETRY_DELAYS[$attempt]}s: $(cat "$gh_stderr_file")" >&2
     sleep "${RETRY_DELAYS[$attempt]}"
     attempt=$((attempt + 1))
 done

--- a/pr-iterate/scripts/check-ci.sh
+++ b/pr-iterate/scripts/check-ci.sh
@@ -17,6 +17,8 @@
 #   0  = all checks complete (passed or failed)
 #   8  = checks still pending
 #   1  = real API error (auth, network, unknown JSON field, etc.)
+# Transient gh API errors (exit code other than 0/8) are retried with backoff.
+# Max retries = number of delay entries in CHECK_CI_RETRY_DELAYS (default 10s/30s).
 
 set -euo pipefail
 
@@ -40,11 +42,28 @@ done
 
 # Capture gh output and exit code explicitly.
 # gh exits 0 for complete checks, 8 for pending, 1 for real errors.
-# We allow exit 0 and 8; anything else is surfaced as {"status":"error"}.
+# We allow exit 0 and 8; anything else is retried then surfaced as {"status":"error"}.
+# Transient gh API errors (exit code other than 0/8) are retried with backoff.
+# Max retries = number of delay entries. Tests override via CHECK_CI_RETRY_DELAYS.
+read -r -a RETRY_DELAYS <<< "${CHECK_CI_RETRY_DELAYS:-10 30}"
+
 gh_stderr_file=$(mktemp)
 checks_json=""
 gh_exit=0
-checks_json=$(gh pr checks "$PR_REF" "${REPO_FLAG[@]}" --json name,state,bucket 2>"$gh_stderr_file") || gh_exit=$?
+attempt=0
+while :; do
+    gh_exit=0
+    checks_json=$(gh pr checks "$PR_REF" "${REPO_FLAG[@]}" --json name,state,bucket 2>"$gh_stderr_file") || gh_exit=$?
+    # exit 0 = checks complete, 8 = pending: both determinate -> NEVER retry
+    if [[ $gh_exit -eq 0 || $gh_exit -eq 8 ]]; then
+        break
+    fi
+    if (( attempt >= ${#RETRY_DELAYS[@]} )); then
+        break
+    fi
+    sleep "${RETRY_DELAYS[$attempt]}"
+    attempt=$((attempt + 1))
+done
 gh_stderr=$(cat "$gh_stderr_file")
 rm -f "$gh_stderr_file"
 


### PR DESCRIPTION
## 概要

Closes #189

- `check-ci.sh` に transient な gh API エラーへの決定論的リトライ機構を追加
- gh コマンドが exit 0/8 以外で失敗した場合、デフォルト 10s → 30s のバックオフで最大 2 回リトライ
- `failed` / `pending` 判定はリトライ対象外とし、誤 green 化を防止
- リトライ発生時は stderr に試行回数をログ出力（stdout JSON は汚染しない）

## 動機

PR #187 の dev-flow / pr-iterate 実行で、CI が実際には green にもかかわらず transient な gh API 失敗により `status:"error"` が返され、LGTM ループが 2 回連続で中断した。

直後の手動再実行では `{"status":"passed","passed":3,"failed":0}` が正常に返ったことから、一過性のネットワーク/gh API ゆらぎが原因と判断。リトライ層をスクリプト側に置くことで LLM agent 側の判断に依存せず、決定論的処理として bats でテスト可能にした。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `pr-iterate/scripts/check-ci.sh` | `CHECK_CI_RETRY_DELAYS` 変数によるバックオフリトライループを追加（デフォルト `"10 30"`、テスト時は `"0 0"` でオーバーライド可） |
| `pr-iterate/scripts/check-ci.bats` | リトライ経路を検証する Test 8〜11 を追加（gh stub にコールカウント機構を実装） |

## テスト計画

- [x] Test 8: gh が 1 回失敗後に成功 → `status:passed`、コール数 2
- [x] Test 9: gh が全リトライ失敗 → `status:error`、exit 1、コール数 3
- [x] Test 10: CI `failed` 判定はリトライなし → コール数 1
- [x] Test 11: CI `pending`（exit 8）はリトライなし → コール数 1