### PR TITLE
fix(workflows): mktemp の /tmp ハードコードを ${TMPDIR:-/tmp} フォールバック形式へ修正

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -1081,7 +1081,7 @@ const JOURNAL_RESULT = {
 
 function bodySaveInstr(body) {
   return `## 本文の保存\n`
-    + `まず Bash で \`mktemp /tmp/dev-flow-XXXXXX.md\` を実行して一時ファイルを作成し、\n`
+    + `まず Bash で \`mktemp "\${TMPDIR:-/tmp}/dev-flow-XXXXXX.md"\` を実行して一時ファイルを作成し、\n`
     + `そのパスを <BODY_FILE> とする。次に **Write tool** を使い、下記 delimiter 内の本文を\n`
     + `**一字一句そのまま** <BODY_FILE> へ書き出せ。本文は絶対に shell（echo/printf/heredoc 等）へ\n`
     + `渡さず、必ず Write tool の content 引数として渡すこと。backtick やコードフェンスを\n`

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -218,7 +218,7 @@ function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSu
 // （旧 writeTempBody の「本文を shell に通さない」意図を agent 側で構造的に再現する）。
 function bodySaveInstr(body) {
   return `## 本文の保存\n`
-    + `まず Bash で \`mktemp /tmp/pr-iterate-XXXXXX.md\` を実行して一時ファイルを作成し、\n`
+    + `まず Bash で \`mktemp "\${TMPDIR:-/tmp}/pr-iterate-XXXXXX.md"\` を実行して一時ファイルを作成し、\n`
     + `そのパスを <BODY_FILE> とする。次に **Write tool** を使い、下記 delimiter 内の本文を\n`
     + `**一字一句そのまま** <BODY_FILE> へ書き出せ。本文は絶対に shell（echo/printf/heredoc 等）へ\n`
     + `渡さず、必ず Write tool の content 引数として渡すこと。backtick やコードフェンスを\n`

--- a/_lib/workflow-tmpdir-mktemp.test.mjs
+++ b/_lib/workflow-tmpdir-mktemp.test.mjs
@@ -1,0 +1,60 @@
+// Regression test: mktemp が TMPDIR フォールバック形式を使うことを保証する。
+//
+// 問題: `mktemp /tmp/...` はサンドボックス環境（macOS の Claude Code sandbox 等）では
+//       /tmp への書き込みが拒否されて失敗する。$TMPDIR 環境変数を参照する形式
+//       `mktemp "${TMPDIR:-/tmp}/..."` を使えばサンドボックスが許可した一時ディレクトリを使える。
+//
+// このテストは:
+//   (a) dev-flow.js / pr-iterate.js に `mktemp /tmp/` という古い形式が残存しないこと
+//   (b) dev-flow.js に mktemp "\${TMPDIR:-/tmp}/dev-flow-XXXXXX.md" が含まれること
+//   (c) pr-iterate.js に mktemp "\${TMPDIR:-/tmp}/pr-iterate-XXXXXX.md" が含まれること
+// を assert する。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const workflowDir = join(repoRoot, '.claude/workflows');
+
+const devFlowPath = join(workflowDir, 'dev-flow.js');
+const prIteratePath = join(workflowDir, 'pr-iterate.js');
+
+const devFlowSrc = readFileSync(devFlowPath, 'utf8');
+const prIterateSrc = readFileSync(prIteratePath, 'utf8');
+
+// (a) 旧形式 `mktemp /tmp/` が残存しないこと
+test('[tmpdir] dev-flow.js: `mktemp /tmp/` という旧形式が含まれない', () => {
+  assert.ok(
+    !devFlowSrc.includes('mktemp /tmp/'),
+    'dev-flow.js に `mktemp /tmp/` が残存している（TMPDIR フォールバック形式へ移行すること）',
+  );
+});
+
+test('[tmpdir] pr-iterate.js: `mktemp /tmp/` という旧形式が含まれない', () => {
+  assert.ok(
+    !prIterateSrc.includes('mktemp /tmp/'),
+    'pr-iterate.js に `mktemp /tmp/` が残存している（TMPDIR フォールバック形式へ移行すること）',
+  );
+});
+
+// (b) dev-flow.js に新形式が含まれること
+// ファイル内の実際の文字列: mktemp "\${TMPDIR:-/tmp}/dev-flow-XXXXXX.md"
+// （JS template literal 内の $ エスケープ: \$ = 1文字のバックスラッシュ + $）
+test('[tmpdir] dev-flow.js: TMPDIR フォールバック形式の mktemp が含まれる', () => {
+  assert.ok(
+    devFlowSrc.includes('mktemp "\\${TMPDIR:-/tmp}/dev-flow-XXXXXX.md"'),
+    'dev-flow.js に mktemp "\\${TMPDIR:-/tmp}/dev-flow-XXXXXX.md" が存在しない（TMPDIR フォールバック形式が必要）',
+  );
+});
+
+// (c) pr-iterate.js に新形式が含まれること
+test('[tmpdir] pr-iterate.js: TMPDIR フォールバック形式の mktemp が含まれる', () => {
+  assert.ok(
+    prIterateSrc.includes('mktemp "\\${TMPDIR:-/tmp}/pr-iterate-XXXXXX.md"'),
+    'pr-iterate.js に mktemp "\\${TMPDIR:-/tmp}/pr-iterate-XXXXXX.md" が存在しない（TMPDIR フォールバック形式が必要）',
+  );
+});


### PR DESCRIPTION
## 概要

Closes #200

- `dev-flow.js` / `pr-iterate.js` の `bodySaveInstr` 内 `mktemp` 指示を `/tmp` ハードコードから `${TMPDIR:-/tmp}` フォールバック形式へ修正
- リグレッション防止テスト `_lib/workflow-tmpdir-mktemp.test.mjs` を追加

## 動機

journal 30 日集計で pr-fix の failure 165 件が `mktemp: failed to create file via template '/tmp/dev-flow-XXXXXX.md': Operation not permitted` で発生していた。原因は workflow の subagent prompt が `/tmp` 直書きの mktemp を指示しており、macOS Claude Code sandbox の `/tmp` 書き込み禁止と衝突するため。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/dev-flow.js` | `mktemp /tmp/dev-flow-XXXXXX.md` → `mktemp "${TMPDIR:-/tmp}/dev-flow-XXXXXX.md"` |
| `.claude/workflows/pr-iterate.js` | `mktemp /tmp/pr-iterate-XXXXXX.md` → `mktemp "${TMPDIR:-/tmp}/pr-iterate-XXXXXX.md"` |
| `_lib/workflow-tmpdir-mktemp.test.mjs` | 旧形式の残存を検知するリグレッションテストを追加 |

## テスト計画

- [x] `_lib/workflow-tmpdir-mktemp.test.mjs` で旧形式 `mktemp /tmp/` の残存がないこと・新形式が含まれることをアサート
- [x] 既存 node test（sync test 含む）が green であること