### PR TITLE
fix(diff-risk-classify): tools/ 配下を public-api クラス判定から除外し構造的 false positive を削減

### DIFF
--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -590,3 +590,50 @@ teardown() {
     [[ "$output" == *'"class":"exec-sink"'* ]]
     printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
 }
+
+# ---------------------------------------------------------------------------
+# [TOOLS-1] tools 緩和: tools/ 配下の export function は public-api に hit しない
+# AC: tools/ は repo 内部の generator/dev CLI 置き場で外部 consumer 不在のため
+#     public-api critical の構造的 false positive を除外する
+# ---------------------------------------------------------------------------
+@test "TOOLS-1 tools 緩和: tools/ 配下の export function -> public-api が含まれない" {
+    mkdir -p "$REPO/tools"
+    printf 'export function buildConfig(opts) {\n  return opts;\n}\n' \
+        > "$REPO/tools/gen-config.mjs"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length == 0'
+}
+
+# ---------------------------------------------------------------------------
+# [TOOLS-2] tools 緩和の狭さ: tools/ 配下でも exec-sink は hit する
+# 緩和は public-api クラス限定であることを pin
+# ---------------------------------------------------------------------------
+@test "TOOLS-2 tools 緩和の狭さ: tools/ 配下の child_process+spawn -> exec-sink は hit する (緩和は public-api 限定)" {
+    mkdir -p "$REPO/tools"
+    printf 'const { spawn } = require("child_process");\nspawn("ls");\n' \
+        > "$REPO/tools/runner.mjs"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"class":"exec-sink"'* ]]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
+}
+
+# ---------------------------------------------------------------------------
+# [TOOLS-3] tools 緩和の narrow ガード: mytools/ は除外されない
+# (^|/)tools/ が mytools/ にはマッチしない = 除外が narrow であることを pin
+# ---------------------------------------------------------------------------
+@test "TOOLS-3 tools 緩和の narrow ガード: mytools/ 配下の export function -> public-api に hit する" {
+    mkdir -p "$REPO/mytools"
+    printf 'export function publicApi() {}\n' \
+        > "$REPO/mytools/api.ts"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -q -m change
+    run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+}

--- a/_shared/scripts/diff-risk-classify.sh
+++ b/_shared/scripts/diff-risk-classify.sh
@@ -232,10 +232,11 @@ while IFS= read -r file; do
     fi
 
     # 5. public-api
-    # _lib/ 配下は repo 内部専用ライブラリで外部 API surface ではないため public-api critical
-    # の構造的 false positive を除外する。緩和はこのクラス限定（他 6 クラスは _lib でも従来どおり判定する）。
-    if echo "$file" | grep -Eq '(^|/)_lib/'; then
-        : # _lib is repo-internal library; skip public-api check only
+    # _lib/ は repo 内部専用ライブラリ、tools/ は repo 内部の generator/dev CLI 置き場で、
+    # いずれも外部 API surface ではないため public-api critical の構造的 false positive を除外する。
+    # 緩和はこのクラス限定（他 6 クラスは _lib/ / tools/ でも従来どおり判定する）。
+    if echo "$file" | grep -Eq '(^|/)(_lib|tools)/'; then
+        : # _lib / tools are repo-internal; skip public-api check only
     elif echo "$added" | grep -Eiq 'export (default |async )?(function|class|const)|module\.exports|@(Get|Post|Put|Delete|Patch)\(|openapi|paths:'; then
         hits="${hits}${file}"$'\t'"public-api"$'\n'
     fi


### PR DESCRIPTION
## 概要

Closes #197

- `_shared/scripts/diff-risk-classify.sh` の public-api クラス判定から `tools/` 配下を除外
- `_lib/` 除外と同じ narrow パターン `(^|/)(_lib|tools)/` に統合
- 除外は public-api クラス限定（exec-sink 等の他 6 クラスは `tools/` でも従来どおり判定）

## 動機

PR #196（issue #195）で `tools/sync-inlines.mjs` の `export function` 5 箇所が public-api クラスで hit し、merge tier が HOLD になる構造的 false positive が発生した（人間 clearance で false positive と確認済み・merge 済み）。

`tools/` は repo 内部の generator / dev CLI 置き場で `_lib/` と同じ性質（外部 consumer 不在・export は unit test 用）。`_lib/` 除外と同一の正当化でリストに追加する。

danger-grep はblast-radius クラスの distrust 機構（永続）だが、本変更はゲートの relax ではなく**入力精度の改善（構造的 FP の除去）**であり W7 軸A invariant には触れない。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `_shared/scripts/diff-risk-classify.sh` | public-api 除外 regex を `_lib` のみ → `_lib\|tools` に拡張、コメント更新 |
| `_shared/scripts/diff-risk-classify.bats` | TOOLS-1〜3 テスト 3 本追加 |

## テスト計画

- [x] TOOLS-1: `tools/` 配下の `export function` → public-api NEGATIVE
- [x] TOOLS-2: `tools/` 配下の `child_process`+`spawn` → exec-sink POSITIVE（除外は public-api 限定であることを pin）
- [x] TOOLS-3: `mytools/` は除外されない（narrow ガード — `(^|/)tools/` パターンを pin）