### PR TITLE
feat(dev-flow): implPrompt に AC・plan contract を注入し evaluator との採点軸を共有（#224）

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -1202,10 +1202,20 @@ const STAGING_CONVENTION = `一時/handoff ファイルの配置規約: `
   + `（git status に混入し realized-diff の refloor 誤発火・宣言外変更 concern の原因になる）。\n`
 
 function implPrompt(t, fixFeedback, extraContext) {
+  // AC・plan contract（summary / architecture_decisions / edge_cases）を全 implementer spawn prompt に注入する。
+  // evaluator が AC ベースで採点するため implementer と採点軸を共有する（issue #224）。
+  // 注入は contract 粒度に留め line-level 詳細は含めない。req / plan は top-level binding で、
+  // 全呼び出しは Plan phase 後（replan 時は最新 plan が注入される）。
+  const archDecisions = plan?.architecture_decisions ?? []
+  const edgeCases = plan?.edge_cases ?? []
   return `cd ${WT} で作業（Bash 呼び出しごとに必ず先頭で cd ${WT} すること。agent の cwd は毎回リセットされる）。`
     + `次の task を ${TESTING} 戦略で実装せよ。共有 worktree のため自分の task の file_changes 以外は触るな。`
     + `git add / commit はするな。\n`
     + `task: ${JSON.stringify(t)}\n`
+    + `requirements（issue 受入条件。evaluator はこの AC を採点軸にする — 自 task に関係する AC を満たすこと）:\n${JSON.stringify(req?.acceptance_criteria ?? [])}\n`
+    + `plan summary: ${JSON.stringify(plan?.summary ?? '')}\n`
+    + (archDecisions.length ? `architecture_decisions（計画の設計判断。この方針に従うこと）:\n${JSON.stringify(archDecisions)}\n` : '')
+    + (edgeCases.length ? `edge_cases（計画が想定する edge case。実装時に考慮すること）:\n${JSON.stringify(edgeCases)}\n` : '')
     + (fixFeedback ? `修正指摘（各項目を解消）:\n${JSON.stringify(fixFeedback)}\n` : '')
     + (extraContext ? `補足コンテキスト（comprehensive 再分析の結果。これで情報不足を解消して実装せよ）:\n${JSON.stringify(extraContext)}\n` : '')
     + STAGING_CONVENTION

--- a/_lib/implementer-requirements-injection.test.mjs
+++ b/_lib/implementer-requirements-injection.test.mjs
@@ -1,0 +1,318 @@
+// implementer prompt への AC・plan contract 注入を source + routing の 2 層で pin する（issue #224）。
+//
+// 背景（issue #224）:
+//   evaluator は acceptance_criteria ベースで実装を採点する（各 AC を satisfied/unsatisfied で判定）。
+//   しかし従来の implPrompt は task と STAGING_CONVENTION のみを渡していたため、implementer は
+//   AC を知らずに実装を行う情報非対称が存在した。この非対称を解消するため、implPrompt に
+//   req.acceptance_criteria / plan.summary / plan.architecture_decisions / plan.edge_cases を注入する。
+//
+// AC4 確認結果:
+//   telemetry の eval_iter は dev-flow.js の telemetry handoff オブジェクト（`eval_iter: evalIters`）に
+//   既存（line 2013 付近）。注入前後で比較するような追加実装は不要 — 既存テストの範囲外。
+//
+// このテストは:
+//   層 1 (source pin):
+//     implPrompt 区間（function implPrompt から async function runImplement まで）に以下が含まれる:
+//       (1) 'acceptance_criteria' が含まれる
+//       (2) 'plan?.summary' または 'plan.summary' が含まれる
+//       (3) 'architecture_decisions' が含まれる
+//       (4) 'edge_cases' が含まれる
+//       (5) 'requirements' ラベルが含まれる（implementer.md 宣言済み入力名との一致 = AC2 検証）
+//   層 2 (routing pin — VM sandbox):
+//       (6) implementer 呼び出しが 2 件以上（serial T1 + parallel T2）
+//       (7) label に ':serial:' を含む implementer call が >= 1
+//       (8) label に ':par:' を含む implementer call が >= 1
+//       (9) 全 implementer call の prompt に 5 sentinel トークンが含まれる:
+//           'AC_SENTINEL_ONE' / 'AC_SENTINEL_TWO' / 'PLAN_SUMMARY_SENTINEL' /
+//           'ARCH_DECISION_SENTINEL' / 'EDGE_CASE_SENTINEL'
+// を assert する。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const devFlowPath = join(here, '..', '.claude/workflows/dev-flow.js');
+
+const src = readFileSync(devFlowPath, 'utf8');
+
+// ============================================================
+// 層 1: source pin
+// implPrompt 区間を切り出して必要トークンを assert する
+// ============================================================
+
+// implPrompt 区間 = function implPrompt の開始から async function runImplement の開始まで
+const implPromptStart = src.indexOf('function implPrompt');
+const implPromptEnd = src.indexOf('async function runImplement');
+
+if (implPromptStart === -1) {
+  throw new Error('dev-flow.js に function implPrompt が見つからない');
+}
+if (implPromptEnd === -1) {
+  throw new Error('dev-flow.js に async function runImplement が見つからない');
+}
+
+const implPromptSection = src.slice(implPromptStart, implPromptEnd);
+
+test('[requirements-injection] implPrompt 区間に acceptance_criteria が含まれる', () => {
+  assert.ok(
+    implPromptSection.includes('acceptance_criteria'),
+    'implPrompt 区間に "acceptance_criteria" が存在しない。AC を implementer prompt に注入すること（issue #224）',
+  );
+});
+
+test('[requirements-injection] implPrompt 区間に plan.summary への参照が含まれる', () => {
+  const hasPlanSummary =
+    implPromptSection.includes('plan?.summary') || implPromptSection.includes('plan.summary');
+  assert.ok(
+    hasPlanSummary,
+    'implPrompt 区間に "plan?.summary" / "plan.summary" が存在しない。plan contract を implementer prompt に注入すること（issue #224）',
+  );
+});
+
+test('[requirements-injection] implPrompt 区間に architecture_decisions が含まれる', () => {
+  assert.ok(
+    implPromptSection.includes('architecture_decisions'),
+    'implPrompt 区間に "architecture_decisions" が存在しない。plan contract を implementer prompt に注入すること（issue #224）',
+  );
+});
+
+test('[requirements-injection] implPrompt 区間に edge_cases が含まれる', () => {
+  assert.ok(
+    implPromptSection.includes('edge_cases'),
+    'implPrompt 区間に "edge_cases" が存在しない。plan contract を implementer prompt に注入すること（issue #224）',
+  );
+});
+
+test('[requirements-injection] implPrompt 区間に requirements ラベルが含まれる（implementer.md AC2 = 入力名一致）', () => {
+  assert.ok(
+    implPromptSection.includes('requirements'),
+    'implPrompt 区間に "requirements" ラベルが存在しない。'
+    + 'implementer.md は requirements を宣言済み入力名として列挙しており、prompt のラベルと一致させること（AC2）',
+  );
+});
+
+// ============================================================
+// 層 2: routing pin（VM sandbox）
+// implementer-staging-convention.test.mjs の makeCountingSandbox / runDevFlowInSandbox を
+// 同型構造で self-contained にコピーして流用する（共有 helper 抽出はしない — 既存ルーティングテスト群も
+// 各自コピー保持の慣例）。
+// stub に sentinel token を注入し、全 implementer call の prompt に到達することを確認する。
+// ============================================================
+
+/**
+ * requirements-injection routing 専用の VM sandbox を組む。
+ * analyze stub に AC sentinel、dev-planner stub に plan sentinel を注入して
+ * implPrompt 経由で implementer に届くことを検証する。
+ *
+ * @returns {{ ctx: vm.Context, calls: Array<{label: string, agentType: string, prompt: string}> }}
+ */
+function makeCountingSandbox() {
+  const calls = [];
+
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+    calls.push({ label, agentType, prompt: String(prompt) });
+
+    if (label === 'worktree') {
+      return { worktree: '/tmp/wt', branch: 'feature/issue-1' };
+    }
+    if (label.startsWith('analyze')) {
+      return {
+        summary: 's',
+        acceptance_criteria: ['AC_SENTINEL_ONE', 'AC_SENTINEL_TWO'],
+        issue_type: 'feat',
+        scope: 'src',
+        estimated_change_file_count: 3,
+        shape: 'standard',
+      };
+    }
+    if (agentType === 'dev-planner') {
+      return {
+        summary: 'PLAN_SUMMARY_SENTINEL',
+        architecture_decisions: [{ decision: 'ARCH_DECISION_SENTINEL', rationale: 'r' }],
+        edge_cases: [{ case: 'EDGE_CASE_SENTINEL', handling: 'h' }],
+        serial: [{ id: 'T1', desc: 'impl', file_changes: ['src/a.ts'], test_plan: 'none', depends_on: [] }],
+        parallel: [{ id: 'T2', desc: 'impl2', file_changes: ['src/b.ts'], test_plan: 'none', depends_on: [] }],
+      };
+    }
+    if (agentType === 'plan-reviewer') {
+      return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
+    }
+    if (label.startsWith('danger-grep')) {
+      return { hits: [] };
+    }
+    if (label === 'realized-diff') {
+      return { files: ['src/a.ts', 'src/b.ts'] };
+    }
+    if (label === 'declared-path-check') {
+      return { files: [] };
+    }
+    if (label.startsWith('test')) {
+      return { tests: 'no_tests', green: true, summary: '' };
+    }
+    if (agentType === 'evaluator') {
+      return {
+        verdict: 'pass',
+        total: 100,
+        threshold: 80,
+        feedback: [],
+        feedback_level: 'implementation',
+        ac_results: [],
+        security_clearance: [],
+      };
+    }
+    if (label.startsWith('pr')) {
+      return { pr_url: 'http://x', pr_number: 1, committed: true };
+    }
+    if (label === 'changed-files') {
+      return { files: ['src/a.ts', 'src/b.ts'] };
+    }
+    if (agentType === 'implementer') {
+      return { status: 'DONE', task_id: 'T1', files: ['src/a.ts'], summary: 'done', concerns: [] };
+    }
+    if (label.startsWith('diff-gate') || label.startsWith('diff-hash')) {
+      return { hash: 'H', empty: false };
+    }
+    return null;
+  };
+
+  const parallelStub = async (fns) => Promise.all((fns || []).map((f) => f()));
+
+  const sandbox = {
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: parallelStub,
+    workflow: async () => ({ status: 'LGTM' }),
+    args: '1',
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+
+  const ctx = vm.createContext(sandbox);
+  return { ctx, calls };
+}
+
+/**
+ * dev-flow.js ソースを strip して async IIFE でラップし vm sandbox で実行する。
+ * implementer-staging-convention.test.mjs の runDevFlowInSandbox と同型。
+ */
+async function runDevFlowInSandbox(source, ctx) {
+  const stripped = source
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = '(async () => {\n' + stripped + '\n})();';
+
+  let caughtError = null;
+  let returned = null;
+  try {
+    const result = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/dev-flow.js' });
+    if (result && typeof result.then === 'function') {
+      returned = await result.catch((e) => {
+        caughtError = e;
+        return null;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return { error: caughtError, returned };
+}
+
+// ============================================================
+// routing pin テスト
+// ============================================================
+
+test('[requirements-injection] routing: implementer 呼び出しが 2 件以上（serial T1 + parallel T2）', async () => {
+  const { ctx, calls } = makeCountingSandbox();
+  const { error } = await runDevFlowInSandbox(src, ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail('dev-flow.js が sandbox でクラッシュ: ' + error.name + ': ' + error.message);
+  }
+
+  const implCalls = calls.filter((c) => c.agentType === 'implementer');
+
+  assert.ok(
+    implCalls.length >= 2,
+    `implementer 呼び出しが 2 件未満（${implCalls.length} 件）。serial T1 + parallel T2 の両方が実行されるはず。`
+    + ` labels: ${implCalls.map((c) => c.label).join(', ')}`,
+  );
+});
+
+test('[requirements-injection] routing: :serial: と :par: の両 label の implementer call が存在する', async () => {
+  const { ctx, calls } = makeCountingSandbox();
+  const { error } = await runDevFlowInSandbox(src, ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail('dev-flow.js が sandbox でクラッシュ: ' + error.name + ': ' + error.message);
+  }
+
+  const implCalls = calls.filter((c) => c.agentType === 'implementer');
+  const serialCalls = implCalls.filter((c) => c.label.includes(':serial:'));
+  const parCalls = implCalls.filter((c) => c.label.includes(':par:'));
+
+  assert.ok(
+    serialCalls.length >= 1,
+    `':serial:' を含む implementer call が 0 件。serial[T1] が実行されるはず。`
+    + ` 全 labels: ${implCalls.map((c) => c.label).join(', ')}`,
+  );
+
+  assert.ok(
+    parCalls.length >= 1,
+    `':par:' を含む implementer call が 0 件。parallel[T2] が fan-out されるはず。`
+    + ` 全 labels: ${implCalls.map((c) => c.label).join(', ')}`,
+  );
+});
+
+test('[requirements-injection] routing: 全 implementer call の prompt に 5 つの sentinel が含まれる', async () => {
+  const { ctx, calls } = makeCountingSandbox();
+  const { error } = await runDevFlowInSandbox(src, ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail('dev-flow.js が sandbox でクラッシュ: ' + error.name + ': ' + error.message);
+  }
+
+  const implCalls = calls.filter((c) => c.agentType === 'implementer');
+
+  assert.ok(
+    implCalls.length >= 1,
+    `implementer が呼ばれていない（0 件）`,
+  );
+
+  const sentinels = [
+    'AC_SENTINEL_ONE',
+    'AC_SENTINEL_TWO',
+    'PLAN_SUMMARY_SENTINEL',
+    'ARCH_DECISION_SENTINEL',
+    'EDGE_CASE_SENTINEL',
+  ];
+
+  for (const c of implCalls) {
+    for (const sentinel of sentinels) {
+      assert.ok(
+        c.prompt.includes(sentinel),
+        `implementer prompt (label=${c.label}) に sentinel '${sentinel}' が含まれない。`
+        + `AC・plan contract（summary / architecture_decisions / edge_cases）が注入されていない（issue #224）`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## 概要

Closes #224

- `implPrompt` に `req.acceptance_criteria` / `plan.summary` / `plan.architecture_decisions` / `plan.edge_cases` を注入し、implementer と evaluator の採点軸を一致させる
- `implementer.md` の入力仕様に宣言済みの `requirements` フィールドが実際の prompt に配線されていない drift を解消
- 並列 fan-out の全 implementer call に同一の contract を注入（token 増は数百 token/task 程度）

## 動機

evaluator は acceptance_criteria ベースで実装を採点するが、従来の implPrompt は `task` と `STAGING_CONVENTION` のみを渡していた。implementer が AC を知らない情報非対称が Evaluate 差し戻し（eval_iter 増）の原因であったため、AC と plan contract を共有して採点軸を揃える。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/dev-flow.js` | `implPrompt` に AC・plan contract（summary / architecture_decisions / edge_cases）を注入 |
| `_lib/implementer-requirements-injection.test.mjs` | 2 層テスト追加: 層1 source pin（implPrompt 区間に必須トークンが含まれる）+ 層2 routing pin（VM sandbox で sentinel が全 implementer call に届く） |

## テスト計画

- [x] 層1 source pin: implPrompt 区間に `acceptance_criteria` / `plan.summary` / `architecture_decisions` / `edge_cases` / `requirements` が含まれる（5 テスト）
- [x] 層2 routing pin: VM sandbox で serial T1 + parallel T2 の両 implementer call に AC/plan sentinel が注入される（3 テスト）
- [x] AC3: telemetry の `eval_iter` は既存（line 2013 付近）で追加実装不要、確認済み
- [x] `implementer.md` 入力仕様の `requirements` ラベルと implPrompt 実装が一致