### PR TITLE
fix(pr-iterate): CI-failed ラウンドの history 記録欠落と max_iterations NaN ガード欠落を修正（#226）

### DIFF
--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -35,7 +35,9 @@ function resolvePositiveIntArg(args, name) {
 
 // args 正規化: 単体 /pr-iterate <pr> でも dev-flow からの workflow('pr-iterate', {pr}) でも受ける
 const PR = resolvePositiveIntArg(args, 'pr')
-const MAX = Number(args?.max_iterations ?? 10)
+const MAX = args?.max_iterations == null
+  ? 10
+  : Number(resolvePositiveIntArg(args.max_iterations, 'max_iterations'))
 const REVIEW_STUCK = 2   // 同一 topic がこの回数出たら stuck と判定し人間へエスカレーション（issue #126）
 
 // ---- Review de-churn モデル（issue #126。#123 Plan ループ収束モデルの Review 版を inline 複製）----
@@ -471,6 +473,29 @@ for (i = 1; i <= MAX; i++) {
       const ciStuckTopics = reviewSeen.stuckTopics()
       log(`iteration ${i}: approve but CI failed — ${ciFindings.length} failing check(s)`
         + `${ciStuckTopics.length ? ` [REVIEW_STUCK: ${ciStuckTopics.join(' / ')}]` : ''}`)
+
+      // CI-failed ラウンドの history 記録（blocking は synthetic CI findings）
+      history.push({ iteration: i, decision: review.decision, summary: review.summary, blocking: ciFindings })
+
+      // per-round 投稿: CI failed。decision は approve だが CI red のため gh pr review --approve は使わず
+      // plain な gh pr comment で情報提供のみ行う
+      const ciRoundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking: ciFindings })
+      const ciRoundPost = await agent(
+        `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: ${review.decision}、CI failed）。\n\n`
+        + bodySaveInstr(ciRoundBody)
+        + `## Instructions\n`
+        + `保存した <BODY_FILE> を使い、以下のコマンドをそのまま実行せよ: \`gh pr comment ${PR} --body-file <BODY_FILE>\`\n`
+        + `投稿成功時: posted:true、使用したコマンドを method に、URL があれば url に返す。\n`
+        + `投稿失敗時でも posted:false を返し throw しないこと。\n`
+        + `\n## Output format\n{ "posted": boolean, "method": string, "url": string }\n`
+        + `\n## Tools\n使用可: Bash, Write\n`
+        + `\n## Boundary\n<BODY_FILE>（一時ファイル）以外のファイルを変更しない。git commit 禁止。\n`
+        + `\n## Token cap\n200 語以内で完結すること。`,
+        { agentType: 'dev-runner', schema: POST_RESULT, label: `post-review#${i}`, phase: 'Iterate' },
+      )
+      if (!ciRoundPost?.posted) {
+        log(`⚠️ post-review#${i} (ci-failed) の投稿に失敗しました（posted=${ciRoundPost?.posted ?? 'null'}）。ワークフローは継続します。`)
+      }
 
       if (ciStuckTopics.length) {
         terminal = 'stuck'

--- a/_lib/priterate-ci-history.test.mjs
+++ b/_lib/priterate-ci-history.test.mjs
@@ -1,0 +1,183 @@
+// F1: CI-failed ラウンドが history と per-round 投稿に反映されることを pin する TDD テスト（red phase）
+// アサーション:
+//   (1) label==='post-review#1' の agent 呼び出しが存在し、prompt に 'CI check failed: bats' が含まれる
+//   (2) label==='post-summary' の prompt に '反復履歴' が含まれ、iter 1 行と iter 2 行が両方含まれる
+//   (3) post-summary の prompt に 'CI check failed: bats' が含まれる（全 blocking 詳細 details セクション経由）
+//   (4) result.status === 'lgtm' かつ result.iterations === 2
+//   (5) ReferenceError/SyntaxError での sandbox クラッシュは assert.fail
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const prIteratePath = join(repoRoot, '.claude/workflows/pr-iterate.js');
+
+function makeSandbox() {
+  const agentCalls = []; // {label, agentType, prompt}
+  let ciCallCount = 0;
+
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+
+    agentCalls.push({ label, agentType, prompt: typeof prompt === 'string' ? prompt : JSON.stringify(prompt) });
+
+    // pr-reviewer: 常に approve
+    if (agentType === 'pr-reviewer') {
+      return { decision: 'approve', issues: [], summary: 'ok' };
+    }
+
+    // ci-check: 1 回目は failed、2 回目は passed
+    if (agentType === 'dev-runner' && typeof prompt === 'string' && prompt.includes('check-ci.sh')) {
+      ciCallCount += 1;
+      if (ciCallCount === 1) {
+        return {
+          status: 'failed',
+          failed_checks: [{ name: 'bats', bucket: 'test', state: 'failure' }],
+        };
+      }
+      return { status: 'passed', failed_checks: [] };
+    }
+
+    // fix: label が 'fix#' で始まる
+    if (label.startsWith('fix#')) {
+      return { applied: true, summary: 'fixed', files: [] };
+    }
+
+    // post 系: label が 'post-' で始まる
+    if (label.startsWith('post-')) {
+      return { posted: true, method: 'gh', url: 'http://x' };
+    }
+
+    // journal-log
+    if (label === 'journal-log') {
+      return { logged: true, summary: 'ok' };
+    }
+
+    return null;
+  };
+
+  const parallelStub = async (fns) => Promise.all((fns || []).map((f) => f()));
+  const workflowStub = async () => ({ status: 'lgtm' });
+
+  const sandbox = {
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: parallelStub,
+    workflow: workflowStub,
+    args: '5',
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+
+  const ctx = vm.createContext(sandbox);
+  return {
+    ctx,
+    getAgentCalls: () => agentCalls,
+  };
+}
+
+async function runPrIterateCapture(src, ctx) {
+  const stripped = src
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = `(async () => {\n${stripped}\n})();`;
+
+  let caughtError = null;
+  let resolvedResult = null;
+  try {
+    const resultPromise = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/pr-iterate.js' });
+    if (resultPromise && typeof resultPromise.then === 'function') {
+      resolvedResult = await resultPromise.catch((e) => {
+        caughtError = e;
+        return null;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return { result: resolvedResult, error: caughtError };
+}
+
+const src = readFileSync(prIteratePath, 'utf8');
+
+test('[ci-history] CI-failed ラウンドが per-round コメントと終端レポートに反映される', async () => {
+  const { ctx, getAgentCalls } = makeSandbox();
+
+  const { result, error } = await runPrIterateCapture(src, ctx);
+
+  // (5) sandbox クラッシュ検出
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`pr-iterate.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  const agentCalls = getAgentCalls();
+
+  // (1) label==='post-review#1' の呼び出しが存在し、prompt に 'CI check failed: bats' が含まれる
+  // CI-failed ラウンド（iteration 1）の per-round コメント投稿の検証
+  const postReview1 = agentCalls.find((c) => c.label === 'post-review#1');
+  assert.ok(
+    postReview1 != null,
+    `label==='post-review#1' の agent 呼び出しが存在するべきだが見つからなかった。呼び出しラベル一覧: ${agentCalls.map((c) => c.label).join(', ')}`,
+  );
+  assert.ok(
+    typeof postReview1.prompt === 'string' && postReview1.prompt.includes('CI check failed: bats'),
+    `post-review#1 の prompt に 'CI check failed: bats' が含まれるべきだが含まれない。\nprompt の先頭500文字: ${String(postReview1?.prompt ?? '').slice(0, 500)}`,
+  );
+
+  // (2) post-summary の prompt に '反復履歴' と '| 1 |' と '| 2 |' が含まれる
+  const postSummary = agentCalls.find((c) => c.label === 'post-summary');
+  assert.ok(
+    postSummary != null,
+    `label==='post-summary' の agent 呼び出しが存在するべきだが見つからなかった。呼び出しラベル一覧: ${agentCalls.map((c) => c.label).join(', ')}`,
+  );
+  assert.ok(
+    typeof postSummary.prompt === 'string' && postSummary.prompt.includes('反復履歴'),
+    `post-summary の prompt に '反復履歴' が含まれるべきだが含まれない。\nprompt の先頭500文字: ${String(postSummary?.prompt ?? '').slice(0, 500)}`,
+  );
+  assert.ok(
+    typeof postSummary.prompt === 'string' && postSummary.prompt.includes('| 1 |'),
+    `post-summary の prompt に '| 1 |'（iter 1 の行）が含まれるべきだが含まれない。\nprompt の先頭800文字: ${String(postSummary?.prompt ?? '').slice(0, 800)}`,
+  );
+  assert.ok(
+    typeof postSummary.prompt === 'string' && postSummary.prompt.includes('| 2 |'),
+    `post-summary の prompt に '| 2 |'（iter 2 の行）が含まれるべきだが含まれない。\nprompt の先頭800文字: ${String(postSummary?.prompt ?? '').slice(0, 800)}`,
+  );
+
+  // (3) post-summary の prompt に 'CI check failed: bats' が含まれる（全 blocking 詳細 details セクション経由）
+  assert.ok(
+    typeof postSummary.prompt === 'string' && postSummary.prompt.includes('CI check failed: bats'),
+    `post-summary の prompt に 'CI check failed: bats' が含まれるべきだが含まれない（全 blocking 詳細 details セクション）。\nprompt の先頭1000文字: ${String(postSummary?.prompt ?? '').slice(0, 1000)}`,
+  );
+
+  // (4) result.status === 'lgtm' かつ result.iterations === 2
+  assert.equal(
+    result?.status,
+    'lgtm',
+    `result.status は 'lgtm' であるべきだが '${result?.status}' だった`,
+  );
+  assert.equal(
+    result?.iterations,
+    2,
+    `result.iterations は 2 であるべきだが ${result?.iterations} だった`,
+  );
+});

--- a/_lib/priterate-max-iterations.test.mjs
+++ b/_lib/priterate-max-iterations.test.mjs
@@ -1,0 +1,249 @@
+// F1: max_iterations の検証を pin する TDD テスト（red phase）
+// テストケース:
+//   (1) args={pr:'5', max_iterations:'abc'} → vm 実行が reject し error.message が /正の整数/ にマッチ
+//   (2) args={pr:'5', max_iterations:'3'} で pr-reviewer が常に request-changes（topic 毎回ユニーク）→
+//       result.status==='max_reached' かつ result.iterations===3
+//   (3) args={pr:'5'}（max_iterations 未指定）で pr-reviewer が即 approve、ci-check passed → lgtm
+//   (4) args='5'（bare string、max_iterations なし）でも lgtm（単体起動の回帰防止）
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const prIteratePath = join(repoRoot, '.claude/workflows/pr-iterate.js');
+
+const src = readFileSync(prIteratePath, 'utf8');
+
+/**
+ * pr-iterate.js を vm sandbox で実行する。
+ * agentStub は呼び出しラベルと agentType で分岐し、全呼び出しを agentCalls に記録する。
+ */
+function makeSandbox({ args, agentStub }) {
+  const sandbox = {
+    phase: () => {},
+    log: () => {},
+    agent: agentStub,
+    parallel: async (fns) => Promise.all((fns || []).map((f) => f())),
+    workflow: async () => ({ status: 'lgtm' }),
+    args,
+    console,
+    JSON,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+  };
+  return vm.createContext(sandbox);
+}
+
+async function runPrIterate(ctx) {
+  const stripped = src
+    .replace(/^export\s+const\s+/gm, 'const ')
+    .replace(/^export\s+function\s+/gm, 'function ');
+  const wrapped = `(async () => {\n${stripped}\n})();`;
+
+  let caughtError = null;
+  let resolvedResult = null;
+  try {
+    const resultPromise = vm.runInContext(wrapped, ctx, { filename: '.claude/workflows/pr-iterate.js' });
+    if (resultPromise && typeof resultPromise.then === 'function') {
+      resolvedResult = await resultPromise.catch((e) => {
+        caughtError = e;
+        return null;
+      });
+    }
+  } catch (e) {
+    caughtError = e;
+  }
+  return { result: resolvedResult, error: caughtError };
+}
+
+// ---- テストケース (1): max_iterations='abc' → 明示 throw ----
+test('[max-iterations] max_iterations="abc" を渡すと /正の整数/ エラーで reject される（NaN silent 受理の禁止）', async () => {
+  const agentCalls = [];
+  const agentStub = async (prompt, opts) => {
+    agentCalls.push({ label: opts?.label ?? '', agentType: opts?.agentType ?? '' });
+    // loop 到達前に throw されるべきなので、何を返してもよい
+    if ((opts?.agentType ?? '') === 'pr-reviewer') {
+      return { decision: 'approve', issues: [], summary: 'ok' };
+    }
+    if ((opts?.agentType ?? '') === 'dev-runner' && typeof prompt === 'string' && prompt.includes('check-ci.sh')) {
+      return { status: 'passed', failed_checks: [] };
+    }
+    if ((opts?.label ?? '').startsWith('post-')) {
+      return { posted: true, method: 'gh', url: 'http://x' };
+    }
+    if ((opts?.label ?? '') === 'journal-log') {
+      return { logged: true, summary: 'ok' };
+    }
+    return null;
+  };
+
+  const ctx = makeSandbox({ args: { pr: '5', max_iterations: 'abc' }, agentStub });
+  const { result, error } = await runPrIterate(ctx);
+
+  // ReferenceError/SyntaxError は別問題なので区別して報告
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`pr-iterate.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+
+  // エラーが発生し、message に '正の整数' が含まれることを確認
+  assert.ok(
+    error != null,
+    `max_iterations='abc' では error が throw されるべきだが、error は null で result=${JSON.stringify(result)} だった`,
+  );
+  assert.match(
+    error?.message ?? '',
+    /正の整数/,
+    `error.message に '正の整数' が含まれるべきだが: "${error?.message}"`,
+  );
+});
+
+// ---- テストケース (2): max_iterations='3' で request-changes 3 回 → max_reached ----
+test('[max-iterations] max_iterations="3" を渡すと上限 3 で max_reached になる', async () => {
+  const agentCalls = [];
+  let reviewCallCount = 0;
+
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+    agentCalls.push({ label, agentType });
+
+    if (agentType === 'pr-reviewer') {
+      reviewCallCount += 1;
+      // topic を毎回ユニークにして REVIEW_STUCK=2 の stuck 検出を回避
+      return {
+        decision: 'request-changes',
+        issues: [{ severity: 'major', topic: `t${reviewCallCount}`, description: `issue ${reviewCallCount}` }],
+        summary: 'ng',
+      };
+    }
+    if (label.startsWith('fix#')) {
+      return { applied: true, summary: 'fixed', files: [] };
+    }
+    if (label.startsWith('post-')) {
+      return { posted: true, method: 'gh', url: 'http://x' };
+    }
+    if (label === 'journal-log') {
+      return { logged: true, summary: 'ok' };
+    }
+    return null;
+  };
+
+  const ctx = makeSandbox({ args: { pr: '5', max_iterations: '3' }, agentStub });
+  const { result, error } = await runPrIterate(ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`pr-iterate.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+  if (error) {
+    assert.fail(`予期しない error: ${error.name}: ${error.message}`);
+  }
+
+  assert.equal(
+    result?.status,
+    'max_reached',
+    `result.status は 'max_reached' であるべきだが '${result?.status}' だった`,
+  );
+  assert.equal(
+    result?.iterations,
+    3,
+    `result.iterations は 3 であるべきだが ${result?.iterations} だった`,
+  );
+});
+
+// ---- テストケース (3): max_iterations 未指定（object args）で approve → lgtm ----
+test('[max-iterations] args={pr:"5"}（max_iterations 未指定）で approve → lgtm（default 10 の正常系維持）', async () => {
+  const agentCalls = [];
+
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+    agentCalls.push({ label, agentType });
+
+    if (agentType === 'pr-reviewer') {
+      return { decision: 'approve', issues: [], summary: 'ok' };
+    }
+    if (agentType === 'dev-runner' && typeof prompt === 'string' && prompt.includes('check-ci.sh')) {
+      return { status: 'passed', failed_checks: [] };
+    }
+    if (label.startsWith('post-')) {
+      return { posted: true, method: 'gh', url: 'http://x' };
+    }
+    if (label === 'journal-log') {
+      return { logged: true, summary: 'ok' };
+    }
+    return null;
+  };
+
+  const ctx = makeSandbox({ args: { pr: '5' }, agentStub });
+  const { result, error } = await runPrIterate(ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`pr-iterate.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+  if (error) {
+    assert.fail(`予期しない error: ${error.name}: ${error.message}`);
+  }
+
+  assert.equal(
+    result?.status,
+    'lgtm',
+    `result.status は 'lgtm' であるべきだが '${result?.status}' だった`,
+  );
+});
+
+// ---- テストケース (4): bare string args='5'（max_iterations なし）で approve → lgtm ----
+test('[max-iterations] args="5"（bare string、max_iterations なし）で approve → lgtm（単体起動の回帰防止）', async () => {
+  const agentCalls = [];
+
+  const agentStub = async (prompt, opts) => {
+    const label = opts?.label ?? '';
+    const agentType = opts?.agentType ?? '';
+    agentCalls.push({ label, agentType });
+
+    if (agentType === 'pr-reviewer') {
+      return { decision: 'approve', issues: [], summary: 'ok' };
+    }
+    if (agentType === 'dev-runner' && typeof prompt === 'string' && prompt.includes('check-ci.sh')) {
+      return { status: 'passed', failed_checks: [] };
+    }
+    if (label.startsWith('post-')) {
+      return { posted: true, method: 'gh', url: 'http://x' };
+    }
+    if (label === 'journal-log') {
+      return { logged: true, summary: 'ok' };
+    }
+    return null;
+  };
+
+  const ctx = makeSandbox({ args: '5', agentStub });
+  const { result, error } = await runPrIterate(ctx);
+
+  if (error && (error.name === 'ReferenceError' || error.name === 'SyntaxError')) {
+    assert.fail(`pr-iterate.js が sandbox でクラッシュ: ${error.name}: ${error.message}`);
+  }
+  if (error) {
+    assert.fail(`予期しない error: ${error.name}: ${error.message}`);
+  }
+
+  assert.equal(
+    result?.status,
+    'lgtm',
+    `result.status は 'lgtm' であるべきだが '${result?.status}' だった`,
+  );
+});


### PR DESCRIPTION
## 概要

Closes #226

- CI-failed ラウンド（pr-reviewer が approve だが CI red）で `history.push` と per-round コメント投稿（`post-review#N`）が素通りされていたバグを修正
- `max_iterations` に非数値文字列（`"abc"` 等）を渡すと NaN が silent 受理されループ 0 回で `max_reached` になる問題を `resolvePositiveIntArg` 経由の検証で修正
- 両バグを pin する TDD テスト 2 ファイルを `_lib/` に追加

## 動機

1. **CI ラウンドの記録欠落**: approve+CI-failed 分岐が `continue` で 513 の `history.push` と per-round コメント投稿を素通りしていた。監査証跡（blast-radius 正当化の根幹）に穴があり P1 修正対象。
2. **NaN ガード欠落**: `MAX = Number(args?.max_iterations ?? 10)` は NaN 検証なし。NaN ならループ 0 回で `max_reached` を silent 返却してしまう。既存 `resolvePositiveIntArg` が流用可能。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/pr-iterate.js` | CI-failed パスに `history.push` + `post-review#N` コメント投稿を追加。`MAX` を `resolvePositiveIntArg` 経由に変更し不正値で明示 error |
| `_lib/priterate-ci-history.test.mjs` | CI-failed ラウンドが per-round コメント・終端レポート・lgtm 到達に正しく反映されることを検証するテスト（新規） |
| `_lib/priterate-max-iterations.test.mjs` | `max_iterations` の不正値エラー・上限 max_reached・デフォルト lgtm 正常系を検証するテスト（新規） |

## テスト計画

- [x] `_lib/priterate-ci-history.test.mjs`: CI-failed history・投稿・lgtm 到達を vm sandbox で pin
- [x] `_lib/priterate-max-iterations.test.mjs`: 不正値エラー・上限 3 で max_reached・デフォルト lgtm・bare string lgtm の 4 ケースを pin
- [ ] `node --test _lib/priterate-ci-history.test.mjs` でグリーン確認
- [ ] `node --test _lib/priterate-max-iterations.test.mjs` でグリーン確認