### PR TITLE
✨ feat(dev-flow): PR コメント3種を結論ファースト+テーブル+折りたたみの人間可読形式に刷新

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -643,6 +643,10 @@ function buildDevflowSummaryBody({
   }
 
   // 8. 空状態の常時可視行
+  // 直前コンテンツ（テーブル行 / bullet）との間に必ず空行を挿入する。
+  // GFM はテーブル終端行を空行で判定し、bullet も lazy continuation で吸収するため
+  // 空行なしで push するとテーブル壊れ・bullet 併合が起きる（AC-2 実効性を損なう）。
+  if (lines[lines.length - 1] !== '') lines.push('');
   if (blockArr.length === 0 && advArr.length === 0) {
     lines.push('Goal Ledger: item なし');
   }

--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -470,30 +470,10 @@ function diffDeclaredPaths(planTasks, changedFiles) {
 // ---- /parallel-disjoint エンジン ----
 
 // ---- devflow-summary-format inline コピー (canonical: _lib/devflow-summary-format.mjs。修正時は両者を同期。byte 一致は _lib/devflow-summary-format.sync.test.mjs が保証) ----
-// bodySaveInstr: PR body 保存 + 投稿の共通指示文を組み立てるヘルパー（pr-iterate.js と同型）。
-function bodySaveInstr(body) {
-  return `## 本文の保存\n`
-    + `まず Bash で \`mktemp /tmp/dev-flow-XXXXXX.md\` を実行して一時ファイルを作成し、\n`
-    + `そのパスを <BODY_FILE> とする。次に **Write tool** を使い、下記 delimiter 内の本文を\n`
-    + `**一字一句そのまま** <BODY_FILE> へ書き出せ。本文は絶対に shell（echo/printf/heredoc 等）へ\n`
-    + `渡さず、必ず Write tool の content 引数として渡すこと。backtick やコードフェンスを\n`
-    + `エスケープ・改変しないこと。以降のコマンドの \`--body-file\` には <BODY_FILE> を指定する。\n`
-    + `<<<DEV_FLOW_BODY_BEGIN>>>\n${body}\n<<<DEV_FLOW_BODY_END>>>\n\n`
+function mdCell(v) {
+  if (v == null) return '';
+  return String(v).replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
 }
-
-// POST_RESULT schema（dev-runner 経由の PR 投稿結果）
-const POST_RESULT = {
-  type: 'object',
-  required: ['posted'],
-  properties: {
-    posted: { type: 'boolean' },
-    method: { type: 'string' },
-    url: { type: 'string' },
-  },
-}
-
-// JOURNAL_RESULT schema（dev-runner-haiku 経由の journal.sh log 記録結果）
-const JOURNAL_RESULT = { type: 'object', required: ['logged'], properties: { logged: { type: 'boolean' }, summary: { type: 'string' } } }
 
 function buildDevflowSummaryBody({
   pr,
@@ -513,12 +493,60 @@ function buildDevflowSummaryBody({
 }) {
   const lines = [];
 
+  const TIER_EMOJI = { 'HOLD': '🔶', 'REVIEW': '🔷', 'AUTO': '✅' };
+
   // 1. 見出し
   lines.push(`## dev-flow 終端サマリー — PR #${pr}`);
   lines.push('');
 
-  // 2. Merge tier セクション
-  lines.push(`### Merge tier: ${mergeTier}`);
+  // 2. at-a-glance テーブル
+  const tierCell = `${TIER_EMOJI[mergeTier] ?? ''} **${mergeTier}**`;
+  const shapeCell = shape != null ? shape : '不明';
+  let testCell;
+  if (testGreen == null) {
+    testCell = '不明';
+  } else if (testGreen === true) {
+    testCell = '✅ green';
+  } else {
+    testCell = '❌ red';
+  }
+  let evalCell;
+  if (evalVerdict == null) {
+    evalCell = '不明';
+  } else if (evalVerdict === 'pass') {
+    evalCell = '✅ pass';
+  } else {
+    evalCell = `❌ ${evalVerdict}`;
+  }
+  const ledgerCell = ledgerConverged ? '✅ 収束' : '⚠️ 未収束';
+  const acArr = acResults && acResults.length > 0 ? acResults : null;
+  let acCell;
+  if (!acArr) {
+    acCell = '—';
+  } else {
+    const s = acArr.filter(a => a.satisfied === true).length;
+    const t = acArr.length;
+    acCell = s === t ? `✅ ${s}/${t}` : `❌ ${s}/${t}`;
+  }
+  const dangerArr = dangerHits && dangerHits.length > 0 ? dangerHits : null;
+  const dangerCell = dangerArr ? `⚠️ ${dangerArr.length} クラス` : '✅ clean';
+
+  lines.push('| Merge tier | shape | test | eval | Ledger | AC | danger |');
+  lines.push('|---|---|---|---|---|---|---|');
+  lines.push(`| ${tierCell} | ${shapeCell} | ${testCell} | ${evalCell} | ${ledgerCell} | ${acCell} | ${dangerCell} |`);
+  lines.push('');
+
+  // 3. gate_policy 行
+  lines.push(`gate_policy: \`${gatePolicy}\``);
+
+  // 4. dangerHits 検出クラス行（1件以上のとき）
+  if (dangerArr) {
+    lines.push(`検出クラス: ${dangerArr.join(', ')}`);
+  }
+
+  // 5. Merge tier 理由（常時可視）
+  lines.push('');
+  lines.push('**Merge tier 理由**:');
   if (!mergeTierReasons || mergeTierReasons.length === 0) {
     lines.push('- 理由記載なし');
   } else {
@@ -526,98 +554,172 @@ function buildDevflowSummaryBody({
       lines.push(`- ${reason}`);
     }
   }
+
+  // 6. 要対応セクション（常時可視）
+  // 未解消事項を収集
+  const blockArr = blockingItems || [];
+  const advArr = advisoryItems || [];
+  const uncheckedBlocking = blockArr.filter(it => it.checked !== true);
+  const uncheckedAdvisory = advArr.filter(it => it.checked !== true);
+  const escalatedChecked = advArr.filter(it => it.escalate === true && it.checked === true);
+  const unsatisfiedAC = acArr ? acArr.filter(a => a.satisfied !== true) : [];
+  const uncleared = securityClearance && securityClearance.length > 0
+    ? securityClearance.filter(sc => sc.cleared !== true)
+    : [];
+  const concerns = planConcerns || [];
+
+  const hasActionItems = uncheckedBlocking.length > 0
+    || uncheckedAdvisory.length > 0
+    || escalatedChecked.length > 0
+    || unsatisfiedAC.length > 0
+    || uncleared.length > 0
+    || concerns.length > 0;
+
   lines.push('');
-
-  // 2.5. ESCALATE-TO-HUMAN セクション（escalate item があるときのみ出力。人間が必ず読む冒頭近くに置く）
-  const escalated = (advisoryItems || []).filter((it) => it && it.escalate === true);
-  if (escalated.length > 0) {
-    lines.push('### ESCALATE-TO-HUMAN（人間の判断が必要）');
-    for (const item of escalated) {
-      const dimension = item.dimension ? ` [${item.dimension}]` : '';
-      const reason = item.escalate_reason ? `（reason: ${item.escalate_reason}）` : '';
-      lines.push(`- ${item.id}${dimension} ${item.text}${reason}`);
-    }
-    lines.push('');
-  }
-
-  // 3. 実行結果サマリー（shape / test_green / eval_verdict）
-  lines.push('### 実行結果');
-  lines.push(`- shape: ${shape != null ? shape : '不明'}`);
-  lines.push(`- test_green: ${testGreen != null ? String(testGreen) : '不明'}`);
-  lines.push(`- eval_verdict: ${evalVerdict != null ? evalVerdict : '不明'}`);
-  lines.push('');
-
-  // 4. Goal Ledger セクション
-  lines.push('### Goal Ledger');
-  lines.push(`- gate_policy: ${gatePolicy}`);
-  lines.push(`- 収束: ${ledgerConverged ? '済' : '未収束'}`);
-
-  // blocking items
-  if (!blockingItems || blockingItems.length === 0) {
-    lines.push('- blocking item なし');
+  if (!hasActionItems) {
+    lines.push('### ✅ 要対応事項なし');
   } else {
-    for (const item of blockingItems) {
-      const status = item.checked ? 'checked' : '未解消';
-      const dimension = item.dimension ? ` [${item.dimension}]` : '';
-      const evidence = item.evidence ? ': ' + item.evidence : '';
-      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}`);
+    lines.push('### ⚠️ 要対応');
+
+    // ledger 未解消テーブル（(i)(ii)(iii)）
+    const ledgerActionItems = [
+      ...uncheckedBlocking.map(it => ({ ...it, _lane: 'blocking' })),
+      ...uncheckedAdvisory.map(it => ({
+        ...it,
+        _lane: it.escalate ? 'advisory (ESCALATE)' : 'advisory',
+      })),
+      ...escalatedChecked.map(it => ({ ...it, _lane: 'advisory (ESCALATE)', _forceVisible: true })),
+    ];
+
+    if (ledgerActionItems.length > 0) {
+      lines.push('');
+      lines.push('| 状態 | id | lane | dimension | 内容 |');
+      lines.push('|---|---|---|---|---|');
+      for (const item of ledgerActionItems) {
+        const status = (item.checked === true && item.escalate) ? '⚠️ 要判断' : '❌ 未解消';
+        const dimension = item.dimension != null ? item.dimension : '—';
+        let content = mdCell(item.text);
+        if (item.evidence) {
+          content += ': ' + mdCell(item.evidence);
+        }
+        if (item.escalate_reason) {
+          content += `（reason: ${mdCell(item.escalate_reason)}）`;
+        }
+        lines.push(`| ${status} | ${item.id} | ${item._lane} | ${dimension} | ${content} |`);
+      }
+    }
+
+    // 未達 AC テーブル（(iv)）
+    if (unsatisfiedAC.length > 0) {
+      lines.push('');
+      lines.push('| 状態 | AC | 検証 | evidence |');
+      lines.push('|---|---|---|---|');
+      for (const ac of unsatisfiedAC) {
+        const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
+        const evidenceCell = ac.evidence ? mdCell(ac.evidence) : '—';
+        lines.push(`| ❌ 未達 | AC#${ac.ac_index + 1} | ${verifiedBy} | ${evidenceCell} |`);
+      }
+    }
+
+    // 未確認 clearance テーブル（(v)）
+    if (uncleared.length > 0) {
+      lines.push('');
+      lines.push('| 状態 | danger class | evidence |');
+      lines.push('|---|---|---|');
+      for (const sc of uncleared) {
+        const evidenceCell = sc.evidence ? mdCell(sc.evidence) : '—';
+        lines.push(`| ❌ 未確認 | ${sc.danger_class} | ${evidenceCell} |`);
+      }
+    }
+
+    // Plan concerns（(vi)）
+    if (concerns.length > 0) {
+      lines.push('');
+      lines.push('**Plan 未解消 concerns**:');
+      for (const concern of concerns) {
+        lines.push(`- ${concern}`);
+      }
     }
   }
 
-  // advisory items
-  if (!advisoryItems || advisoryItems.length === 0) {
-    lines.push('- advisory item なし');
-  } else {
-    for (const item of advisoryItems) {
-      const status = item.checked ? 'checked' : '未解消';
-      const escalateSuffix = item.escalate ? ' (ESCALATE)' : '';
-      const dimension = item.dimension ? ` [${item.dimension}]` : '';
-      const evidence = item.evidence ? ': ' + item.evidence : '';
-      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}${escalateSuffix}`);
-    }
+  // 8. 空状態の常時可視行
+  if (blockArr.length === 0 && advArr.length === 0) {
+    lines.push('Goal Ledger: item なし');
   }
-  lines.push('');
-
-  // 5. AC evidence セクション
-  lines.push('### Acceptance Criteria');
   if (!acResults || acResults.length === 0) {
-    lines.push('AC 判定なし（evaluator 未実行 or AC 欠落）');
-  } else {
-    for (const ac of acResults) {
-      const satisfiedLabel = ac.satisfied ? 'satisfied' : '未達';
-      const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
-      const evidenceSuffix = ac.evidence ? ': ' + ac.evidence : '';
-      lines.push(`- AC#${ac.ac_index + 1}: ${satisfiedLabel}（${verifiedBy}）${evidenceSuffix}`);
-    }
+    lines.push('Acceptance Criteria: AC 判定なし（evaluator 未実行 or AC 欠落）');
   }
-  lines.push('');
-
-  // 6. Security clearance セクション
-  lines.push('### Security clearance');
   if (!securityClearance || securityClearance.length === 0) {
-    lines.push('- danger-grep clean（clearance 不要）');
-  } else {
-    for (const sc of securityClearance) {
-      const clearedLabel = sc.cleared ? 'cleared' : '未確認';
-      const evidenceSuffix = sc.evidence ? ': ' + sc.evidence : '';
-      lines.push(`- ${sc.danger_class}: ${clearedLabel}${evidenceSuffix}`);
-    }
+    lines.push('Security clearance: danger-grep clean（clearance 不要）');
   }
-  if (dangerHits && dangerHits.length > 0) {
-    lines.push(`- 検出クラス: ${dangerHits.join(', ')}`);
-  }
-  lines.push('');
 
-  // 7. Plan concerns セクション（空なら省略）
-  if (planConcerns && planConcerns.length > 0) {
-    lines.push('### Plan 未解消 concerns');
-    for (const concern of planConcerns) {
-      lines.push(`- ${concern}`);
+  // 7. 折りたたみブロック群（AC-3）
+
+  // 解消済み ledger
+  const resolvedItems = [
+    ...blockArr.filter(it => it.checked === true).map(it => ({ ...it, _lane: 'blocking' })),
+    ...advArr.filter(it => it.checked === true && it.escalate !== true).map(it => ({ ...it, _lane: 'advisory' })),
+  ];
+  if (resolvedItems.length > 0) {
+    const n = resolvedItems.length;
+    lines.push('');
+    lines.push(`<details><summary>✅ Goal Ledger 解消済み ${n} 件</summary>`);
+    lines.push('');
+    lines.push('| id | lane | dimension | 内容 | evidence |');
+    lines.push('|---|---|---|---|---|');
+    for (const item of resolvedItems) {
+      const dimension = item.dimension != null ? item.dimension : '—';
+      const content = mdCell(item.text);
+      const evidence = item.evidence ? mdCell(item.evidence) : '—';
+      lines.push(`| ${item.id} | ${item._lane} | ${dimension} | ${content} | ${evidence} |`);
     }
     lines.push('');
+    lines.push('</details>');
   }
 
-  // 8. 末尾
+  // satisfied AC
+  if (acArr) {
+    const satisfiedAC = acArr.filter(a => a.satisfied === true);
+    const s = satisfiedAC.length;
+    const t = acArr.length;
+    if (s > 0) {
+      lines.push('');
+      lines.push(`<details><summary>✅ Acceptance Criteria ${s}/${t} satisfied</summary>`);
+      lines.push('');
+      lines.push('| AC | 検証 | evidence |');
+      lines.push('|---|---|---|');
+      for (const ac of satisfiedAC) {
+        const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
+        const evidenceCell = ac.evidence ? mdCell(ac.evidence) : '—';
+        lines.push(`| AC#${ac.ac_index + 1} | ${verifiedBy} | ${evidenceCell} |`);
+      }
+      lines.push('');
+      lines.push('</details>');
+    }
+  }
+
+  // cleared security clearance
+  if (securityClearance && securityClearance.length > 0) {
+    const cleared = securityClearance.filter(sc => sc.cleared === true);
+    const c = cleared.length;
+    const ct = securityClearance.length;
+    if (c > 0) {
+      lines.push('');
+      lines.push(`<details><summary>✅ Security clearance ${c}/${ct} cleared</summary>`);
+      lines.push('');
+      lines.push('| danger class | evidence |');
+      lines.push('|---|---|');
+      for (const sc of cleared) {
+        const evidenceCell = sc.evidence ? mdCell(sc.evidence) : '—';
+        lines.push(`| ${sc.danger_class} | ${evidenceCell} |`);
+      }
+      lines.push('');
+      lines.push('</details>');
+    }
+  }
+
+  // 9. 末尾
+  lines.push('');
   lines.push('---');
   lines.push('*このコメントは dev-flow により自動生成されました。*');
   lines.push(`<!-- dev-flow:${mergeTier} -->`);
@@ -862,6 +964,33 @@ const RISK = {
 const CHANGED = {
   type: 'object', required: ['files'],
   properties: { files: { type: 'array', items: { type: 'string' } } },
+}
+const POST_RESULT = {
+  type: 'object',
+  required: ['posted'],
+  properties: {
+    posted: { type: 'boolean' },
+    method: { type: 'string' },
+    url: { type: 'string' },
+  },
+}
+const JOURNAL_RESULT = {
+  type: 'object',
+  required: ['logged'],
+  properties: {
+    logged: { type: 'boolean' },
+    summary: { type: 'string' },
+  },
+}
+
+function bodySaveInstr(body) {
+  return `## 本文の保存\n`
+    + `まず Bash で \`mktemp /tmp/dev-flow-XXXXXX.md\` を実行して一時ファイルを作成し、\n`
+    + `そのパスを <BODY_FILE> とする。次に **Write tool** を使い、下記 delimiter 内の本文を\n`
+    + `**一字一句そのまま** <BODY_FILE> へ書き出せ。本文は絶対に shell（echo/printf/heredoc 等）へ\n`
+    + `渡さず、必ず Write tool の content 引数として渡すこと。backtick やコードフェンスを\n`
+    + `エスケープ・改変しないこと。以降のコマンドの \`--body-file\` には <BODY_FILE> を指定する。\n`
+    + `<<<DEV_FLOW_BODY_BEGIN>>>\n${body}\n<<<DEV_FLOW_BODY_END>>>\n\n`
 }
 
 // ---- helpers ----

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -61,25 +61,41 @@ const DECISION_LABEL = {
   'comment': 'コメント',
 };
 
+function mdCell(v) {
+  if (v == null) return '';
+  return String(v).replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+}
+
 function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
+  const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
+  const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const label = DECISION_LABEL[decision] ?? decision;
+  const emoji = DECISION_EMOJI[decision] ?? '';
   const lines = [];
 
   lines.push(`## PR #${pr} — レビュー結果 (iteration ${iteration})`);
   lines.push('');
-  lines.push(`**判定**: ${label}`);
-  lines.push('');
-  lines.push('### Blocking 指摘');
 
-  if (!blocking || blocking.length === 0) {
-    lines.push('blocking 指摘なし');
+  const blockingList = blocking || [];
+  if (blockingList.length === 0) {
+    lines.push(`**判定**: ${emoji} ${label} — ✅ blocking 指摘なし`);
   } else {
-    for (const f of blocking) {
+    const c = blockingList.filter((f) => f.severity === 'critical').length;
+    const m = blockingList.filter((f) => f.severity === 'major').length;
+    lines.push(`**判定**: ${emoji} ${label} — blocking ${blockingList.length} 件（critical ${c} / major ${m}）`);
+    lines.push('');
+    lines.push('| # | 重大度 | 場所 | 指摘 | 提案 |');
+    lines.push('|---|---|---|---|---|');
+    let idx = 1;
+    for (const f of blockingList) {
+      const sev = SEV_LABEL[f.severity] ?? f.severity;
       const loc = f.file != null
-        ? `${f.file}${f.line != null ? ':' + f.line : ''} `
-        : '';
-      const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
-      lines.push(`- [${f.severity}] ${loc}${f.description}${sug}`);
+        ? (f.line != null ? `\`${f.file}:${f.line}\`` : `\`${f.file}\``)
+        : '—';
+      const desc = mdCell(f.description);
+      const sug = f.suggestion != null ? mdCell(f.suggestion) : '—';
+      lines.push(`| ${idx} | ${sev} | ${loc} | ${desc} | ${sug} |`);
+      idx++;
     }
   }
 
@@ -94,38 +110,60 @@ const STATUS_HEADLINE = {
 };
 
 function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, history }) {
-  const headline = STATUS_HEADLINE[status] ?? status;
+  const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
+  const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const lines = [];
 
   lines.push(`## PR #${pr} — pr-iterate 終了レポート`);
   lines.push('');
-  lines.push(`### ${headline}`);
+  lines.push(`### ${STATUS_HEADLINE[status] ?? status}`);
   lines.push('');
-  lines.push(`- **総反復回数**: ${iterations}`);
-  lines.push(`- **最終判定**: ${DECISION_LABEL[lastDecision] ?? lastDecision}`);
-  lines.push(`- **最終判定理由**: ${lastSummary}`);
 
-  if (history && history.length > 0) {
+  lines.push('| 終了状態 | 総反復 | 最終判定 |');
+  lines.push('|---|---|---|');
+  const decEmoji = DECISION_EMOJI[lastDecision] ?? '';
+  const decLabel = DECISION_LABEL[lastDecision] ?? lastDecision;
+  lines.push(`| ${status} | ${iterations} | ${decEmoji} ${decLabel} |`);
+
+  lines.push('');
+  lines.push(`**最終判定理由**: ${lastSummary}`);
+
+  const histList = history || [];
+  if (histList.length > 0) {
     lines.push('');
     lines.push('### 反復履歴');
-    for (const round of history) {
-      const roundLabel = DECISION_LABEL[round.decision] ?? round.decision;
-      lines.push('');
-      lines.push(`#### Iteration ${round.iteration}: ${roundLabel}`);
-      lines.push(`${round.summary}`);
-      if (round.blocking && round.blocking.length > 0) {
-        lines.push(`- blocking 指摘数: ${round.blocking.length}`);
-        for (const f of round.blocking) {
-          const loc = f.file != null
-            ? `${f.file}${f.line != null ? ':' + f.line : ''} `
-            : '';
-          const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
-          lines.push(`  - [${f.severity}] ${loc}${f.description}${sug}`);
-        }
-      } else {
-        lines.push('- blocking 指摘なし');
-      }
+    lines.push('');
+    lines.push('| iter | 判定 | blocking | summary |');
+    lines.push('|---|---|---|---|');
+    for (const round of histList) {
+      const rEmoji = DECISION_EMOJI[round.decision] ?? '';
+      const rLabel = DECISION_LABEL[round.decision] ?? round.decision;
+      const bCount = (round.blocking ?? []).length;
+      const rawSummary = mdCell(round.summary);
+      const rSummary = rawSummary.length > 120 ? rawSummary.slice(0, 120) + '…' : rawSummary;
+      lines.push(`| ${round.iteration} | ${rEmoji} ${rLabel} | ${bCount} | ${rSummary} |`);
     }
+  }
+
+  const allBlocking = histList.flatMap((r) => (r.blocking ?? []).map((f) => ({ iter: r.iteration, ...f })));
+  const totalBlocking = allBlocking.length;
+  if (totalBlocking > 0) {
+    lines.push('');
+    lines.push(`<details><summary>全 blocking 指摘の詳細（${totalBlocking} 件）</summary>`);
+    lines.push('');
+    lines.push('| iter | 重大度 | 場所 | 指摘 | 提案 |');
+    lines.push('|---|---|---|---|---|');
+    for (const f of allBlocking) {
+      const sev = SEV_LABEL[f.severity] ?? f.severity;
+      const loc = f.file != null
+        ? (f.line != null ? `\`${f.file}:${f.line}\`` : `\`${f.file}\``)
+        : '—';
+      const desc = mdCell(f.description);
+      const sug = f.suggestion != null ? mdCell(f.suggestion) : '—';
+      lines.push(`| ${f.iter} | ${sev} | ${loc} | ${desc} | ${sug} |`);
+    }
+    lines.push('');
+    lines.push('</details>');
   }
 
   lines.push('');

--- a/_lib/devflow-summary-format.mjs
+++ b/_lib/devflow-summary-format.mjs
@@ -9,6 +9,17 @@
 // この関数を修正する際は、必ず dev-flow.js の inline コピーも同期すること。
 
 /**
+ * Markdown テーブルセルの値をエスケープする。
+ * パイプ文字を \| に、改行を <br> に変換する。
+ * @param {*} v
+ * @returns {string}
+ */
+export function mdCell(v) {
+  if (v == null) return '';
+  return String(v).replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+}
+
+/**
  * dev-flow 終端サマリー markdown を生成する。
  * @param {object} opts
  * @param {number|string} opts.pr - PR 番号
@@ -45,12 +56,60 @@ export function buildDevflowSummaryBody({
 }) {
   const lines = [];
 
+  const TIER_EMOJI = { 'HOLD': '🔶', 'REVIEW': '🔷', 'AUTO': '✅' };
+
   // 1. 見出し
   lines.push(`## dev-flow 終端サマリー — PR #${pr}`);
   lines.push('');
 
-  // 2. Merge tier セクション
-  lines.push(`### Merge tier: ${mergeTier}`);
+  // 2. at-a-glance テーブル
+  const tierCell = `${TIER_EMOJI[mergeTier] ?? ''} **${mergeTier}**`;
+  const shapeCell = shape != null ? shape : '不明';
+  let testCell;
+  if (testGreen == null) {
+    testCell = '不明';
+  } else if (testGreen === true) {
+    testCell = '✅ green';
+  } else {
+    testCell = '❌ red';
+  }
+  let evalCell;
+  if (evalVerdict == null) {
+    evalCell = '不明';
+  } else if (evalVerdict === 'pass') {
+    evalCell = '✅ pass';
+  } else {
+    evalCell = `❌ ${evalVerdict}`;
+  }
+  const ledgerCell = ledgerConverged ? '✅ 収束' : '⚠️ 未収束';
+  const acArr = acResults && acResults.length > 0 ? acResults : null;
+  let acCell;
+  if (!acArr) {
+    acCell = '—';
+  } else {
+    const s = acArr.filter(a => a.satisfied === true).length;
+    const t = acArr.length;
+    acCell = s === t ? `✅ ${s}/${t}` : `❌ ${s}/${t}`;
+  }
+  const dangerArr = dangerHits && dangerHits.length > 0 ? dangerHits : null;
+  const dangerCell = dangerArr ? `⚠️ ${dangerArr.length} クラス` : '✅ clean';
+
+  lines.push('| Merge tier | shape | test | eval | Ledger | AC | danger |');
+  lines.push('|---|---|---|---|---|---|---|');
+  lines.push(`| ${tierCell} | ${shapeCell} | ${testCell} | ${evalCell} | ${ledgerCell} | ${acCell} | ${dangerCell} |`);
+  lines.push('');
+
+  // 3. gate_policy 行
+  lines.push(`gate_policy: \`${gatePolicy}\``);
+
+  // 4. dangerHits 検出クラス行（1件以上のとき）
+  if (dangerArr) {
+    lines.push(`検出クラス: ${dangerArr.join(', ')}`);
+  }
+
+  // 5. Merge tier 理由（常時可視）
+  lines.push('');
+  lines.push('**Merge tier 理由**:');
   if (!mergeTierReasons || mergeTierReasons.length === 0) {
     lines.push('- 理由記載なし');
   } else {
@@ -58,98 +117,172 @@ export function buildDevflowSummaryBody({
       lines.push(`- ${reason}`);
     }
   }
+
+  // 6. 要対応セクション（常時可視）
+  // 未解消事項を収集
+  const blockArr = blockingItems || [];
+  const advArr = advisoryItems || [];
+  const uncheckedBlocking = blockArr.filter(it => it.checked !== true);
+  const uncheckedAdvisory = advArr.filter(it => it.checked !== true);
+  const escalatedChecked = advArr.filter(it => it.escalate === true && it.checked === true);
+  const unsatisfiedAC = acArr ? acArr.filter(a => a.satisfied !== true) : [];
+  const uncleared = securityClearance && securityClearance.length > 0
+    ? securityClearance.filter(sc => sc.cleared !== true)
+    : [];
+  const concerns = planConcerns || [];
+
+  const hasActionItems = uncheckedBlocking.length > 0
+    || uncheckedAdvisory.length > 0
+    || escalatedChecked.length > 0
+    || unsatisfiedAC.length > 0
+    || uncleared.length > 0
+    || concerns.length > 0;
+
   lines.push('');
-
-  // 2.5. ESCALATE-TO-HUMAN セクション（escalate item があるときのみ出力。人間が必ず読む冒頭近くに置く）
-  const escalated = (advisoryItems || []).filter((it) => it && it.escalate === true);
-  if (escalated.length > 0) {
-    lines.push('### ESCALATE-TO-HUMAN（人間の判断が必要）');
-    for (const item of escalated) {
-      const dimension = item.dimension ? ` [${item.dimension}]` : '';
-      const reason = item.escalate_reason ? `（reason: ${item.escalate_reason}）` : '';
-      lines.push(`- ${item.id}${dimension} ${item.text}${reason}`);
-    }
-    lines.push('');
-  }
-
-  // 3. 実行結果サマリー（shape / test_green / eval_verdict）
-  lines.push('### 実行結果');
-  lines.push(`- shape: ${shape != null ? shape : '不明'}`);
-  lines.push(`- test_green: ${testGreen != null ? String(testGreen) : '不明'}`);
-  lines.push(`- eval_verdict: ${evalVerdict != null ? evalVerdict : '不明'}`);
-  lines.push('');
-
-  // 4. Goal Ledger セクション
-  lines.push('### Goal Ledger');
-  lines.push(`- gate_policy: ${gatePolicy}`);
-  lines.push(`- 収束: ${ledgerConverged ? '済' : '未収束'}`);
-
-  // blocking items
-  if (!blockingItems || blockingItems.length === 0) {
-    lines.push('- blocking item なし');
+  if (!hasActionItems) {
+    lines.push('### ✅ 要対応事項なし');
   } else {
-    for (const item of blockingItems) {
-      const status = item.checked ? 'checked' : '未解消';
-      const dimension = item.dimension ? ` [${item.dimension}]` : '';
-      const evidence = item.evidence ? ': ' + item.evidence : '';
-      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}`);
+    lines.push('### ⚠️ 要対応');
+
+    // ledger 未解消テーブル（(i)(ii)(iii)）
+    const ledgerActionItems = [
+      ...uncheckedBlocking.map(it => ({ ...it, _lane: 'blocking' })),
+      ...uncheckedAdvisory.map(it => ({
+        ...it,
+        _lane: it.escalate ? 'advisory (ESCALATE)' : 'advisory',
+      })),
+      ...escalatedChecked.map(it => ({ ...it, _lane: 'advisory (ESCALATE)', _forceVisible: true })),
+    ];
+
+    if (ledgerActionItems.length > 0) {
+      lines.push('');
+      lines.push('| 状態 | id | lane | dimension | 内容 |');
+      lines.push('|---|---|---|---|---|');
+      for (const item of ledgerActionItems) {
+        const status = (item.checked === true && item.escalate) ? '⚠️ 要判断' : '❌ 未解消';
+        const dimension = item.dimension != null ? item.dimension : '—';
+        let content = mdCell(item.text);
+        if (item.evidence) {
+          content += ': ' + mdCell(item.evidence);
+        }
+        if (item.escalate_reason) {
+          content += `（reason: ${mdCell(item.escalate_reason)}）`;
+        }
+        lines.push(`| ${status} | ${item.id} | ${item._lane} | ${dimension} | ${content} |`);
+      }
+    }
+
+    // 未達 AC テーブル（(iv)）
+    if (unsatisfiedAC.length > 0) {
+      lines.push('');
+      lines.push('| 状態 | AC | 検証 | evidence |');
+      lines.push('|---|---|---|---|');
+      for (const ac of unsatisfiedAC) {
+        const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
+        const evidenceCell = ac.evidence ? mdCell(ac.evidence) : '—';
+        lines.push(`| ❌ 未達 | AC#${ac.ac_index + 1} | ${verifiedBy} | ${evidenceCell} |`);
+      }
+    }
+
+    // 未確認 clearance テーブル（(v)）
+    if (uncleared.length > 0) {
+      lines.push('');
+      lines.push('| 状態 | danger class | evidence |');
+      lines.push('|---|---|---|');
+      for (const sc of uncleared) {
+        const evidenceCell = sc.evidence ? mdCell(sc.evidence) : '—';
+        lines.push(`| ❌ 未確認 | ${sc.danger_class} | ${evidenceCell} |`);
+      }
+    }
+
+    // Plan concerns（(vi)）
+    if (concerns.length > 0) {
+      lines.push('');
+      lines.push('**Plan 未解消 concerns**:');
+      for (const concern of concerns) {
+        lines.push(`- ${concern}`);
+      }
     }
   }
 
-  // advisory items
-  if (!advisoryItems || advisoryItems.length === 0) {
-    lines.push('- advisory item なし');
-  } else {
-    for (const item of advisoryItems) {
-      const status = item.checked ? 'checked' : '未解消';
-      const escalateSuffix = item.escalate ? ' (ESCALATE)' : '';
-      const dimension = item.dimension ? ` [${item.dimension}]` : '';
-      const evidence = item.evidence ? ': ' + item.evidence : '';
-      lines.push(`- [${status}] ${item.id}${dimension} ${item.text}${evidence}${escalateSuffix}`);
-    }
+  // 8. 空状態の常時可視行
+  if (blockArr.length === 0 && advArr.length === 0) {
+    lines.push('Goal Ledger: item なし');
   }
-  lines.push('');
-
-  // 5. AC evidence セクション
-  lines.push('### Acceptance Criteria');
   if (!acResults || acResults.length === 0) {
-    lines.push('AC 判定なし（evaluator 未実行 or AC 欠落）');
-  } else {
-    for (const ac of acResults) {
-      const satisfiedLabel = ac.satisfied ? 'satisfied' : '未達';
-      const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
-      const evidenceSuffix = ac.evidence ? ': ' + ac.evidence : '';
-      lines.push(`- AC#${ac.ac_index + 1}: ${satisfiedLabel}（${verifiedBy}）${evidenceSuffix}`);
-    }
+    lines.push('Acceptance Criteria: AC 判定なし（evaluator 未実行 or AC 欠落）');
   }
-  lines.push('');
-
-  // 6. Security clearance セクション
-  lines.push('### Security clearance');
   if (!securityClearance || securityClearance.length === 0) {
-    lines.push('- danger-grep clean（clearance 不要）');
-  } else {
-    for (const sc of securityClearance) {
-      const clearedLabel = sc.cleared ? 'cleared' : '未確認';
-      const evidenceSuffix = sc.evidence ? ': ' + sc.evidence : '';
-      lines.push(`- ${sc.danger_class}: ${clearedLabel}${evidenceSuffix}`);
-    }
+    lines.push('Security clearance: danger-grep clean（clearance 不要）');
   }
-  if (dangerHits && dangerHits.length > 0) {
-    lines.push(`- 検出クラス: ${dangerHits.join(', ')}`);
-  }
-  lines.push('');
 
-  // 7. Plan concerns セクション（空なら省略）
-  if (planConcerns && planConcerns.length > 0) {
-    lines.push('### Plan 未解消 concerns');
-    for (const concern of planConcerns) {
-      lines.push(`- ${concern}`);
+  // 7. 折りたたみブロック群（AC-3）
+
+  // 解消済み ledger
+  const resolvedItems = [
+    ...blockArr.filter(it => it.checked === true).map(it => ({ ...it, _lane: 'blocking' })),
+    ...advArr.filter(it => it.checked === true && it.escalate !== true).map(it => ({ ...it, _lane: 'advisory' })),
+  ];
+  if (resolvedItems.length > 0) {
+    const n = resolvedItems.length;
+    lines.push('');
+    lines.push(`<details><summary>✅ Goal Ledger 解消済み ${n} 件</summary>`);
+    lines.push('');
+    lines.push('| id | lane | dimension | 内容 | evidence |');
+    lines.push('|---|---|---|---|---|');
+    for (const item of resolvedItems) {
+      const dimension = item.dimension != null ? item.dimension : '—';
+      const content = mdCell(item.text);
+      const evidence = item.evidence ? mdCell(item.evidence) : '—';
+      lines.push(`| ${item.id} | ${item._lane} | ${dimension} | ${content} | ${evidence} |`);
     }
     lines.push('');
+    lines.push('</details>');
   }
 
-  // 8. 末尾
+  // satisfied AC
+  if (acArr) {
+    const satisfiedAC = acArr.filter(a => a.satisfied === true);
+    const s = satisfiedAC.length;
+    const t = acArr.length;
+    if (s > 0) {
+      lines.push('');
+      lines.push(`<details><summary>✅ Acceptance Criteria ${s}/${t} satisfied</summary>`);
+      lines.push('');
+      lines.push('| AC | 検証 | evidence |');
+      lines.push('|---|---|---|');
+      for (const ac of satisfiedAC) {
+        const verifiedBy = ac.verified_by != null ? ac.verified_by : 'inspection';
+        const evidenceCell = ac.evidence ? mdCell(ac.evidence) : '—';
+        lines.push(`| AC#${ac.ac_index + 1} | ${verifiedBy} | ${evidenceCell} |`);
+      }
+      lines.push('');
+      lines.push('</details>');
+    }
+  }
+
+  // cleared security clearance
+  if (securityClearance && securityClearance.length > 0) {
+    const cleared = securityClearance.filter(sc => sc.cleared === true);
+    const c = cleared.length;
+    const ct = securityClearance.length;
+    if (c > 0) {
+      lines.push('');
+      lines.push(`<details><summary>✅ Security clearance ${c}/${ct} cleared</summary>`);
+      lines.push('');
+      lines.push('| danger class | evidence |');
+      lines.push('|---|---|');
+      for (const sc of cleared) {
+        const evidenceCell = sc.evidence ? mdCell(sc.evidence) : '—';
+        lines.push(`| ${sc.danger_class} | ${evidenceCell} |`);
+      }
+      lines.push('');
+      lines.push('</details>');
+    }
+  }
+
+  // 9. 末尾
+  lines.push('');
   lines.push('---');
   lines.push('*このコメントは dev-flow により自動生成されました。*');
   lines.push(`<!-- dev-flow:${mergeTier} -->`);

--- a/_lib/devflow-summary-format.mjs
+++ b/_lib/devflow-summary-format.mjs
@@ -206,6 +206,10 @@ export function buildDevflowSummaryBody({
   }
 
   // 8. 空状態の常時可視行
+  // 直前コンテンツ（テーブル行 / bullet）との間に必ず空行を挿入する。
+  // GFM はテーブル終端行を空行で判定し、bullet も lazy continuation で吸収するため
+  // 空行なしで push するとテーブル壊れ・bullet 併合が起きる（AC-2 実効性を損なう）。
+  if (lines[lines.length - 1] !== '') lines.push('');
   if (blockArr.length === 0 && advArr.length === 0) {
     lines.push('Goal Ledger: item なし');
   }

--- a/_lib/devflow-summary-format.sync.test.mjs
+++ b/_lib/devflow-summary-format.sync.test.mjs
@@ -2,7 +2,7 @@
 //
 // 背景: .claude/workflows/dev-flow.js は Claude Code の dynamic workflow ローダーが
 // 独自の VM コンテキストで評価する。ESM の import 文はそのコンテキストで使用できないため、
-// buildDevflowSummaryBody の関数本体を dev-flow.js に inline コピーしている。
+// mdCell / buildDevflowSummaryBody の関数本体を dev-flow.js に inline コピーしている。
 // このテストはその手動同期の漏れを CI で検出するための安全網である。
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -13,18 +13,25 @@ import { dirname, join } from 'node:path';
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..');
 
+// canonical ソースまたは inline コピーから指定関数の `function fnName ... }` ブロックを抽出する。
+// export キーワードは除いて比較するため、先頭の `export ` を strip する。
 function extractFn(src, fnName) {
   const m = src.match(new RegExp(`function ${fnName}\\([\\s\\S]*?\\n}`));
   if (!m) throw new Error(`${fnName} が見つからない`);
   return m[0].trim();
 }
 
-const fnName = 'buildDevflowSummaryBody';
-const canonicalSrc = readFileSync(join(repoRoot, '_lib/devflow-summary-format.mjs'), 'utf8');
-const canonical = extractFn(canonicalSrc, fnName);
+for (const fnName of ['mdCell', 'buildDevflowSummaryBody']) {
+  const canonicalSrc = readFileSync(join(repoRoot, '_lib/devflow-summary-format.mjs'), 'utf8');
+  const canonical = extractFn(canonicalSrc, fnName);
 
-test(`.claude/workflows/dev-flow.js の inline ${fnName} が canonical と byte 一致`, () => {
-  const inlinedSrc = readFileSync(join(repoRoot, '.claude/workflows/dev-flow.js'), 'utf8');
-  const inlined = extractFn(inlinedSrc, fnName);
-  assert.equal(inlined, canonical, `.claude/workflows/dev-flow.js の inline コピー ${fnName} が _lib/devflow-summary-format.mjs と乖離している`);
-});
+  test(`.claude/workflows/dev-flow.js の inline ${fnName} が canonical と byte 一致`, () => {
+    const inlinedSrc = readFileSync(join(repoRoot, '.claude/workflows/dev-flow.js'), 'utf8');
+    const inlined = extractFn(inlinedSrc, fnName);
+    assert.equal(
+      inlined,
+      canonical,
+      `.claude/workflows/dev-flow.js の inline コピー ${fnName} が _lib/devflow-summary-format.mjs と乖離している`,
+    );
+  });
+}

--- a/_lib/devflow-summary-format.test.mjs
+++ b/_lib/devflow-summary-format.test.mjs
@@ -779,3 +779,49 @@ test('旧形式「### Security clearance」セクション見出しが出ない'
   const body = buildDevflowSummaryBody({ ...BASE_INPUT });
   assert.ok(!body.includes('### Security clearance'), '旧 Security clearance セクションが出ない');
 });
+
+// ─── 空状態行の直前行が空行であること (GFM テーブル・bullet 崩壊防止) ──────────
+
+test('要対応テーブルあり + securityClearance 空 -> Security clearance 空状態行の直前行が空行', () => {
+  // ケース(a): HOLD + danger clean の典型。unchecked blocking item あり（テーブル行末）、
+  // acResults は非空（AC 空状態行は出ない）、securityClearance のみ空（clearance 空状態行が出る）。
+  // 要対応テーブルの最終行（| ... |）直後に空行なしで空状態行が push されると
+  // GFM がテーブル行として吸収し壊れる。直前行が空行であることを assert する。
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'HOLD',
+    mergeTierReasons: ['blocking item unresolved'],
+    blockingItems: [
+      { id: 'B1', text: 'unresolved item', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'ok', verified_by: 'evaluator' },
+    ],
+    securityClearance: undefined,
+  });
+  const lines = body.split('\n');
+  const secIdx = lines.findIndex(l => l.includes('Security clearance: danger-grep clean'));
+  assert.ok(secIdx >= 0, 'Security clearance 空状態行が存在する');
+  assert.equal(lines[secIdx - 1], '', `Security clearance 空状態行の直前行（index ${secIdx - 1}）が空行`);
+});
+
+test('planConcerns あり + acResults 空 -> AC 空状態行の直前行が空行', () => {
+  // ケース(b): planConcerns が要対応セクションの最後の場合。
+  // blockingItems は非空（Goal Ledger 空状態行は出ない）、securityClearance は非空（clearance 空状態行は出ない）。
+  // "- concern A" 直後に空行なしで AC 空状態行が push されると
+  // GFM の lazy continuation で bullet 内に視覚的に併合される。
+  // 直前行が空行であることを assert する。
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'unresolved', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+    planConcerns: ['concern A'],
+    acResults: undefined,
+    securityClearance: [{ danger_class: 'SQL_INJECTION', cleared: true, evidence: 'ok' }],
+  });
+  const lines = body.split('\n');
+  const acIdx = lines.findIndex(l => l.includes('Acceptance Criteria: AC 判定なし'));
+  assert.ok(acIdx >= 0, 'AC 空状態行が存在する');
+  assert.equal(lines[acIdx - 1], '', `AC 空状態行の直前行（index ${acIdx - 1}）が空行`);
+});

--- a/_lib/devflow-summary-format.test.mjs
+++ b/_lib/devflow-summary-format.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildDevflowSummaryBody } from './devflow-summary-format.mjs';
+import { buildDevflowSummaryBody, mdCell } from './devflow-summary-format.mjs';
 
 // ─── 共通テストデータ ───────────────────────────────────────────────────────────
 
@@ -16,39 +16,172 @@ const BASE_INPUT = {
   securityClearance: undefined,
   planConcerns: [],
   dangerHits: [],
+  shape: 'standard',
+  testGreen: true,
+  evalVerdict: 'pass',
 };
 
-// ─── mergeTier ────────────────────────────────────────────────────────────────
+// ─── mdCell ───────────────────────────────────────────────────────────────────
 
-test('mergeTier=HOLD -> 見出しに HOLD を含む', () => {
+test('mdCell: null -> 空文字', () => {
+  assert.equal(mdCell(null), '');
+});
+
+test('mdCell: undefined -> 空文字', () => {
+  assert.equal(mdCell(undefined), '');
+});
+
+test('mdCell: | をエスケープ', () => {
+  assert.equal(mdCell('a|b'), 'a\\|b');
+});
+
+test('mdCell: \\n を <br> に変換', () => {
+  assert.equal(mdCell('a\nb'), 'a<br>b');
+});
+
+test('mdCell: \\r\\n を <br> に変換', () => {
+  assert.equal(mdCell('a\r\nb'), 'a<br>b');
+});
+
+test('mdCell: 通常文字列はそのまま', () => {
+  assert.equal(mdCell('hello world'), 'hello world');
+});
+
+// ─── at-a-glance テーブル絵文字 ──────────────────────────────────────────────
+
+test('mergeTier=HOLD -> at-a-glance テーブルに🔶 **HOLD** を含む', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
     mergeTier: 'HOLD',
     mergeTierReasons: ['danger hit detected'],
   });
-  assert.ok(typeof body === 'string', 'string を返す');
-  assert.ok(body.includes('HOLD'), 'HOLD を含む');
-  assert.ok(body.includes('danger hit detected'), 'reason を含む');
+  assert.ok(body.includes('🔶 **HOLD**'), 'HOLD 絵文字を含む');
 });
 
-test('mergeTier=REVIEW -> 見出しに REVIEW を含む', () => {
+test('mergeTier=REVIEW -> at-a-glance テーブルに🔷 **REVIEW** を含む', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
     mergeTier: 'REVIEW',
-    mergeTierReasons: ['advisory item present'],
   });
-  assert.ok(body.includes('REVIEW'), 'REVIEW を含む');
-  assert.ok(body.includes('advisory item present'), 'reason を含む');
+  assert.ok(body.includes('🔷 **REVIEW**'), 'REVIEW 絵文字を含む');
 });
 
-test('mergeTier=AUTO -> 見出しに AUTO を含む', () => {
+test('mergeTier=AUTO -> at-a-glance テーブルに✅ **AUTO** を含む', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
     mergeTier: 'AUTO',
     mergeTierReasons: [],
   });
-  assert.ok(body.includes('AUTO'), 'AUTO を含む');
+  assert.ok(body.includes('✅ **AUTO**'), 'AUTO 絵文字を含む');
 });
+
+test('at-a-glance テーブルにヘッダー行を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT });
+  assert.ok(body.includes('| Merge tier | shape | test | eval | Ledger | AC | danger |'), 'ヘッダー行を含む');
+});
+
+test('testGreen=true -> at-a-glance テーブルに「✅ green」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, testGreen: true });
+  assert.ok(body.includes('✅ green'), 'test green を含む');
+});
+
+test('testGreen=false -> at-a-glance テーブルに「❌ red」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, testGreen: false });
+  assert.ok(body.includes('❌ red'), 'test red を含む');
+});
+
+test('testGreen=null -> at-a-glance テーブルに「不明」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, testGreen: null });
+  assert.ok(body.includes('不明'), 'test 不明を含む');
+});
+
+test('evalVerdict=pass -> at-a-glance テーブルに「✅ pass」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, evalVerdict: 'pass' });
+  assert.ok(body.includes('✅ pass'), 'eval pass を含む');
+});
+
+test('evalVerdict=fail -> at-a-glance テーブルに「❌ fail」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, evalVerdict: 'fail' });
+  assert.ok(body.includes('❌ fail'), 'eval fail を含む');
+});
+
+test('evalVerdict=null -> at-a-glance テーブルに「不明」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, evalVerdict: null });
+  assert.ok(body.includes('不明'), 'eval 不明を含む');
+});
+
+test('ledgerConverged=true -> at-a-glance テーブルに「✅ 収束」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, ledgerConverged: true });
+  assert.ok(body.includes('✅ 収束'), 'ledger 収束を含む');
+});
+
+test('ledgerConverged=false -> at-a-glance テーブルに「⚠️ 未収束」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, ledgerConverged: false });
+  assert.ok(body.includes('⚠️ 未収束'), 'ledger 未収束を含む');
+});
+
+test('dangerHits 2件 -> at-a-glance テーブルに「⚠️ 2 クラス」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    dangerHits: ['SQL_INJECTION', 'PATH_TRAVERSAL'],
+  });
+  assert.ok(body.includes('⚠️ 2 クラス'), 'danger 2クラスを含む');
+});
+
+test('dangerHits 0件 -> at-a-glance テーブルに「✅ clean」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, dangerHits: [] });
+  assert.ok(body.includes('✅ clean'), 'danger clean を含む');
+});
+
+test('acResults 6件全 satisfied -> at-a-glance テーブルに「✅ 6/6」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'ok1', verified_by: 'evaluator' },
+      { ac_index: 1, satisfied: true, evidence: 'ok2', verified_by: 'evaluator' },
+      { ac_index: 2, satisfied: true, evidence: 'ok3', verified_by: 'evaluator' },
+      { ac_index: 3, satisfied: true, evidence: 'ok4', verified_by: 'evaluator' },
+      { ac_index: 4, satisfied: true, evidence: 'ok5', verified_by: 'evaluator' },
+      { ac_index: 5, satisfied: true, evidence: 'ok6', verified_by: 'evaluator' },
+    ],
+  });
+  assert.ok(body.includes('✅ 6/6'), 'AC 6/6 を含む');
+});
+
+test('acResults undefined -> at-a-glance テーブルに「—」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, acResults: undefined });
+  assert.ok(body.includes('—'), 'AC — を含む');
+});
+
+// ─── gatePolicy ───────────────────────────────────────────────────────────────
+
+test('gatePolicy 文字列が at-a-glance 直下行に出る', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    gatePolicy: 'llm-major-advisory',
+  });
+  assert.ok(body.includes('`llm-major-advisory`'), 'gatePolicy バッククォートを含む');
+  const lines = body.split('\n');
+  const gatePolicyLineIdx = lines.findIndex(l => l.includes('gate_policy:') && l.includes('llm-major-advisory'));
+  assert.ok(gatePolicyLineIdx >= 0, 'gate_policy 行を含む');
+});
+
+// ─── dangerHits 検出クラス ────────────────────────────────────────────────────
+
+test('dangerHits 2件 -> 「検出クラス: SQL_INJECTION, PATH_TRAVERSAL」行を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    dangerHits: ['SQL_INJECTION', 'PATH_TRAVERSAL'],
+  });
+  assert.ok(body.includes('検出クラス: SQL_INJECTION, PATH_TRAVERSAL'), '検出クラス行を含む');
+});
+
+test('dangerHits 0件 -> 「検出クラス:」行を含まない', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, dangerHits: [] });
+  assert.ok(!body.includes('検出クラス:'), '検出クラス行を含まない');
+});
+
+// ─── Merge tier 理由 ──────────────────────────────────────────────────────────
 
 test('mergeTierReasons が空の場合は「理由記載なし」を含む', () => {
   const body = buildDevflowSummaryBody({
@@ -70,255 +203,461 @@ test('mergeTierReasons が複数件の場合はすべてを含む', () => {
   assert.ok(body.includes('reason C'), '3件目を含む');
 });
 
-// ─── Goal Ledger (blockingItems / advisoryItems) ──────────────────────────────
+test('Merge tier 理由セクションは常時可視（details 前）', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    mergeTier: 'REVIEW',
+    mergeTierReasons: ['advisory item present'],
+    blockingItems: [
+      { id: 'B1', text: 'check this', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  const detailsIdx = body.indexOf('<details>');
+  const reasonIdx = body.indexOf('advisory item present');
+  if (detailsIdx >= 0) {
+    assert.ok(reasonIdx < detailsIdx, 'Merge tier 理由は details より前');
+  } else {
+    assert.ok(reasonIdx >= 0, 'Merge tier 理由を含む');
+  }
+});
 
-test('blockingItems / advisoryItems 0件 -> 「blocking item なし」を含む', () => {
+// ─── 常時可視 invariant (AC-2) ────────────────────────────────────────────────
+
+test('常時可視 invariant: unchecked blocking item が details より前に出る', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'unchecked blocking text', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+    advisoryItems: [
+      { id: 'A1', text: 'checked advisory', severity: 'minor', checked: true, dimension: 'style', escalate: false },
+    ],
+  });
+  const detailsIdx = body.indexOf('<details>');
+  const blockingIdx = body.indexOf('unchecked blocking text');
+  assert.ok(blockingIdx >= 0, 'blocking text を含む');
+  if (detailsIdx >= 0) {
+    assert.ok(blockingIdx < detailsIdx, 'unchecked blocking が details より前');
+  }
+});
+
+test('常時可視 invariant: 未達 AC が details より前に出る', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [
+      { ac_index: 0, satisfied: false, evidence: 'failed evidence', verified_by: 'evaluator' },
+      { ac_index: 1, satisfied: true, evidence: 'passed', verified_by: 'evaluator' },
+    ],
+  });
+  const detailsIdx = body.indexOf('<details>');
+  const failedIdx = body.indexOf('AC#1');
+  assert.ok(failedIdx >= 0, '未達 AC を含む');
+  if (detailsIdx >= 0) {
+    assert.ok(failedIdx < detailsIdx, '未達 AC が details より前');
+  }
+});
+
+test('常時可視 invariant: 未確認 clearance が details より前に出る', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    securityClearance: [
+      { danger_class: 'XSS', cleared: false, evidence: '' },
+      { danger_class: 'SQL_INJECTION', cleared: true, evidence: 'ok' },
+    ],
+  });
+  const detailsIdx = body.indexOf('<details>');
+  const unclearedIdx = body.indexOf('XSS');
+  assert.ok(unclearedIdx >= 0, '未確認 clearance を含む');
+  if (detailsIdx >= 0) {
+    assert.ok(unclearedIdx < detailsIdx, '未確認 clearance が details より前');
+  }
+});
+
+test('常時可視 invariant: planConcerns が details より前に出る', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    planConcerns: ['concern X'],
+    blockingItems: [
+      { id: 'B1', text: 'b', severity: 'critical', checked: true, dimension: 'sec' },
+    ],
+  });
+  const detailsIdx = body.indexOf('<details>');
+  const concernIdx = body.indexOf('concern X');
+  assert.ok(concernIdx >= 0, 'concern を含む');
+  if (detailsIdx >= 0) {
+    assert.ok(concernIdx < detailsIdx, 'concern が details より前');
+  }
+});
+
+// ─── 要対応セクション (AC-2) ──────────────────────────────────────────────────
+
+test('要対応ゼロ -> 「### ✅ 要対応事項なし」を含み「### ⚠️ 要対応」を含まない', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'resolved', severity: 'major', checked: true, dimension: 'quality' },
+    ],
+    advisoryItems: [
+      { id: 'A1', text: 'resolved advisory', severity: 'minor', checked: true, dimension: 'style', escalate: false },
+    ],
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'ok', verified_by: 'evaluator' },
+    ],
+    securityClearance: [
+      { danger_class: 'SQL_INJECTION', cleared: true, evidence: 'safe' },
+    ],
+    planConcerns: [],
+  });
+  assert.ok(body.includes('### ✅ 要対応事項なし'), '要対応事項なしを含む');
+  assert.ok(!body.includes('### ⚠️ 要対応'), '⚠️ 要対応を含まない');
+});
+
+test('unchecked blocking item あり -> 「### ⚠️ 要対応」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'unresolved', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  assert.ok(body.includes('### ⚠️ 要対応'), '要対応を含む');
+  assert.ok(!body.includes('### ✅ 要対応事項なし'), '要対応事項なしを含まない');
+});
+
+test('未達 AC あり -> 「### ⚠️ 要対応」を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [
+      { ac_index: 0, satisfied: false, evidence: 'fail', verified_by: 'evaluator' },
+    ],
+  });
+  assert.ok(body.includes('### ⚠️ 要対応'), '要対応を含む');
+});
+
+test('escalate=true かつ checked=true の advisory item が要対応テーブルに出る', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'escalated but checked', severity: 'major', checked: true, dimension: 'quality', escalate: true, escalate_reason: 'human needed' },
+    ],
+  });
+  assert.ok(body.includes('### ⚠️ 要対応'), '要対応を含む（escalate checked でも常時可視）');
+  assert.ok(body.includes('advisory (ESCALATE)'), 'advisory (ESCALATE) lane を含む');
+  const detailsIdx = body.indexOf('<details>');
+  const escalateIdx = body.indexOf('escalated but checked');
+  assert.ok(escalateIdx >= 0, 'escalate item text を含む');
+  if (detailsIdx >= 0) {
+    assert.ok(escalateIdx < detailsIdx, 'escalate item が details より前');
+  }
+});
+
+test('ledger 未解消テーブルに「❌ 未解消」状態を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'blocking text', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  assert.ok(body.includes('❌ 未解消'), '未解消状態を含む');
+});
+
+test('escalate=true checked=true -> テーブルに「⚠️ 要判断」状態を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'escalated checked', severity: 'major', checked: true, dimension: 'quality', escalate: true },
+    ],
+  });
+  assert.ok(body.includes('⚠️ 要判断'), '要判断状態を含む');
+});
+
+test('ledger テーブルに | 状態 | id | lane | dimension | 内容 | ヘッダーを含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'check', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  assert.ok(body.includes('| 状態 | id | lane | dimension | 内容 |'), 'ledger テーブルヘッダーを含む');
+});
+
+test('blocking item の lane が「blocking」', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'blocking item', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  const lines = body.split('\n');
+  const itemLine = lines.find(l => l.includes('B1') && l.includes('blocking item'));
+  assert.ok(itemLine, 'B1 行を含む');
+  assert.ok(itemLine.includes('| blocking |'), 'blocking lane を含む');
+});
+
+test('advisory item の lane が「advisory」', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'advisory item', severity: 'minor', checked: false, dimension: 'style', escalate: false },
+    ],
+  });
+  const lines = body.split('\n');
+  const itemLine = lines.find(l => l.includes('A1') && l.includes('advisory item'));
+  assert.ok(itemLine, 'A1 行を含む');
+  assert.ok(itemLine.includes('| advisory |'), 'advisory lane を含む');
+});
+
+test('escalate advisory item の lane が「advisory (ESCALATE)」', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'escalated advisory', severity: 'major', checked: false, dimension: 'quality', escalate: true },
+    ],
+  });
+  const lines = body.split('\n');
+  const itemLine = lines.find(l => l.includes('A1') && l.includes('escalated advisory'));
+  assert.ok(itemLine, 'A1 行を含む');
+  assert.ok(itemLine.includes('| advisory (ESCALATE) |'), 'advisory (ESCALATE) lane を含む');
+});
+
+test('ledger item に escalate_reason があれば「（reason: ...）」が後置される', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    advisoryItems: [
+      { id: 'A1', text: 'escalated', severity: 'major', checked: false, dimension: 'quality', escalate: true, escalate_reason: 'needs human review' },
+    ],
+  });
+  assert.ok(body.includes('（reason: needs human review）'), 'escalate_reason を含む');
+});
+
+test('未達 AC テーブルに | 状態 | AC | 検証 | evidence | ヘッダーを含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [
+      { ac_index: 0, satisfied: false, evidence: 'fail', verified_by: 'evaluator' },
+    ],
+  });
+  assert.ok(body.includes('| 状態 | AC | 検証 | evidence |'), 'AC テーブルヘッダーを含む');
+});
+
+test('未確認 clearance テーブルに | 状態 | danger class | evidence | ヘッダーを含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    securityClearance: [
+      { danger_class: 'XSS', cleared: false, evidence: '' },
+    ],
+  });
+  assert.ok(body.includes('| 状態 | danger class | evidence |'), 'clearance テーブルヘッダーを含む');
+});
+
+// ─── エスケープ (AC-4) ────────────────────────────────────────────────────────
+
+test('text に | を含む item でセルが \\\\| にエスケープされる', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'text with | pipe', severity: 'critical', checked: false, dimension: 'security' },
+    ],
+  });
+  assert.ok(body.includes('text with \\| pipe'), 'パイプがエスケープされる');
+});
+
+test('evidence に \\n を含む item でセルが <br> に変換される', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'item', severity: 'critical', checked: false, dimension: 'security', evidence: 'line1\nline2' },
+    ],
+  });
+  assert.ok(body.includes('line1<br>line2'), '改行が <br> に変換される');
+});
+
+// ─── 30 item + details 折りたたみ (AC-3) ─────────────────────────────────────
+
+test('checked item 30件 + unchecked 1件 -> checked が details 内・unchecked が details 外', () => {
+  const blockingItems = [];
+  for (let i = 0; i < 30; i++) {
+    blockingItems.push({
+      id: `B${i + 1}`,
+      text: `checked item ${i + 1}`,
+      severity: 'major',
+      checked: true,
+      dimension: 'quality',
+      evidence: `evidence ${i + 1}`,
+    });
+  }
+  blockingItems.push({
+    id: 'B31',
+    text: 'unchecked item 31',
+    severity: 'critical',
+    checked: false,
+    dimension: 'security',
+  });
+
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems,
+  });
+
+  const detailsIdx = body.indexOf('<details>');
+  assert.ok(detailsIdx >= 0, '<details> を含む');
+
+  // unchecked item は details より前
+  const uncheckedIdx = body.indexOf('unchecked item 31');
+  assert.ok(uncheckedIdx >= 0, 'unchecked item を含む');
+  assert.ok(uncheckedIdx < detailsIdx, 'unchecked item が details より前');
+
+  // details summary に 30件表示
+  assert.ok(body.includes('✅ Goal Ledger 解消済み 30 件'), 'details summary に 30 件を含む');
+
+  // checked item は details 以降にのみ出現
+  for (let i = 0; i < 30; i++) {
+    const id = `B${i + 1}`;
+    const firstIdx = body.indexOf(`| ${id} |`);
+    // checked items should only appear after <details>
+    assert.ok(firstIdx > detailsIdx, `${id} が details 以降にのみ出現`);
+  }
+});
+
+// ─── satisfied AC details (AC-3) ─────────────────────────────────────────────
+
+test('acResults 6件全 satisfied -> details に「Acceptance Criteria 6/6 satisfied」summary を含む', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'ok1', verified_by: 'evaluator' },
+      { ac_index: 1, satisfied: true, evidence: 'ok2', verified_by: 'evaluator' },
+      { ac_index: 2, satisfied: true, evidence: 'ok3', verified_by: 'evaluator' },
+      { ac_index: 3, satisfied: true, evidence: 'ok4', verified_by: 'evaluator' },
+      { ac_index: 4, satisfied: true, evidence: 'ok5', verified_by: 'evaluator' },
+      { ac_index: 5, satisfied: true, evidence: 'ok6', verified_by: 'evaluator' },
+    ],
+  });
+  assert.ok(body.includes('Acceptance Criteria 6/6 satisfied'), 'details summary を含む');
+  // satisfied AC は details 内
+  const detailsIdx = body.indexOf('<details>');
+  assert.ok(detailsIdx >= 0, '<details> を含む');
+});
+
+// ─── securityClearance details (AC-3) ────────────────────────────────────────
+
+test('securityClearance 未確認 1件 + cleared 6件 -> 未確認が details 外・cleared が details 内', () => {
+  const securityClearance = [];
+  for (let i = 0; i < 6; i++) {
+    securityClearance.push({
+      danger_class: `SAFE_CLASS_${i}`,
+      cleared: true,
+      evidence: `evidence ${i}`,
+    });
+  }
+  securityClearance.push({
+    danger_class: 'UNCLEARED_CLASS',
+    cleared: false,
+    evidence: '',
+  });
+
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    securityClearance,
+    dangerHits: ['UNCLEARED_CLASS'],
+  });
+
+  const detailsIdx = body.indexOf('<details>');
+  const unclearedIdx = body.indexOf('UNCLEARED_CLASS');
+  assert.ok(unclearedIdx >= 0, '未確認クラスを含む');
+  if (detailsIdx >= 0) {
+    assert.ok(unclearedIdx < detailsIdx, '未確認が details より前');
+  }
+  assert.ok(body.includes('Security clearance 6/7 cleared'), 'clearance details summary を含む');
+});
+
+// ─── details 直後空行 (AC-3) ─────────────────────────────────────────────────
+
+test('各 <summary> を含む行の直後が空行', () => {
+  const body = buildDevflowSummaryBody({
+    ...BASE_INPUT,
+    blockingItems: [
+      { id: 'B1', text: 'resolved', severity: 'major', checked: true, dimension: 'quality' },
+    ],
+    acResults: [
+      { ac_index: 0, satisfied: true, evidence: 'ok', verified_by: 'evaluator' },
+    ],
+  });
+  const lines = body.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('<summary>') && lines[i].includes('</summary>')) {
+      assert.equal(lines[i + 1], '', `<summary> 行 ${i} の直後が空行`);
+    }
+  }
+});
+
+// ─── 空状態の常時可視行 ────────────────────────────────────────────────────────
+
+test('blockingItems も advisoryItems も空 -> 「Goal Ledger: item なし」を含む', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
     blockingItems: [],
     advisoryItems: [],
   });
-  assert.ok(body.includes('blocking item なし'), 'blocking 空時の表示');
-  // undefined が文字列に展開されていないこと
-  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
+  assert.ok(body.includes('Goal Ledger: item なし'), 'Goal Ledger item なしを含む');
 });
 
-test('blockingItems 複数件 -> 各 id/text を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    blockingItems: [
-      { id: 'B1', text: 'security unresolved', severity: 'critical', checked: false, dimension: 'security' },
-      { id: 'B2', text: 'AC unsatisfied', severity: 'major', checked: true, dimension: 'quality' },
-    ],
-  });
-  assert.ok(body.includes('B1'), 'B1 id を含む');
-  assert.ok(body.includes('security unresolved'), 'B1 text を含む');
-  assert.ok(body.includes('B2'), 'B2 id を含む');
-  assert.ok(body.includes('AC unsatisfied'), 'B2 text を含む');
-});
-
-test('blockingItems checked:true -> "checked" を表示', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    blockingItems: [
-      { id: 'B1', text: 'resolved item', severity: 'major', checked: true, dimension: 'quality' },
-    ],
-  });
-  assert.ok(body.includes('checked'), 'checked ラベルを含む');
-});
-
-test('blockingItems checked:false -> "未解消" を表示', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    blockingItems: [
-      { id: 'B1', text: 'unresolved item', severity: 'critical', checked: false, dimension: 'security' },
-    ],
-  });
-  assert.ok(body.includes('未解消'), '未解消ラベルを含む');
-});
-
-test('advisoryItems 複数件 -> 各 id/text を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [
-      { id: 'A1', text: 'style concern', severity: 'minor', checked: false, dimension: 'style', escalate: false },
-      { id: 'A2', text: 'perf concern', severity: 'major', checked: false, dimension: 'perf', escalate: false },
-    ],
-  });
-  assert.ok(body.includes('A1'), 'A1 id を含む');
-  assert.ok(body.includes('style concern'), 'A1 text を含む');
-  assert.ok(body.includes('A2'), 'A2 id を含む');
-  assert.ok(body.includes('perf concern'), 'A2 text を含む');
-});
-
-test('advisoryItems escalate:true -> "(ESCALATE)" を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [
-      { id: 'A1', text: 'urgent advisory', severity: 'major', checked: false, dimension: 'security', escalate: true },
-    ],
-  });
-  assert.ok(body.includes('ESCALATE'), 'ESCALATE を含む');
-});
-
-test('advisoryItems escalate:false -> "(ESCALATE)" を含まない', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [
-      { id: 'A1', text: 'normal advisory', severity: 'minor', checked: false, dimension: 'style', escalate: false },
-    ],
-  });
-  assert.ok(!body.includes('ESCALATE'), 'ESCALATE を含まない');
-});
-
-test('gatePolicy と ledgerConverged を Goal Ledger セクションに含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    gatePolicy: 'llm-major-advisory',
-    ledgerConverged: false,
-  });
-  assert.ok(body.includes('llm-major-advisory'), 'gatePolicy を含む');
-  assert.ok(body.includes('未収束'), 'ledgerConverged false を示す');
-});
-
-test('ledgerConverged:true -> "済" を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    ledgerConverged: true,
-  });
-  assert.ok(body.includes('済'), 'converged 済を含む');
-});
-
-// ─── acResults ────────────────────────────────────────────────────────────────
-
-test('acResults が undefined -> 例外を投げず「AC 判定なし」を含む', () => {
+test('acResults undefined -> 「AC 判定なし（evaluator 未実行 or AC 欠落）」を常時可視領域に含む', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
     acResults: undefined,
   });
-  assert.ok(body.includes('AC 判定なし'), 'AC 判定なし を含む');
-  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
+  assert.ok(body.includes('AC 判定なし（evaluator 未実行 or AC 欠落）'), 'AC 判定なしを含む');
+  const detailsIdx = body.indexOf('<details>');
+  const acNoneIdx = body.indexOf('AC 判定なし');
+  if (detailsIdx >= 0) {
+    assert.ok(acNoneIdx < detailsIdx, 'AC 判定なしが details より前');
+  }
 });
 
-test('acResults が null -> 「AC 判定なし」を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    acResults: null,
-  });
-  assert.ok(body.includes('AC 判定なし'), 'AC 判定なし を含む');
+test('acResults null -> 「AC 判定なし」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, acResults: null });
+  assert.ok(body.includes('AC 判定なし'), 'AC 判定なしを含む');
 });
 
-test('acResults が空配列 -> 「AC 判定なし」を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    acResults: [],
-  });
-  assert.ok(body.includes('AC 判定なし'), '空配列時も AC 判定なし を含む');
+test('acResults 空配列 -> 「AC 判定なし」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, acResults: [] });
+  assert.ok(body.includes('AC 判定なし'), '空配列時も AC 判定なしを含む');
 });
 
-test('acResults 複数件（satisfied true/false 混在）-> 各 AC index と evidence を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    acResults: [
-      { ac_index: 0, satisfied: true, evidence: 'test passed', verified_by: 'evaluator' },
-      { ac_index: 1, satisfied: false, evidence: 'test failed', verified_by: 'evaluator' },
-      { ac_index: 2, satisfied: true, evidence: '', verified_by: undefined },
-    ],
-  });
-  assert.ok(body.includes('AC#1'), 'AC#1 を含む (0-indexed+1)');
-  assert.ok(body.includes('AC#2'), 'AC#2 を含む');
-  assert.ok(body.includes('AC#3'), 'AC#3 を含む');
-  assert.ok(body.includes('satisfied'), 'satisfied を含む');
-  assert.ok(body.includes('未達'), '未達を含む');
-  assert.ok(body.includes('test passed'), 'evidence を含む');
-  assert.ok(body.includes('test failed'), 'evidence を含む');
-  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
+test('securityClearance undefined -> 「Security clearance: danger-grep clean（clearance 不要）」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, securityClearance: undefined });
+  assert.ok(body.includes('Security clearance: danger-grep clean（clearance 不要）'), 'clearance clean を含む');
 });
 
-test('acResults の verified_by が undefined -> デフォルト "inspection" を表示', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    acResults: [
-      { ac_index: 0, satisfied: true, evidence: 'ok', verified_by: undefined },
-    ],
-  });
-  assert.ok(body.includes('inspection'), 'verified_by undefined -> inspection');
+test('securityClearance 空配列 -> 「Security clearance: danger-grep clean（clearance 不要）」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, securityClearance: [] });
+  assert.ok(body.includes('Security clearance: danger-grep clean（clearance 不要）'), '空配列 -> clean を含む');
 });
 
-// ─── securityClearance ────────────────────────────────────────────────────────
+// ─── 末尾マーカー (AC-5) ──────────────────────────────────────────────────────
 
-test('securityClearance が undefined -> 「danger-grep clean」を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    securityClearance: undefined,
-  });
-  assert.ok(body.includes('danger-grep clean'), 'clearance なし -> clean');
-});
-
-test('securityClearance が空配列 -> 「danger-grep clean」を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    securityClearance: [],
-  });
-  assert.ok(body.includes('danger-grep clean'), '空配列 -> clean');
-});
-
-test('securityClearance 複数件（cleared true/false）-> danger_class と cleared 状態を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    securityClearance: [
-      { danger_class: 'SQL_INJECTION', cleared: true, evidence: 'parameterized queries' },
-      { danger_class: 'XSS', cleared: false, evidence: '' },
-    ],
-  });
-  assert.ok(body.includes('SQL_INJECTION'), 'SQL_INJECTION を含む');
-  assert.ok(body.includes('cleared'), 'cleared を含む');
-  assert.ok(body.includes('XSS'), 'XSS を含む');
-  assert.ok(body.includes('未確認'), '未確認を含む');
-  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
-});
-
-test('dangerHits があれば検出クラス情報を補足表示', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    dangerHits: ['SQL_INJECTION', 'PATH_TRAVERSAL'],
-    securityClearance: [
-      { danger_class: 'SQL_INJECTION', cleared: true, evidence: 'ok' },
-    ],
-  });
-  assert.ok(body.includes('SQL_INJECTION'), 'dangerHits クラスを含む');
-});
-
-// ─── planConcerns ─────────────────────────────────────────────────────────────
-
-test('planConcerns あり -> concern 文字列を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    planConcerns: ['concern A', 'concern B'],
-  });
-  assert.ok(body.includes('concern A'), 'concern A を含む');
-  assert.ok(body.includes('concern B'), 'concern B を含む');
-});
-
-test('planConcerns 空 -> concern セクション見出しを含まない', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    planConcerns: [],
-  });
-  assert.ok(!body.includes('Plan 未解消 concerns'), 'plan concerns 見出しを含まない');
-});
-
-// ─── 末尾マーカー ──────────────────────────────────────────────────────────────
-
-test('末尾に安定マーカー <!-- dev-flow:TIER --> を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    mergeTier: 'HOLD',
-  });
-  assert.ok(body.includes('<!-- dev-flow:HOLD -->'), '安定マーカーを含む');
-});
-
-test('末尾に自動生成コメントを含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-  });
-  assert.ok(body.includes('dev-flow により自動生成'), '自動生成コメントを含む');
+test('末尾マーカーが /<!-- dev-flow:(HOLD|REVIEW|AUTO) -->$/ で末尾一致', () => {
+  for (const tier of ['HOLD', 'REVIEW', 'AUTO']) {
+    const body = buildDevflowSummaryBody({ ...BASE_INPUT, mergeTier: tier, mergeTierReasons: [] });
+    const pattern = new RegExp(`<!-- dev-flow:${tier} -->$`);
+    assert.match(body, pattern, `${tier} のマーカーが末尾一致`);
+  }
 });
 
 test('末尾に --- 区切り線を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-  });
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT });
   assert.ok(body.includes('---'), '区切り線を含む');
+});
+
+test('末尾に自動生成コメントを含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT });
+  assert.ok(body.includes('dev-flow により自動生成'), '自動生成コメントを含む');
 });
 
 // ─── 見出し ────────────────────────────────────────────────────────────────────
 
 test('見出しに PR 番号を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    pr: 99,
-  });
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, pr: 99 });
   assert.ok(body.includes('PR #99'), 'PR 番号を含む');
 });
 
@@ -347,6 +686,9 @@ test('決定性: 同入力 -> 2回呼んで byte 完全一致', () => {
     ],
     planConcerns: ['concern 1', 'concern 2'],
     dangerHits: ['SQL_INJECTION'],
+    shape: 'complex',
+    testGreen: true,
+    evalVerdict: 'pass',
   };
   const first = buildDevflowSummaryBody(input);
   const second = buildDevflowSummaryBody(input);
@@ -359,165 +701,81 @@ test('箇条書きは「- 」始まりで「・」を使わない', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
     mergeTierReasons: ['reason X'],
-    blockingItems: [
-      { id: 'B1', text: 'some item', severity: 'critical', checked: false, dimension: 'security' },
-    ],
-    advisoryItems: [
-      { id: 'A1', text: 'advisory item', severity: 'minor', checked: false, dimension: 'style', escalate: false },
-    ],
     planConcerns: ['plan concern'],
   });
   assert.ok(!body.includes('・'), '「・」を使わない');
-  // 箇条書き行の存在確認
-  const lines = body.split('\n');
-  const bulletLines = lines.filter(l => l.trim().startsWith('- '));
-  assert.ok(bulletLines.length > 0, '「- 」始まりの箇条書き行が存在する');
 });
 
-// ─── shape / testGreen / evalVerdict ─────────────────────────────────────────
+// ─── Plan concerns ────────────────────────────────────────────────────────────
 
-test('shape が渡されると「実行結果」セクションに shape 値を含む', () => {
+test('planConcerns あり -> concern 文字列を含む', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
-    shape: 'standard',
+    planConcerns: ['concern A', 'concern B'],
   });
-  assert.ok(body.includes('### 実行結果'), '実行結果セクションを含む');
-  assert.ok(body.includes('shape: standard'), 'shape 値を含む');
+  assert.ok(body.includes('concern A'), 'concern A を含む');
+  assert.ok(body.includes('concern B'), 'concern B を含む');
 });
 
-test('shape が null -> 「不明」を表示', () => {
+test('planConcerns 空 -> 「Plan 未解消 concerns」見出しを含まない', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
-    shape: null,
+    planConcerns: [],
   });
-  assert.ok(body.includes('shape: 不明'), 'shape null -> 不明');
+  assert.ok(!body.includes('Plan 未解消 concerns'), 'plan concerns 見出しを含まない');
 });
 
-test('testGreen: true -> 「test_green: true」を含む', () => {
+// ─── undefined が文字列に含まれない ──────────────────────────────────────────
+
+test('undefined が文字列に展開されない', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
-    testGreen: true,
+    acResults: undefined,
+    securityClearance: undefined,
   });
-  assert.ok(body.includes('test_green: true'), 'testGreen true を含む');
+  assert.ok(!body.includes('undefined'), 'undefined が含まれない');
 });
 
-test('testGreen: false -> 「test_green: false」を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    testGreen: false,
-  });
-  assert.ok(body.includes('test_green: false'), 'testGreen false を含む');
+// ─── shape ────────────────────────────────────────────────────────────────────
+
+test('shape=complex -> at-a-glance テーブルに「complex」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, shape: 'complex' });
+  assert.ok(body.includes('complex'), 'shape complex を含む');
 });
 
-test('testGreen: null -> 「不明」を表示', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    testGreen: null,
-  });
-  assert.ok(body.includes('test_green: 不明'), 'testGreen null -> 不明');
+test('shape=null -> at-a-glance テーブルに「不明」を含む', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT, shape: null });
+  assert.ok(body.includes('不明'), 'shape null -> 不明');
 });
 
-test('evalVerdict: pass -> 「eval_verdict: pass」を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    evalVerdict: 'pass',
-  });
-  assert.ok(body.includes('eval_verdict: pass'), 'evalVerdict pass を含む');
-});
+// ─── 旧形式のセクション見出しが出ない ────────────────────────────────────────
 
-test('evalVerdict: null -> 「不明」を表示', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    evalVerdict: null,
-  });
-  assert.ok(body.includes('eval_verdict: 不明'), 'evalVerdict null -> 不明');
-});
-
-// ─── dimension (lane) 表示 ────────────────────────────────────────────────────
-
-test('blockingItems の行に dimension を [lane] 形式で含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    blockingItems: [
-      { id: 'B1', text: 'sec issue', severity: 'critical', checked: false, dimension: 'security' },
-    ],
-  });
-  assert.ok(body.includes('[security]'), 'dimension を [security] 形式で含む');
-});
-
-test('advisoryItems の行に dimension を [lane] 形式で含む', () => {
+test('旧形式「### ESCALATE-TO-HUMAN（人間の判断が必要）」セクションが出ない', () => {
   const body = buildDevflowSummaryBody({
     ...BASE_INPUT,
     advisoryItems: [
-      { id: 'A1', text: 'style concern', severity: 'minor', checked: false, dimension: 'style', escalate: false },
+      { id: 'A1', text: 'escalated', severity: 'major', checked: false, dimension: 'quality', escalate: true },
     ],
   });
-  assert.ok(body.includes('[style]'), 'dimension を [style] 形式で含む');
+  assert.ok(!body.includes('### ESCALATE-TO-HUMAN（人間の判断が必要）'), '旧 ESCALATE-TO-HUMAN 専用セクションが出ない');
 });
 
-test('blockingItems の checked 項目に evidence を含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    blockingItems: [
-      { id: 'B1', text: 'resolved', severity: 'major', checked: true, dimension: 'quality', evidence: 'test passed' },
-    ],
-  });
-  assert.ok(body.includes('test passed'), 'evidence を含む');
+test('旧形式「### 実行結果」セクションが出ない', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT });
+  assert.ok(!body.includes('### 実行結果'), '旧 実行結果セクションが出ない');
 });
 
-// ─── ESCALATE-TO-HUMAN セクション ────────────────────────────────────────────
-
-test('escalate:true の advisory item がある -> ESCALATE-TO-HUMAN セクションを含む', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [
-      { id: 'A1', text: 'naming preference', severity: 'major', checked: false, dimension: 'style', escalate: true, escalate_reason: 'preference' },
-    ],
-  });
-  assert.ok(body.includes('### ESCALATE-TO-HUMAN（人間の判断が必要）'), 'ESCALATE-TO-HUMAN 見出しを含む');
-  assert.ok(body.includes('- A1 [style] naming preference（reason: preference）'), 'escalate item 行を含む');
+test('旧形式「### Goal Ledger」セクション見出しが出ない', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT });
+  assert.ok(!body.includes('### Goal Ledger'), '旧 Goal Ledger セクションが出ない');
 });
 
-test('escalate_reason なしの escalate item -> 行末に（reason: ...）が付かない', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [
-      { id: 'A2', text: 'some concern', severity: 'major', checked: false, dimension: 'quality', escalate: true },
-    ],
-  });
-  assert.ok(body.includes('### ESCALATE-TO-HUMAN（人間の判断が必要）'), 'ESCALATE-TO-HUMAN 見出しを含む');
-  assert.ok(body.includes('- A2 [quality] some concern'), 'escalate item 行を含む');
-  assert.ok(!body.includes('reason:'), '（reason: ...）を含まない');
+test('旧形式「### Acceptance Criteria」セクション見出しが出ない', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT });
+  assert.ok(!body.includes('### Acceptance Criteria'), '旧 Acceptance Criteria セクションが出ない');
 });
 
-test('escalate item ゼロ（escalate:false のみ）-> ESCALATE-TO-HUMAN セクションを含まない', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [
-      { id: 'A1', text: 'normal advisory', severity: 'minor', checked: false, dimension: 'style', escalate: false },
-    ],
-  });
-  assert.ok(!body.includes('ESCALATE-TO-HUMAN'), 'ESCALATE-TO-HUMAN セクションを含まない');
-});
-
-test('advisoryItems 空 -> ESCALATE-TO-HUMAN セクションを含まない', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [],
-  });
-  assert.ok(!body.includes('ESCALATE-TO-HUMAN'), 'ESCALATE-TO-HUMAN セクションを含まない');
-});
-
-test('ESCALATE-TO-HUMAN セクション位置: Merge tier より後、実行結果より前', () => {
-  const body = buildDevflowSummaryBody({
-    ...BASE_INPUT,
-    advisoryItems: [
-      { id: 'A1', text: 'naming preference', severity: 'major', checked: false, dimension: 'style', escalate: true, escalate_reason: 'preference' },
-    ],
-  });
-  const escalateIdx = body.indexOf('### ESCALATE-TO-HUMAN');
-  const mergeTierIdx = body.indexOf('### Merge tier');
-  const jikkoIdx = body.indexOf('### 実行結果');
-  assert.ok(escalateIdx > mergeTierIdx, 'ESCALATE-TO-HUMAN は Merge tier より後');
-  assert.ok(escalateIdx < jikkoIdx, 'ESCALATE-TO-HUMAN は 実行結果 より前');
+test('旧形式「### Security clearance」セクション見出しが出ない', () => {
+  const body = buildDevflowSummaryBody({ ...BASE_INPUT });
+  assert.ok(!body.includes('### Security clearance'), '旧 Security clearance セクションが出ない');
 });

--- a/_lib/pr-comment-format.mjs
+++ b/_lib/pr-comment-format.mjs
@@ -15,6 +15,11 @@ const DECISION_LABEL = {
   'comment': 'コメント',
 };
 
+export function mdCell(v) {
+  if (v == null) return '';
+  return String(v).replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+}
+
 /**
  * per-round レビューコメント markdown を生成する。
  * @param {object} opts
@@ -25,24 +30,35 @@ const DECISION_LABEL = {
  * @returns {string}
  */
 export function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
+  const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
+  const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const label = DECISION_LABEL[decision] ?? decision;
+  const emoji = DECISION_EMOJI[decision] ?? '';
   const lines = [];
 
   lines.push(`## PR #${pr} — レビュー結果 (iteration ${iteration})`);
   lines.push('');
-  lines.push(`**判定**: ${label}`);
-  lines.push('');
-  lines.push('### Blocking 指摘');
 
-  if (!blocking || blocking.length === 0) {
-    lines.push('blocking 指摘なし');
+  const blockingList = blocking || [];
+  if (blockingList.length === 0) {
+    lines.push(`**判定**: ${emoji} ${label} — ✅ blocking 指摘なし`);
   } else {
-    for (const f of blocking) {
+    const c = blockingList.filter((f) => f.severity === 'critical').length;
+    const m = blockingList.filter((f) => f.severity === 'major').length;
+    lines.push(`**判定**: ${emoji} ${label} — blocking ${blockingList.length} 件（critical ${c} / major ${m}）`);
+    lines.push('');
+    lines.push('| # | 重大度 | 場所 | 指摘 | 提案 |');
+    lines.push('|---|---|---|---|---|');
+    let idx = 1;
+    for (const f of blockingList) {
+      const sev = SEV_LABEL[f.severity] ?? f.severity;
       const loc = f.file != null
-        ? `${f.file}${f.line != null ? ':' + f.line : ''} `
-        : '';
-      const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
-      lines.push(`- [${f.severity}] ${loc}${f.description}${sug}`);
+        ? (f.line != null ? `\`${f.file}:${f.line}\`` : `\`${f.file}\``)
+        : '—';
+      const desc = mdCell(f.description);
+      const sug = f.suggestion != null ? mdCell(f.suggestion) : '—';
+      lines.push(`| ${idx} | ${sev} | ${loc} | ${desc} | ${sug} |`);
+      idx++;
     }
   }
 
@@ -68,38 +84,60 @@ const STATUS_HEADLINE = {
  * @returns {string}
  */
 export function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, history }) {
-  const headline = STATUS_HEADLINE[status] ?? status;
+  const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
+  const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const lines = [];
 
   lines.push(`## PR #${pr} — pr-iterate 終了レポート`);
   lines.push('');
-  lines.push(`### ${headline}`);
+  lines.push(`### ${STATUS_HEADLINE[status] ?? status}`);
   lines.push('');
-  lines.push(`- **総反復回数**: ${iterations}`);
-  lines.push(`- **最終判定**: ${DECISION_LABEL[lastDecision] ?? lastDecision}`);
-  lines.push(`- **最終判定理由**: ${lastSummary}`);
 
-  if (history && history.length > 0) {
+  lines.push('| 終了状態 | 総反復 | 最終判定 |');
+  lines.push('|---|---|---|');
+  const decEmoji = DECISION_EMOJI[lastDecision] ?? '';
+  const decLabel = DECISION_LABEL[lastDecision] ?? lastDecision;
+  lines.push(`| ${status} | ${iterations} | ${decEmoji} ${decLabel} |`);
+
+  lines.push('');
+  lines.push(`**最終判定理由**: ${lastSummary}`);
+
+  const histList = history || [];
+  if (histList.length > 0) {
     lines.push('');
     lines.push('### 反復履歴');
-    for (const round of history) {
-      const roundLabel = DECISION_LABEL[round.decision] ?? round.decision;
-      lines.push('');
-      lines.push(`#### Iteration ${round.iteration}: ${roundLabel}`);
-      lines.push(`${round.summary}`);
-      if (round.blocking && round.blocking.length > 0) {
-        lines.push(`- blocking 指摘数: ${round.blocking.length}`);
-        for (const f of round.blocking) {
-          const loc = f.file != null
-            ? `${f.file}${f.line != null ? ':' + f.line : ''} `
-            : '';
-          const sug = f.suggestion != null ? ` → ${f.suggestion}` : '';
-          lines.push(`  - [${f.severity}] ${loc}${f.description}${sug}`);
-        }
-      } else {
-        lines.push('- blocking 指摘なし');
-      }
+    lines.push('');
+    lines.push('| iter | 判定 | blocking | summary |');
+    lines.push('|---|---|---|---|');
+    for (const round of histList) {
+      const rEmoji = DECISION_EMOJI[round.decision] ?? '';
+      const rLabel = DECISION_LABEL[round.decision] ?? round.decision;
+      const bCount = (round.blocking ?? []).length;
+      const rawSummary = mdCell(round.summary);
+      const rSummary = rawSummary.length > 120 ? rawSummary.slice(0, 120) + '…' : rawSummary;
+      lines.push(`| ${round.iteration} | ${rEmoji} ${rLabel} | ${bCount} | ${rSummary} |`);
     }
+  }
+
+  const allBlocking = histList.flatMap((r) => (r.blocking ?? []).map((f) => ({ iter: r.iteration, ...f })));
+  const totalBlocking = allBlocking.length;
+  if (totalBlocking > 0) {
+    lines.push('');
+    lines.push(`<details><summary>全 blocking 指摘の詳細（${totalBlocking} 件）</summary>`);
+    lines.push('');
+    lines.push('| iter | 重大度 | 場所 | 指摘 | 提案 |');
+    lines.push('|---|---|---|---|---|');
+    for (const f of allBlocking) {
+      const sev = SEV_LABEL[f.severity] ?? f.severity;
+      const loc = f.file != null
+        ? (f.line != null ? `\`${f.file}:${f.line}\`` : `\`${f.file}\``)
+        : '—';
+      const desc = mdCell(f.description);
+      const sug = f.suggestion != null ? mdCell(f.suggestion) : '—';
+      lines.push(`| ${f.iter} | ${sev} | ${loc} | ${desc} | ${sug} |`);
+    }
+    lines.push('');
+    lines.push('</details>');
   }
 
   lines.push('');

--- a/_lib/pr-comment-format.sync.test.mjs
+++ b/_lib/pr-comment-format.sync.test.mjs
@@ -21,7 +21,7 @@ function extractFn(src, fnName) {
   return m[0].trim();
 }
 
-for (const fnName of ['buildReviewCommentBody', 'buildTerminalSummaryBody']) {
+for (const fnName of ['mdCell', 'buildReviewCommentBody', 'buildTerminalSummaryBody']) {
   const canonicalSrc = readFileSync(join(repoRoot, '_lib/pr-comment-format.mjs'), 'utf8');
   const canonical = extractFn(canonicalSrc, fnName);
 

--- a/_lib/pr-comment-format.test.mjs
+++ b/_lib/pr-comment-format.test.mjs
@@ -1,61 +1,153 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildReviewCommentBody, buildTerminalSummaryBody } from './pr-comment-format.mjs';
+import { buildReviewCommentBody, buildTerminalSummaryBody, mdCell } from './pr-comment-format.mjs';
 
-// ─── buildReviewCommentBody ───────────────────────────────────────────────────
+// --- mdCell ------------------------------------------------------------------
 
-test('buildReviewCommentBody: approve -> 承認/LGTM ラベルを含む見出し', () => {
+test('mdCell: null/undefined -> 空文字列', () => {
+  assert.equal(mdCell(null), '');
+  assert.equal(mdCell(undefined), '');
+});
+
+test('mdCell: | をエスケープする', () => {
+  assert.equal(mdCell('a|b'), 'a\\|b');
+});
+
+test('mdCell: 改行を <br> に変換する', () => {
+  assert.equal(mdCell('a\nb'), 'a<br>b');
+  assert.equal(mdCell('a\r\nb'), 'a<br>b');
+});
+
+test('mdCell: 数値を文字列に変換する', () => {
+  assert.equal(mdCell(42), '42');
+});
+
+// --- buildReviewCommentBody --------------------------------------------------
+
+test('buildReviewCommentBody: approve -> 絵文字 ✅ + ラベルが判定行に出る', () => {
   const body = buildReviewCommentBody({
     pr: 42,
     iteration: 1,
     decision: 'approve',
     blocking: [],
   });
-  assert.ok(typeof body === 'string', 'string を返す');
-  assert.ok(body.includes('1'), 'iteration 番号を含む');
-  assert.ok(body.includes('承認') || body.includes('LGTM'), 'approve ラベルを含む');
+  assert.ok(body.includes('✅'), 'approve の絵文字 ✅ を含む');
+  assert.ok(body.includes('承認'), 'approve のラベル "承認" を含む');
+  assert.ok(body.includes('**判定**'), '判定行を含む');
 });
 
-test('buildReviewCommentBody: request-changes -> 変更要求 ラベルを含む見出し', () => {
+test('buildReviewCommentBody: request-changes -> 絵文字 🔴 + ラベルが判定行に出る', () => {
   const body = buildReviewCommentBody({
     pr: 10,
     iteration: 2,
     decision: 'request-changes',
     blocking: [],
   });
-  assert.ok(body.includes('変更要求'), 'request-changes ラベルを含む');
+  assert.ok(body.includes('🔴'), 'request-changes の絵文字 🔴 を含む');
+  assert.ok(body.includes('変更要求'), 'request-changes のラベルを含む');
   assert.ok(body.includes('2'), 'iteration 番号を含む');
 });
 
-test('buildReviewCommentBody: comment -> コメント ラベルを含む見出し', () => {
+test('buildReviewCommentBody: comment -> 絵文字 💬 + ラベルが判定行に出る', () => {
   const body = buildReviewCommentBody({
     pr: 7,
     iteration: 3,
     decision: 'comment',
     blocking: [],
   });
-  assert.ok(body.includes('コメント'), 'comment ラベルを含む');
+  assert.ok(body.includes('💬'), 'comment の絵文字 💬 を含む');
+  assert.ok(body.includes('コメント'), 'comment のラベルを含む');
   assert.ok(body.includes('3'), 'iteration 番号を含む');
 });
 
-test('buildReviewCommentBody: blocking 空の場合は "blocking 指摘なし" を表示', () => {
+test('buildReviewCommentBody: blocking 0 件で "✅ blocking 指摘なし" を含みテーブルヘッダを含まない', () => {
   const body = buildReviewCommentBody({
     pr: 5,
     iteration: 1,
     decision: 'approve',
     blocking: [],
   });
-  assert.ok(body.includes('blocking 指摘なし'), 'blocking 空時の表示');
+  assert.ok(body.includes('✅ blocking 指摘なし'), 'blocking 空時の表示');
+  assert.ok(!body.includes('| # | 重大度 |'), 'テーブルヘッダが存在しない');
 });
 
-test('buildReviewCommentBody: finding に file/line/suggestion すべて有り', () => {
+test('buildReviewCommentBody: blocking 2 件（critical 1 / major 1）で件数内訳とテーブル行が出る', () => {
+  const body = buildReviewCommentBody({
+    pr: 3,
+    iteration: 2,
+    decision: 'request-changes',
+    blocking: [
+      { severity: 'critical', file: 'src/a.ts', line: 10, description: 'null check missing', suggestion: 'add null guard' },
+      { severity: 'major', file: 'src/b.ts', description: 'unused import' },
+    ],
+  });
+  assert.ok(body.includes('（critical 1 / major 1）'), '件数内訳を含む');
+  assert.ok(body.includes('| # | 重大度 |'), 'テーブルヘッダを含む');
+  assert.ok(body.includes('🔴 critical'), 'critical ラベルを含む');
+  assert.ok(body.includes('🟠 major'), 'major ラベルを含む');
+  assert.ok(body.includes('| 1 |'), 'テーブル行 1 を含む');
+  assert.ok(body.includes('| 2 |'), 'テーブル行 2 を含む');
+});
+
+test('buildReviewCommentBody: description / suggestion に | と \\n を含む finding でエスケープされる (AC-4)', () => {
   const body = buildReviewCommentBody({
     pr: 5,
     iteration: 1,
     decision: 'request-changes',
     blocking: [
       {
-        severity: 'error',
+        severity: 'critical',
+        description: 'pipe|char\nnewline',
+        suggestion: 'fix|this\nplease',
+      },
+    ],
+  });
+  assert.ok(body.includes('pipe\\|char'), '| が \\| にエスケープされる');
+  assert.ok(body.includes('<br>'), '改行が <br> に変換される');
+  assert.ok(!body.match(/\npipe\|char/), '生の | + 改行がセルに残らない');
+});
+
+test('buildReviewCommentBody: f.file null / f.line null / f.suggestion null で — fallback', () => {
+  const body = buildReviewCommentBody({
+    pr: 5,
+    iteration: 1,
+    decision: 'request-changes',
+    blocking: [
+      {
+        severity: 'critical',
+        description: 'some error',
+      },
+    ],
+  });
+  const rows = body.split('\n').filter(l => l.startsWith('|') && !l.startsWith('| #') && !l.startsWith('|---'));
+  assert.ok(rows.some(r => r.includes(' — ')), '場所か suggestion に — が出る');
+});
+
+test('buildReviewCommentBody: f.file あり f.line null でバッククォート付き file のみ', () => {
+  const body = buildReviewCommentBody({
+    pr: 5,
+    iteration: 1,
+    decision: 'request-changes',
+    blocking: [
+      {
+        severity: 'major',
+        file: 'src/foo.ts',
+        description: 'issue here',
+      },
+    ],
+  });
+  assert.ok(body.includes('`src/foo.ts`'), 'file がバッククォート付きで出る');
+  assert.ok(!body.includes(':undefined'), 'line null で :undefined が出ない');
+});
+
+test('buildReviewCommentBody: f.file あり f.line あり でバッククォート付き file:line', () => {
+  const body = buildReviewCommentBody({
+    pr: 5,
+    iteration: 1,
+    decision: 'request-changes',
+    blocking: [
+      {
+        severity: 'critical',
         file: 'src/foo.ts',
         line: 42,
         description: 'null check missing',
@@ -63,66 +155,21 @@ test('buildReviewCommentBody: finding に file/line/suggestion すべて有り',
       },
     ],
   });
-  assert.ok(body.includes('error'), 'severity を含む');
-  assert.ok(body.includes('src/foo.ts'), 'file を含む');
-  assert.ok(body.includes('42'), 'line を含む');
+  assert.ok(body.includes('`src/foo.ts:42`'), 'file:line がバッククォート付きで出る');
   assert.ok(body.includes('null check missing'), 'description を含む');
   assert.ok(body.includes('add null guard'), 'suggestion を含む');
-  // bullet format: `- [severity] file:line description → suggestion`
-  assert.ok(body.includes('- [error]'), 'bullet 形式を含む');
-  assert.ok(body.includes('src/foo.ts:42'), 'file:line 形式を含む');
-  assert.ok(body.includes('→'), '矢印区切り');
 });
 
-test('buildReviewCommentBody: finding に file/line なし', () => {
+test('buildReviewCommentBody: blocking 1 件で "blocking 1 件" が判定行に出る', () => {
   const body = buildReviewCommentBody({
     pr: 5,
     iteration: 1,
     decision: 'request-changes',
     blocking: [
-      {
-        severity: 'warning',
-        description: 'unused variable',
-      },
+      { severity: 'critical', description: 'critical issue' },
     ],
   });
-  assert.ok(body.includes('warning'), 'severity を含む');
-  assert.ok(body.includes('unused variable'), 'description を含む');
-  // file:line は含まない
-  assert.ok(!body.match(/undefined:undefined/), 'file:line が undefined にならない');
-});
-
-test('buildReviewCommentBody: finding に suggestion なし', () => {
-  const body = buildReviewCommentBody({
-    pr: 5,
-    iteration: 1,
-    decision: 'request-changes',
-    blocking: [
-      {
-        severity: 'error',
-        file: 'src/bar.ts',
-        line: 10,
-        description: 'type error',
-      },
-    ],
-  });
-  assert.ok(body.includes('type error'), 'description を含む');
-  // suggestion の矢印が出ない
-  assert.ok(!body.includes('→ undefined'), 'undefined suggestion を出力しない');
-});
-
-test('buildReviewCommentBody: 複数 finding をすべてリスト', () => {
-  const body = buildReviewCommentBody({
-    pr: 3,
-    iteration: 2,
-    decision: 'request-changes',
-    blocking: [
-      { severity: 'error', description: 'first error' },
-      { severity: 'warning', description: 'second warning' },
-    ],
-  });
-  assert.ok(body.includes('first error'), '1件目を含む');
-  assert.ok(body.includes('second warning'), '2件目を含む');
+  assert.ok(body.includes('blocking 1 件'), '件数が判定行に出る');
 });
 
 test('buildReviewCommentBody: 決定性（同入力 -> 同出力）', () => {
@@ -131,7 +178,7 @@ test('buildReviewCommentBody: 決定性（同入力 -> 同出力）', () => {
     iteration: 5,
     decision: 'request-changes',
     blocking: [
-      { severity: 'error', file: 'a.ts', line: 1, description: 'desc', suggestion: 'fix' },
+      { severity: 'critical', file: 'a.ts', line: 1, description: 'desc', suggestion: 'fix' },
     ],
   };
   const first = buildReviewCommentBody(input);
@@ -139,9 +186,9 @@ test('buildReviewCommentBody: 決定性（同入力 -> 同出力）', () => {
   assert.equal(first, second, '同入力 -> バイト完全一致');
 });
 
-// ─── buildTerminalSummaryBody ─────────────────────────────────────────────────
+// --- buildTerminalSummaryBody ------------------------------------------------
 
-test('buildTerminalSummaryBody: lgtm -> LGTM/承認 見出し', () => {
+test('buildTerminalSummaryBody: lgtm -> 🎉 LGTM 見出しと at-a-glance テーブルが出る', () => {
   const body = buildTerminalSummaryBody({
     pr: 42,
     status: 'lgtm',
@@ -150,12 +197,12 @@ test('buildTerminalSummaryBody: lgtm -> LGTM/承認 見出し', () => {
     lastSummary: 'looks good',
     history: [],
   });
-  assert.ok(typeof body === 'string', 'string を返す');
-  assert.ok(body.includes('42'), 'PR 番号を含む');
-  assert.ok(body.includes('LGTM') || body.includes('承認'), 'lgtm 見出しを含む');
+  assert.ok(body.includes('🎉 LGTM'), 'lgtm 見出しを含む');
+  assert.ok(body.includes('| 終了状態 | 総反復 | 最終判定 |'), 'at-a-glance テーブルヘッダを含む');
+  assert.ok(body.includes('✅'), 'approve 絵文字を含む');
 });
 
-test('buildTerminalSummaryBody: stuck -> 人間レビューへエスカレーション(stuck)', () => {
+test('buildTerminalSummaryBody: stuck -> ⚠️ STUCK 見出しが出る', () => {
   const body = buildTerminalSummaryBody({
     pr: 10,
     status: 'stuck',
@@ -164,11 +211,11 @@ test('buildTerminalSummaryBody: stuck -> 人間レビューへエスカレーシ
     lastSummary: 'not improving',
     history: [],
   });
-  assert.ok(body.includes('stuck') || body.includes('エスカレーション'), 'stuck 見出しを含む');
-  assert.ok(body.includes('人間レビュー') || body.includes('エスカレーション'), '人間レビューへの言及');
+  assert.ok(body.includes('⚠️ STUCK'), 'stuck 見出しを含む');
+  assert.ok(body.includes('エスカレーション'), '人間エスカレーションへの言及');
 });
 
-test('buildTerminalSummaryBody: fix_failed -> 自動修正失敗', () => {
+test('buildTerminalSummaryBody: fix_failed -> ⚠️ 自動修正失敗 見出しが出る', () => {
   const body = buildTerminalSummaryBody({
     pr: 5,
     status: 'fix_failed',
@@ -177,10 +224,10 @@ test('buildTerminalSummaryBody: fix_failed -> 自動修正失敗', () => {
     lastSummary: 'fix failed',
     history: [],
   });
-  assert.ok(body.includes('自動修正失敗') || body.includes('fix_failed'), 'fix_failed 見出しを含む');
+  assert.ok(body.includes('⚠️ 自動修正失敗'), 'fix_failed 見出しを含む');
 });
 
-test('buildTerminalSummaryBody: max_reached -> 上限到達', () => {
+test('buildTerminalSummaryBody: max_reached -> ⚠️ 反復上限到達 見出しが出る', () => {
   const body = buildTerminalSummaryBody({
     pr: 8,
     status: 'max_reached',
@@ -189,10 +236,135 @@ test('buildTerminalSummaryBody: max_reached -> 上限到達', () => {
     lastSummary: 'max iterations hit',
     history: [],
   });
-  assert.ok(body.includes('上限到達') || body.includes('max_reached'), 'max_reached 見出しを含む');
+  assert.ok(body.includes('⚠️ 反復上限到達'), 'max_reached 見出しを含む');
 });
 
-test('buildTerminalSummaryBody: iterations と lastDecision/lastSummary を含む', () => {
+test('buildTerminalSummaryBody: 末尾マーカーが /<!-- pr-iterate:(lgtm|stuck|fix_failed|max_reached):\\d+ -->$/ で末尾一致 (AC-5)', () => {
+  for (const status of ['lgtm', 'stuck', 'fix_failed', 'max_reached']) {
+    const body = buildTerminalSummaryBody({
+      pr: 55,
+      status,
+      iterations: 3,
+      lastDecision: 'request-changes',
+      lastSummary: 'summary',
+      history: [],
+    });
+    assert.ok(
+      /<!-- pr-iterate:(lgtm|stuck|fix_failed|max_reached):\d+ -->$/.test(body),
+      status + ': 末尾マーカーが正規表現に一致する',
+    );
+  }
+});
+
+test('buildTerminalSummaryBody: history 3 round（うち 2 round に blocking 計 3 件）で "#### Iteration" 見出しが存在せず <details> が 1 個だけ・統合テーブルに iter 列と 3 行が入る (AC-7)', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 1,
+    status: 'lgtm',
+    iterations: 3,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    history: [
+      {
+        iteration: 1,
+        decision: 'request-changes',
+        summary: 'needs work',
+        blocking: [
+          { severity: 'critical', description: 'first critical' },
+          { severity: 'major', description: 'first major' },
+        ],
+      },
+      {
+        iteration: 2,
+        decision: 'request-changes',
+        summary: 'still issues',
+        blocking: [
+          { severity: 'critical', description: 'second critical' },
+        ],
+      },
+      {
+        iteration: 3,
+        decision: 'approve',
+        summary: 'looks good',
+        blocking: [],
+      },
+    ],
+  });
+  assert.ok(!body.includes('#### Iteration'), '#### Iteration 見出しが存在しない');
+  const detailsMatches = body.match(/<details>/g);
+  assert.ok(detailsMatches && detailsMatches.length === 1, '<details> が 1 個だけ存在する');
+  assert.ok(body.includes('| iter |'), '統合テーブルに iter 列を含む');
+  assert.ok(body.includes('first critical'), 'first critical が含まれる');
+  assert.ok(body.includes('first major'), 'first major が含まれる');
+  assert.ok(body.includes('second critical'), 'second critical が含まれる');
+});
+
+test('buildTerminalSummaryBody: <summary> 行の直後が空行であること', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 1,
+    status: 'stuck',
+    iterations: 2,
+    lastDecision: 'request-changes',
+    lastSummary: 'stuck',
+    history: [
+      {
+        iteration: 1,
+        decision: 'request-changes',
+        summary: 'issue',
+        blocking: [{ severity: 'critical', description: 'some issue' }],
+      },
+    ],
+  });
+  const lines = body.split('\n');
+  const summaryLineIdx = lines.findIndex((l) => l.includes('<summary>'));
+  assert.ok(summaryLineIdx !== -1, '<summary> 行が存在する');
+  assert.equal(lines[summaryLineIdx + 1], '', '<summary> 直後が空行');
+});
+
+test('buildTerminalSummaryBody: history 空 / blocking 全 0 で details ブロック自体が無い', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 1,
+    status: 'lgtm',
+    iterations: 1,
+    lastDecision: 'approve',
+    lastSummary: 'all good',
+    history: [],
+  });
+  assert.ok(!body.includes('<details>'), 'details ブロックが存在しない');
+});
+
+test('buildTerminalSummaryBody: blocking 全 0 の history でも details ブロックが無い', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 1,
+    status: 'lgtm',
+    iterations: 2,
+    lastDecision: 'approve',
+    lastSummary: 'all good',
+    history: [
+      { iteration: 1, decision: 'request-changes', summary: 'minor', blocking: [] },
+      { iteration: 2, decision: 'approve', summary: 'ok', blocking: [] },
+    ],
+  });
+  assert.ok(!body.includes('<details>'), 'blocking 0 なら details ブロックが存在しない');
+});
+
+test('buildTerminalSummaryBody: 反復履歴 summary が 120 文字超で truncate + "…"', () => {
+  const longSummary = 'x'.repeat(130);
+  const body = buildTerminalSummaryBody({
+    pr: 1,
+    status: 'lgtm',
+    iterations: 1,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    history: [
+      { iteration: 1, decision: 'approve', summary: longSummary, blocking: [] },
+    ],
+  });
+  const truncated = 'x'.repeat(120) + '\u2026';
+  assert.ok(body.includes(truncated), '120 文字で truncate + … が入る');
+  assert.ok(!body.includes('x'.repeat(130)), '130 文字のままでは含まれない');
+});
+
+test('buildTerminalSummaryBody: **最終判定理由** が出力に含まれる', () => {
   const body = buildTerminalSummaryBody({
     pr: 20,
     status: 'lgtm',
@@ -201,11 +373,10 @@ test('buildTerminalSummaryBody: iterations と lastDecision/lastSummary を含�
     lastSummary: 'all checks pass',
     history: [],
   });
-  assert.ok(body.includes('4'), 'iteration 数を含む');
-  assert.ok(body.includes('all checks pass'), 'lastSummary を含む');
+  assert.ok(body.includes('**最終判定理由**: all checks pass'), 'lastSummary を含む');
 });
 
-test('buildTerminalSummaryBody: history セクションをレンダリング', () => {
+test('buildTerminalSummaryBody: history セクションの反復履歴テーブルに各 round の decision が出る', () => {
   const body = buildTerminalSummaryBody({
     pr: 1,
     status: 'lgtm',
@@ -217,9 +388,7 @@ test('buildTerminalSummaryBody: history セクションをレンダリング', (
         iteration: 1,
         decision: 'request-changes',
         summary: 'needs work',
-        blocking: [
-          { severity: 'error', description: 'something wrong' },
-        ],
+        blocking: [],
       },
       {
         iteration: 2,
@@ -229,28 +398,10 @@ test('buildTerminalSummaryBody: history セクションをレンダリング', (
       },
     ],
   });
-  // 各ラウンドの decision が含まれる
-  assert.ok(body.includes('request-changes') || body.includes('変更要求'), 'iteration 1 decision');
-  assert.ok(body.includes('approve') || body.includes('承認'), 'iteration 2 decision');
-  // summary が含まれる
+  assert.ok(body.includes('変更要求'), 'iteration 1 decision');
+  assert.ok(body.includes('承認'), 'iteration 2 decision');
   assert.ok(body.includes('needs work'), 'iteration 1 summary');
   assert.ok(body.includes('looks good now'), 'iteration 2 summary');
-  // blocking count/list
-  assert.ok(body.includes('something wrong') || body.includes('1'), 'blocking finding');
-});
-
-test('buildTerminalSummaryBody: idempotency marker を埋め込む', () => {
-  const body = buildTerminalSummaryBody({
-    pr: 55,
-    status: 'stuck',
-    iterations: 3,
-    lastDecision: 'request-changes',
-    lastSummary: 'still stuck',
-    history: [],
-  });
-  // status と iterations を含む安定マーカー行
-  assert.ok(body.includes('stuck'), 'status をマーカーに含む');
-  assert.ok(body.includes('3'), 'iterations をマーカーに含む');
 });
 
 test('buildTerminalSummaryBody: 決定性（同入力 -> 同出力）', () => {
@@ -265,7 +416,7 @@ test('buildTerminalSummaryBody: 決定性（同入力 -> 同出力）', () => {
         iteration: 1,
         decision: 'request-changes',
         summary: 'minor issues',
-        blocking: [{ severity: 'warning', description: 'style' }],
+        blocking: [{ severity: 'major', description: 'style' }],
       },
       {
         iteration: 2,


### PR DESCRIPTION
## 概要

Closes #190

- `buildDevflowSummaryBody`（`_lib/devflow-summary-format.mjs` + `dev-flow.js` inline）に at-a-glance テーブルを追加し、Merge tier / shape / test / eval / Ledger / AC / danger を1行で可視化
- `buildReviewCommentBody` / `buildTerminalSummaryBody`（`_lib/pr-comment-format.mjs` + `pr-iterate.js` inline）をテーブル形式・結論ファーストの形式に刷新
- `mdCell()` エスケープヘルパー（`|`→`\|`、改行→`<br>`、null→空文字）を両 canonical に追加
- 未解消 blocking item・HOLD/REVIEW 理由などを `<details>` の外（常時可視領域）に配置し、解消済み items のみ折りたたみ
- 対応するユニットテスト・sync テストをすべて更新

## 動機

dev-flow / pr-iterate が自動投稿する PR コメントが「1 finding = 1 長文 bullet」の素朴な連結で生成されており、merge 判断者が結論を把握するまでに時間がかかっていた。merge は人間が行う安全設計（blast-radius 永続ゲート）のため、「未解消事項が一目でわかる」ことは dev-flow の安全設計の実効性に直結する。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `_lib/devflow-summary-format.mjs` | `mdCell()` 追加、`buildDevflowSummaryBody` を at-a-glance テーブル+要対応セクション形式に刷新 |
| `_lib/pr-comment-format.mjs` | `mdCell()` 追加、`buildReviewCommentBody` / `buildTerminalSummaryBody` をテーブル形式に刷新 |
| `_lib/devflow-summary-format.test.mjs` | 新形式に対応するユニットテスト更新（期待値・エッジケース追加） |
| `_lib/pr-comment-format.test.mjs` | 新形式に対応するユニットテスト更新 |
| `_lib/devflow-summary-format.sync.test.mjs` | `mdCell` を sync 対象関数リストに追加 |
| `_lib/pr-comment-format.sync.test.mjs` | `mdCell` を sync 対象関数リストに追加 |
| `.claude/workflows/dev-flow.js` | `devflow-summary-format.mjs` の inline コピーを canonical と同期 |
| `.claude/workflows/pr-iterate.js` | `pr-comment-format.mjs` の inline コピーを canonical と同期 |

## テスト計画

- [x] `node --test _lib/devflow-summary-format.test.mjs` green
- [x] `node --test _lib/pr-comment-format.test.mjs` green
- [x] `node --test _lib/devflow-summary-format.sync.test.mjs` green（inline コピー byte 一致）
- [x] `node --test _lib/pr-comment-format.sync.test.mjs` green（inline コピー byte 一致）
- [ ] `bash tests/run-node-tests.sh` 全 green（CI）