### PR TITLE
fix(dev-flow-doctor): ARG_MAX 対策と unbound variable 修正で実行不能を解消

### DIFF
--- a/dev-flow-doctor/scripts/analyze-dev-flow-family.bats
+++ b/dev-flow-doctor/scripts/analyze-dev-flow-family.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Tests for dev-flow-doctor/scripts/analyze-dev-flow-family.sh
+#
+# Focus: ARG_MAX-safe load_journal_entries — verifies that a large corpus
+# (8,000 files with long path names) succeeds where the old
+# `jq -s '.' "${files[@]}"` fast-path would hit "Argument list too long".
+#
+# Test cases:
+#   1. ARG_MAX regression: 8,000 journal files → status 0, valid JSON,
+#      dev-kickoff total == 8000
+#   2. malformed-file tolerance: 3 valid + 1 broken → exit 0, valid 3 counted
+#   3. empty journal dir → exit 0, per_skill all-zero totals
+#   4. non-existent CLAUDE_JOURNAL_DIR → exit 0
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/analyze-dev-flow-family.sh"
+
+# ---------------------------------------------------------------------------
+# setup_file: create the large corpus once for the entire test file.
+#   We generate 8,000 journal JSON files with basenames padded to ~240 chars
+#   so that the aggregate argv length exceeds macOS ARG_MAX (1 MB) when all
+#   paths are expanded into a single execve call.
+# ---------------------------------------------------------------------------
+setup_file() {
+    export CORPUS_DIR
+    CORPUS_DIR="$(mktemp -d)"
+
+    # Empty config so environment skill-config.json does not leak in
+    export EMPTY_CONFIG
+    EMPTY_CONFIG="$(mktemp)"
+    printf '{}' > "$EMPTY_CONFIG"
+
+    # Today's date in UTC for the timestamp field
+    TODAY_ISO="$(date -u +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u --iso-8601=seconds | sed 's/+.*/Z/')"
+
+    # Generate 8,000 files.
+    # Basename padding: "aaa...a-N.json" where the 'a' run is 220 chars,
+    # giving each basename ~231 chars.
+    # With a typical /tmp/... prefix (~30 chars) each full path is ~260 chars.
+    # 8000 x 260 = ~2 MB >> macOS ARG_MAX = 1 MB.
+    local pad
+    pad="$(printf 'a%.0s' {1..220})"
+    local i
+    for i in $(seq 1 8000); do
+        local fname="${pad}-${i}.json"
+        printf '{"id":"t-%d","timestamp":"%s","skill":"dev-kickoff","outcome":"success","source":"manual","duration_turns":3}\n' \
+            "$i" "$TODAY_ISO" > "${CORPUS_DIR}/${fname}"
+    done
+}
+
+teardown_file() {
+    rm -rf "$CORPUS_DIR"
+    rm -f "$EMPTY_CONFIG"
+}
+
+# ---------------------------------------------------------------------------
+# setup / teardown per test: small journals live in BATS_TMPDIR
+# ---------------------------------------------------------------------------
+setup() {
+    EMPTY_CONFIG_LOCAL="$(mktemp)"
+    printf '{}' > "$EMPTY_CONFIG_LOCAL"
+}
+
+teardown() {
+    rm -f "$EMPTY_CONFIG_LOCAL"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: ARG_MAX regression
+#   8,000 files whose paths exceed ARG_MAX in aggregate.
+#   Old fast-path: `jq -s '.' "${files[@]}"` -> "Argument list too long".
+#   New fast-path: printf NUL-pipe + xargs -0 cat + jq -s stdin -> succeeds.
+# ---------------------------------------------------------------------------
+@test "ARG_MAX regression: 8000 large-path files -> exit 0, valid JSON, total==8000" {
+    run env \
+        CLAUDE_JOURNAL_DIR="$CORPUS_DIR" \
+        SKILL_CONFIG_PATH="$EMPTY_CONFIG" \
+        bash "$SCRIPT" --window 30d
+    [ "$status" -eq 0 ]
+
+    # Output must be valid JSON
+    printf '%s\n' "$output" | jq empty
+
+    # dev-kickoff must have total == 8000
+    local total
+    total=$(printf '%s\n' "$output" | jq '[.per_skill[] | select(.skill=="dev-kickoff")][0].total')
+    [ "$total" -eq 8000 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: malformed-file tolerance
+#   3 valid + 1 broken JSON file -> exit 0, valid 3 entries counted.
+# ---------------------------------------------------------------------------
+@test "malformed-file tolerance: 3 valid + 1 broken -> exit 0, dev-kickoff total==3" {
+    local jdir
+    jdir="$(mktemp -d)"
+    local today_iso
+    today_iso="$(date -u +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u --iso-8601=seconds | sed 's/+.*/Z/')"
+
+    # 3 valid entries
+    local i
+    for i in 1 2 3; do
+        printf '{"id":"m-%d","timestamp":"%s","skill":"dev-kickoff","outcome":"success","source":"manual","duration_turns":2}\n' \
+            "$i" "$today_iso" > "${jdir}/valid-${i}.json"
+    done
+    # 1 broken entry (truncated JSON)
+    printf '{"broken":' > "${jdir}/broken.json"
+
+    run env \
+        CLAUDE_JOURNAL_DIR="$jdir" \
+        SKILL_CONFIG_PATH="$EMPTY_CONFIG_LOCAL" \
+        bash "$SCRIPT" --window 30d
+    rm -rf "$jdir"
+    [ "$status" -eq 0 ]
+
+    printf '%s\n' "$output" | jq empty
+
+    local total
+    total=$(printf '%s\n' "$output" | jq '[.per_skill[] | select(.skill=="dev-kickoff")][0].total')
+    [ "$total" -eq 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: empty journal dir -> exit 0, all per_skill totals == 0
+# ---------------------------------------------------------------------------
+@test "empty journal dir -> exit 0, all per_skill totals == 0" {
+    local jdir
+    jdir="$(mktemp -d)"
+
+    run env \
+        CLAUDE_JOURNAL_DIR="$jdir" \
+        SKILL_CONFIG_PATH="$EMPTY_CONFIG_LOCAL" \
+        bash "$SCRIPT" --window 30d
+    rm -rf "$jdir"
+    [ "$status" -eq 0 ]
+
+    printf '%s\n' "$output" | jq empty
+
+    local sum
+    sum=$(printf '%s\n' "$output" | jq '[.per_skill[].total] | add // 0')
+    [ "$sum" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: non-existent CLAUDE_JOURNAL_DIR -> exit 0
+# ---------------------------------------------------------------------------
+@test "non-existent CLAUDE_JOURNAL_DIR -> exit 0" {
+    run env \
+        CLAUDE_JOURNAL_DIR="/nonexistent/path/that/does/not/exist" \
+        SKILL_CONFIG_PATH="$EMPTY_CONFIG_LOCAL" \
+        bash "$SCRIPT" --window 30d
+    [ "$status" -eq 0 ]
+
+    printf '%s\n' "$output" | jq empty
+}

--- a/dev-flow-doctor/scripts/analyze-dev-flow-family.sh
+++ b/dev-flow-doctor/scripts/analyze-dev-flow-family.sh
@@ -134,12 +134,15 @@ load_journal_entries() {
     printf '[]'
     return
   fi
-  # Slurp all entries at once. If any single file is malformed, jq -s fails
-  # for the whole batch, which previously produced an empty [] and caused a
-  # false-positive "all family skills dead" result. Fall back to per-file
-  # parsing so one bad file never blanks the whole journal.
+  # Slurp all entries via NUL-pipe + xargs cat + jq -s stdin.
+  # Avoids ARG_MAX ("Argument list too long") when journal has 3,500+ files:
+  #   printf is a bash builtin (ARG_MAX not applied), xargs -0 auto-splits
+  #   cat calls to stay within OS limits, jq -s slurps the concatenated stream
+  #   of JSON objects into a single array -- identical output to the old approach.
+  # If any file is malformed, jq -s fails for the whole batch and we fall
+  # through to the per-file rescue path below.
   local slurped=""
-  if slurped=$(jq -s '.' "${files[@]}" 2>/dev/null); then
+  if slurped=$(printf '%s\0' "${files[@]}" | xargs -0 cat -- 2>/dev/null | jq -cs '.' 2>/dev/null); then
     printf '%s' "$slurped"
     return
   fi
@@ -160,11 +163,11 @@ load_journal_entries() {
 ALL_ENTRIES=$(load_journal_entries)
 
 # Filter by since
-WINDOW_ENTRIES=$(echo "$ALL_ENTRIES" | jq \
+WINDOW_ENTRIES=$(echo "$ALL_ENTRIES" | jq -c \
   --arg since "$SINCE_ISO" \
   '[.[] | select(.timestamp >= $since)]')
 
-FAMILY_ENTRIES=$(echo "$WINDOW_ENTRIES" | jq \
+FAMILY_ENTRIES=$(echo "$WINDOW_ENTRIES" | jq -c \
   --argjson fam "$FAMILY_SKILLS_JSON" \
   '[.[] | select(.skill as $s | $fam | index($s))]')
 
@@ -172,8 +175,7 @@ FAMILY_ENTRIES=$(echo "$WINDOW_ENTRIES" | jq \
 # Per-skill aggregation
 # ----------------------------------------------------------------------------
 
-PER_SKILL=$(jq -n \
-  --argjson entries "$FAMILY_ENTRIES" \
+PER_SKILL=$(echo "$FAMILY_ENTRIES" | jq -c \
   --argjson fam "$FAMILY_SKILLS_JSON" \
   '
   # status_distribution buckets the dev-implement return_status enum (issue #92):
@@ -188,7 +190,7 @@ PER_SKILL=$(jq -n \
     else "unknown"
     end;
   [ $fam[] as $s |
-    ($entries | map(select(.skill == $s))) as $es |
+    (. | map(select(.skill == $s))) as $es |
     ($es | length) as $total |
     ($es | map(select(.outcome == "success")) | length) as $succ |
     ($es | map(select(.outcome == "failure")) | length) as $fail |
@@ -276,9 +278,8 @@ BOTTLENECKS=$(echo "$PER_SKILL" | jq \
 # within the window. We match against "Skill: <name>" / "Task: <name>" and
 # also allow a generic non-word-character boundary so that e.g. "dev-integrate"
 # is not accidentally satisfied by "dev-integrate-extra".
-DISCONNECTED=$(jq -n \
+DISCONNECTED=$(echo "$WINDOW_ENTRIES" | jq -c \
   --argjson per_skill "$PER_SKILL" \
-  --argjson entries "$WINDOW_ENTRIES" \
   --arg window "$WINDOW" \
   '
   def escape_regex(s): s | gsub("([.+*?^$()\\[\\]{}|\\\\])"; "\\\\\(.)");
@@ -286,7 +287,7 @@ DISCONNECTED=$(jq -n \
     ($p.total == 0) as $no_own |
     (escape_regex($p.skill)) as $esc |
     ("(^|[^A-Za-z0-9_-])" + $esc + "([^A-Za-z0-9_-]|$)") as $re |
-    ( $entries
+    ( .
       | map(select(.source == "hook-capture"))
       | map(.context.input_summary // "")
       | map(select(. != ""))

--- a/dev-flow-doctor/scripts/run-diagnostics.bats
+++ b/dev-flow-doctor/scripts/run-diagnostics.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# Tests for dev-flow-doctor/scripts/run-diagnostics.sh
+#
+# Focus: run_worktree_checks の age_days 算出部分における
+#        unset / 空 / 非数値セーフ対策の regression テスト。
+#
+# Setup: mktemp -d に隔離 git repo（git init + user config + empty commit）を作り、
+#        その親に `<repo名>-worktrees/` ディレクトリを用意。
+#        スクリプトは `cd <repo> && run-diagnostics.sh --scope worktrees` で実行。
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/run-diagnostics.sh"
+
+# ---------------------------------------------------------------------------
+# setup_file: AC1 smoke テスト用 journal corpus（3,600 エントリ）を生成
+# ---------------------------------------------------------------------------
+setup_file() {
+    CORPUS_DIR="$(mktemp -d)"
+    export CORPUS_DIR
+    # 3,600 件の journal corpus を生成（basename ~240文字 padding 付き）
+    local pad
+    pad=$(printf '%0.s-' {1..200})  # 200文字のパディング
+    for i in $(seq 1 3600); do
+        local ts
+        ts=$(printf '%010d' "$i")
+        # skill=dev-flow の JSON lines 形式
+        printf '{"ts":"%s","skill":"dev-flow","status":"success","mode":"standard","padding":"%s"}\n' \
+            "$ts" "$pad" >> "${CORPUS_DIR}/journal-${ts}.jsonl"
+    done
+    export CORPUS_DIR
+}
+
+teardown_file() {
+    rm -rf "${CORPUS_DIR:-}"
+}
+
+# ---------------------------------------------------------------------------
+# 各テストで使う隔離 git repo セットアップ
+# ---------------------------------------------------------------------------
+setup() {
+    REPO="$(mktemp -d)"
+    export REPO
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@t
+    git -C "$REPO" config user.name t
+    git -C "$REPO" commit -q --allow-empty -m base
+
+    REPO_NAME="$(basename "$REPO")"
+    WORKTREE_BASE="${REPO}/../${REPO_NAME}-worktrees"
+    mkdir -p "$WORKTREE_BASE"
+    export WORKTREE_BASE
+
+    # 各テストで fake stat を置く用の bin dir
+    FAKE_BIN="$(mktemp -d)"
+    export FAKE_BIN
+}
+
+teardown() {
+    rm -rf "${REPO:-}" "${FAKE_BIN:-}"
+    # WORKTREE_BASE は REPO の兄弟ディレクトリなので個別に削除
+    rm -rf "${WORKTREE_BASE:-}"
+}
+
+# ---------------------------------------------------------------------------
+# (1) stat 非数値出力 regression
+#     fake stat が "ERR" という文字列を出力するケースで死なないこと
+# ---------------------------------------------------------------------------
+@test "(1) stat 非数値出力: status 0 かつ valid JSON を返す（旧実装は算術展開で死ぬ）" {
+    # fake stat shim: 非数値 "ERR" を stdout に出力して exit 0
+    printf '#!/bin/sh\nprintf "ERR"\nexit 0\n' > "${FAKE_BIN}/stat"
+    chmod +x "${FAKE_BIN}/stat"
+
+    # ダミー worktree dir
+    mkdir -p "${WORKTREE_BASE}/dummy-wt"
+
+    run bash -c "cd '${REPO}' && PATH='${FAKE_BIN}:${PATH}' '${SCRIPT}' --scope worktrees"
+    [ "$status" -eq 0 ]
+    # valid JSON であること（jq がパースできること）
+    printf '%s\n' "$output" | jq empty
+}
+
+# ---------------------------------------------------------------------------
+# (2) stat 空出力 regression
+#     fake stat が空文字を出力するケースで stale_worktrees が 0 になること
+#     （旧実装: 空 → mod_time=0 → age_days≈20000日 → false-positive stale）
+# ---------------------------------------------------------------------------
+@test "(2) stat 空出力: stale_worktrees == 0 で false-positive stale を出さない" {
+    # fake stat shim: 空文字を出力して exit 0
+    printf '#!/bin/sh\nprintf ""\nexit 0\n' > "${FAKE_BIN}/stat"
+    chmod +x "${FAKE_BIN}/stat"
+
+    # ダミー worktree dir
+    mkdir -p "${WORKTREE_BASE}/dummy-wt"
+
+    run bash -c "cd '${REPO}' && PATH='${FAKE_BIN}:${PATH}' '${SCRIPT}' --scope worktrees"
+    [ "$status" -eq 0 ]
+    # valid JSON であること
+    printf '%s\n' "$output" | jq empty
+    # stale_worktrees == 0 であること（timestamp 取得不能 → stale 扱いしない）
+    local stale
+    stale=$(printf '%s\n' "$output" | jq '.checks.worktree_health.stale_worktrees')
+    [ "$stale" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# (3) 正常系
+#     fake stat なし・新しい worktree dir で stale_worktrees 0、
+#     registered_worktrees >= 1 を確認
+# ---------------------------------------------------------------------------
+@test "(3) 正常系: status 0、stale_worktrees 0、registered_worktrees >= 1" {
+    # ダミー worktree dir（最近作成されたのでstaleでない）
+    mkdir -p "${WORKTREE_BASE}/recent-wt"
+
+    run bash -c "cd '${REPO}' && '${SCRIPT}' --scope worktrees"
+    [ "$status" -eq 0 ]
+    # valid JSON であること
+    printf '%s\n' "$output" | jq empty
+    # stale_worktrees == 0 であること
+    local stale
+    stale=$(printf '%s\n' "$output" | jq '.checks.worktree_health.stale_worktrees')
+    [ "$stale" -eq 0 ]
+    # registered_worktrees >= 1 であること（git worktree list は少なくとも main を返す）
+    local reg
+    reg=$(printf '%s\n' "$output" | jq '.checks.worktree_health.registered_worktrees')
+    [ "$reg" -ge 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# (4) AC1 smoke: 3,600 件 journal corpus で full 実行が status 0 かつ valid JSON
+# ---------------------------------------------------------------------------
+@test "(4) AC1 smoke: 3600件corpus で --scope full が status 0 かつ valid JSON（score/checks キー存在）" {
+    # 空の config を用意（SKILL_CONFIG_PATH を環境変数で指定）
+    local empty_config
+    empty_config="$(mktemp)"
+    printf '{}' > "$empty_config"
+
+    run bash -c "cd '${REPO}' && CLAUDE_JOURNAL_DIR='${CORPUS_DIR}' SKILL_CONFIG_PATH='${empty_config}' '${SCRIPT}' --scope full --window 30d"
+    rm -f "$empty_config"
+    [ "$status" -eq 0 ]
+    # valid JSON
+    printf '%s\n' "$output" | jq empty
+    # score キーが存在
+    printf '%s\n' "$output" | jq -e 'has("score")'
+    # checks キーが存在
+    printf '%s\n' "$output" | jq -e 'has("checks")'
+}

--- a/dev-flow-doctor/scripts/run-diagnostics.bats
+++ b/dev-flow-doctor/scripts/run-diagnostics.bats
@@ -11,22 +11,27 @@
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/run-diagnostics.sh"
 
 # ---------------------------------------------------------------------------
-# setup_file: AC1 smoke テスト用 journal corpus（3,600 エントリ）を生成
+# setup_file: smoke テスト用 journal corpus（3,600 エントリ）を生成
+#
+# ファイル形式: *.json（analyze-dev-flow-family.sh / journal.sh が glob する拡張子）
+# JSON schema: 実 schema に準拠（timestamp / skill / outcome / source / duration_turns）
+# skill: "pr-fix"（DEFAULT_FAMILY_SKILLS に含まれる family skill）
+# timestamp: 今日の UTC 日付（--window 30d フィルタを通過させるため）
 # ---------------------------------------------------------------------------
 setup_file() {
     CORPUS_DIR="$(mktemp -d)"
     export CORPUS_DIR
-    # 3,600 件の journal corpus を生成（basename ~240文字 padding 付き）
-    local pad
-    pad=$(printf '%0.s-' {1..200})  # 200文字のパディング
+
+    # 今日の UTC 日付（--window 30d のフィルタを通過するタイムスタンプ）
+    TODAY_ISO="$(date -u +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u --iso-8601=seconds | sed 's/+.*/Z/')"
+    export TODAY_ISO
+
+    # 3,600 件のエントリを個別の *.json ファイルとして生成
+    local i
     for i in $(seq 1 3600); do
-        local ts
-        ts=$(printf '%010d' "$i")
-        # skill=dev-flow の JSON lines 形式
-        printf '{"ts":"%s","skill":"dev-flow","status":"success","mode":"standard","padding":"%s"}\n' \
-            "$ts" "$pad" >> "${CORPUS_DIR}/journal-${ts}.jsonl"
+        printf '{"id":"c-%d","timestamp":"%s","skill":"pr-fix","outcome":"success","source":"manual","duration_turns":3}\n' \
+            "$i" "$TODAY_ISO" > "${CORPUS_DIR}/corpus-$(printf '%04d' "$i")-pr-fix.json"
     done
-    export CORPUS_DIR
 }
 
 teardown_file() {
@@ -125,10 +130,14 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# (4) AC1 smoke: 3,600 件 journal corpus で full 実行が status 0 かつ valid JSON
+# (4) 3,600 件 journal corpus で --scope full が corpus を実際に読み込むこと
+#
+# 単なる exit 0 ではなく、corpus が analyze-dev-flow-family.sh を通じて
+# 実際に集計されたことを non-vacuous に検証する:
+#   - .checks.dev_flow_family.status が "error"/"skipped" でないこと
+#   - .checks.dev_flow_family.per_skill 内の pr-fix エントリの total が 3600 であること
 # ---------------------------------------------------------------------------
-@test "(4) AC1 smoke: 3600件corpus で --scope full が status 0 かつ valid JSON（score/checks キー存在）" {
-    # 空の config を用意（SKILL_CONFIG_PATH を環境変数で指定）
+@test "(4) 3600件corpus: --scope full で pr-fix total==3600 が集計されること（corpus が実際に流れる）" {
     local empty_config
     empty_config="$(mktemp)"
     printf '{}' > "$empty_config"
@@ -136,10 +145,22 @@ teardown() {
     run bash -c "cd '${REPO}' && CLAUDE_JOURNAL_DIR='${CORPUS_DIR}' SKILL_CONFIG_PATH='${empty_config}' '${SCRIPT}' --scope full --window 30d"
     rm -f "$empty_config"
     [ "$status" -eq 0 ]
-    # valid JSON
+
+    # valid JSON であること
     printf '%s\n' "$output" | jq empty
-    # score キーが存在
+
+    # score / checks キーが存在すること
     printf '%s\n' "$output" | jq -e 'has("score")'
-    # checks キーが存在
     printf '%s\n' "$output" | jq -e 'has("checks")'
+
+    # dev_flow_family が error / skipped でないこと（corpus が実際に読まれたこと）
+    local dff_status
+    dff_status=$(printf '%s\n' "$output" | jq -r '.checks.dev_flow_family.status // "missing"')
+    [ "$dff_status" != "error" ]
+    [ "$dff_status" != "skipped" ]
+
+    # pr-fix の total が 3600 であること（corpus が集計されたことの非自明な確認）
+    local pr_fix_total
+    pr_fix_total=$(printf '%s\n' "$output" | jq '[.checks.dev_flow_family.per_skill[] | select(.skill=="pr-fix")][0].total // 0')
+    [ "$pr_fix_total" -eq 3600 ]
 }

--- a/dev-flow-doctor/scripts/run-diagnostics.sh
+++ b/dev-flow-doctor/scripts/run-diagnostics.sh
@@ -324,11 +324,17 @@ run_worktree_checks() {
       fi
 
       # Check staleness (>7 days since last modification)
-      local mod_time
+      local mod_time now age_days
       mod_time=$(stat -f %m "$wt_dir" 2>/dev/null || stat -c %Y "$wt_dir" 2>/dev/null || echo 0)
-      local now
-      now=$(now_sec)
-      local age_days=$(( (now - mod_time) / 86400 ))
+      now=$(now_sec 2>/dev/null || echo 0)
+      # Numeric guard: normalize non-numeric / empty values to 0
+      [[ "$mod_time" =~ ^[0-9]+$ ]] || mod_time=0
+      [[ "$now" =~ ^[0-9]+$ ]] || now=0
+      age_days=$(( (${now:-0} - ${mod_time:-0}) / 86400 ))
+      # Timestamp unavailable guard: skip stale classification when timestamps could not be read
+      if [[ "$mod_time" -eq 0 || "$now" -eq 0 ]]; then
+        age_days=0
+      fi
       if [[ $age_days -gt 7 ]]; then
         stale_count=$((stale_count + 1))
         stale_dirs=$(echo "$stale_dirs" | jq --arg d "$wt_dir" --argjson days "$age_days" '. + [{path: $d, age_days: $days}]')


### PR DESCRIPTION
## 概要

Closes #202

- `analyze-dev-flow-family.sh`: `jq -s '.' "${files[@]}"` を `printf NUL-pipe + xargs -0 cat + jq -cs stdin` に変更し、journal 3,500+ ファイルで発生する "Argument list too long"（ARG_MAX 超過）を解消
- `run-diagnostics.sh`: worktree staleness チェックで `stat` が取れない環境での `mod_time`/`now` の非数値を `0` に正規化し、未取得時は stale 判定をスキップするガードを追加
- 両スクリプトに bats テストを新規追加（4 ケース: ARG_MAX 回帰・malformed ファイル tolerance・空ディレクトリ・存在しない CLAUDE_JOURNAL_DIR）

## 動機

2026-06-11 の health check 実行で dev-flow-doctor が即死する P0 バグが発生。

- `analyze-dev-flow-family.sh`: journal が 3,567 ファイルに達し、glob 展開した配列を `jq -s '.'` に直接渡す fast-path が OS の ARG_MAX（macOS: 1 MB）を超過してクラッシュ
- `run-diagnostics.sh`: `set -u` 環境下で `stat` 失敗時に未定義変数を参照してクラッシュ

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `dev-flow-doctor/scripts/analyze-dev-flow-family.sh` | `jq -s '.' "${files[@]}"` → `printf '%s\0' ... \| xargs -0 cat \| jq -cs '.'` に変更。`jq -c` フラグを追加し中間出力をコンパクト化 |
| `dev-flow-doctor/scripts/run-diagnostics.sh` | `mod_time`/`now` を `[[ ... =~ ^[0-9]+$ ]]` で数値チェックし非数値は 0 に正規化。両値が 0 の場合は `age_days=0` にフォールバック |
| `dev-flow-doctor/scripts/analyze-dev-flow-family.bats` | 新規追加: ARG_MAX 8000 ファイル回帰テスト他 4 ケース |
| `dev-flow-doctor/scripts/run-diagnostics.bats` | 新規追加: staleness チェックのエッジケーステスト |

## テスト計画

- [x] `analyze-dev-flow-family.bats`: 8,000 ファイル ARG_MAX 回帰・malformed ファイル tolerance・空ディレクトリ・存在しない journal dir → bats green
- [x] `run-diagnostics.bats`: stat 失敗時の数値ガード動作確認
- [ ] `bash tests/run-all-bats.sh --strict` で CI green を確認