### PR TITLE
docs(agents): evaluator の feedback_level 判定フローと根拠記載要件を明文化

### DIFF
--- a/.claude/agents/evaluator.md
+++ b/.claude/agents/evaluator.md
@@ -76,6 +76,21 @@ type に応じた追加観点を持つ（例: api なら入力検証・エラー
   - **`implementation`**: 実装レベルの欠陥（計画は正しいがコードが追従していない / バグ / テスト不足）
     → workflow は implementer に差し戻す
 
+### feedback_level 判定フロー
+
+**根本質問**: 「plan に忠実に従って実装し直しても同じ欠陥が再現するか？」
+- **Yes（再現する）** → `design`
+- **No（plan 通りに直せば解消する）** → `implementation`
+
+**灰色領域の個別規則**:
+1. plan に edge case / 要件が記載済みだが実装で条件漏れ → `implementation`（plan は正しく、コードが追従していない）
+2. plan にも実装にも当該 edge case / 要件の記載が無い → `design`（スコープ漏れ）
+3. plan の記載が曖昧で実装が誤った解釈を選んだ → `design`（plan の具体化不足。同じ plan から再実装しても再発しうる）
+4. plan が誤った設計を指示し実装が忠実に従った → `design`
+5. 複数 task 間のインターフェース不整合で原因が task 分割・契約定義にある → `design`、単一 task 内のバグ → `implementation`
+
+**tie-breaker**: 上記で決められない場合は `implementation` に倒す（design 差し戻しは replan+reimpl の二重コストで、design churn は orchestrator の early-cutoff 対象 — 上記「収束は orchestrator が最終判断する」セクションと整合）。
+
 `fail` の場合 `feedback[]` に**具体的で実行可能な**項目を入れる（「コード品質を上げよ」のような曖昧は禁止。
 ファイル・関数・パターンを名指す）。feedback は `verdict: pass` でも返せる（escalate のみの報告がありうる。orchestrator は verdict に関係なく feedback[] を処理する）。各 feedback 項目は次の構造を持つ:
 
@@ -83,7 +98,7 @@ type に応じた追加観点を持つ（例: api なら入力検証・エラー
   `major` に格下げしてはならない）
 - `topic`: その問題を一意に識別する**短い安定した文字列**（例 `"missing input validation in createUser"`）。
   同一問題は iteration を跨いで**同じ topic 文字列を再利用**する（orchestrator が topic で stuck を突合する）
-- `description`: 問題の具体的な説明（ファイル・関数・パターンを名指す）
+- `description`: 問題の具体的な説明（ファイル・関数・パターンを名指す）。**feedback_level の分岐根拠を必ず含める** — design 根拠例: 「plan F2 に当該 edge case の記載なし」、implementation 根拠例: 「plan F1 に記載済みだが src/foo.ts の分岐で条件漏れ」
 - `suggestion`: 修正方針
 - `escalate`（省略時 false）: **正確性ではなく当事者性・好み・訓練分布外性が論点のとき true** にする人間 required-block フラグ。true にすると merge tier が HOLD になり人間が読まないと merge できない。**品質の高低（コードが良い/悪い）では使わない** — 品質問題は severity で表現する。判定基準: (a) accountability=結果責任を人間が負うべき決定（例: 外部公開 API 命名・課金挙動の変更）、(b) preference=技術的に複数解が同等で好みの問題（issue に指定なし）、(c) novelty=訓練分布外で自信を持って判定できない（前例なきドメイン固有仕様の解釈）、(d) blast-radius=誤りだった場合の影響が PR スコープを超える（例: データ移行方針）。escalate は major/minor いずれの severity にも付けられる。
 - `escalate_reason`: `accountability` | `preference` | `novelty` | `blast-radius`（escalate:true のとき (a)-(d) から選ぶ。escalate:false なら省略）。
@@ -129,7 +144,7 @@ type に応じた追加観点を持つ（例: api なら入力検証・エラー
   "threshold": 7.0,
   "feedback": [
     {"severity": "major", "topic": "missing input validation in createUser",
-     "description": "src/user.ts createUser が email 形式を検証していない",
+     "description": "src/user.ts createUser が email 形式を検証していない（plan F1 に入力検証が記載済みだが実装で漏れ）",
      "suggestion": "zod スキーマで email を検証し 400 を返す"},
     {"severity": "minor", "topic": "public API naming choice",
      "description": "エンドポイント命名が issue に未指定で複数案が同等",
@@ -149,6 +164,6 @@ type に応じた追加観点を持つ（例: api なら入力検証・エラー
 
 - **diff・plan・テスト結果しか見ない**: 実装の経緯は知らない（by design）
 - **正直に採点**: commit 前に実問題を捕まえるのが目的。rubber-stamp しない
-- **feedback_level が肝**: design か implementation かで retry 先が変わる。慎重に判定する
+- **feedback_level が肝**: design か implementation かで retry 先が変わる。Step 4 の判定フローに従い慎重に判定する
 - **state を書かない**: 返り値 JSON が唯一の出力
 - **escalate は当事者性で立てる**: 正確性・品質の問題は severity、人間にしか決められない論点（当事者性/好み/分布外）は escalate。乱発しない — verdict: pass でも escalate は立てられる


### PR DESCRIPTION
## 概要

Closes #204

- `evaluator.md` の Step 4 に `feedback_level` 判定フローのセクションを新設
- 根本質問（「plan に忠実に従って実装し直しても同じ欠陥が再現するか？」）を判定の起点として明文化
- 灰色領域の個別規則（5パターン）と `implementation` への tie-breaker を追記
- `feedback[].description` に分岐根拠の記載を必須化
- サンプル JSON の `description` を根拠記載フォーマットに合わせて更新
- 原則セクションの `feedback_level` 説明に「Step 4 の判定フローに従い」を追記

## 動機

`feedback_level: design | implementation` の分岐はリトライ先のルーティングを決める急所だが、判定基準が明文化されていなかった。灰色領域（「edge case の方針は plan にあるが実装で条件漏れ」等）で誤ルートすると、replan + reimpl の無駄な iteration が発生する。明確な判定フローと根拠記載要件を設けることで、evaluator の判定一貫性を高める。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/agents/evaluator.md` | Step 4 に `feedback_level` 判定フロー（根本質問・灰色領域5規則・tie-breaker）を追記。description への分岐根拠記載を必須化。サンプル JSON・原則セクションを更新 |

## テスト計画

- [x] `diff evaluator.staged.md .claude/agents/evaluator.md` で差分が 0 であることを確認
- [x] description 1,536 文字制約未超過（frontmatter の description は変更なし）