### PR TITLE
feat(pr-iterate): verification_evidence で判定根拠を構造化表示（#242）

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -90,9 +90,19 @@ moving target（蒸し返し）を生む。これを避ける:
      "description": "日本語で何が問題か",
      "suggestion": "日本語で具体的な修正"}
   ],
-  "summary": "日本語の総評（LGTM か、何が残っているか）"
+  "summary": "日本語の総評（LGTM か、何が残っているか）",
+  "verification_evidence": [
+    "worktree で全 N node テストを実行し green を確認",
+    "diff を PR の宣言意図（title/body）と照合し過不足なし"
+  ]
 }
 ```
+
+- `summary` は**結論 1-2 文に留める**。検証根拠の列挙を summary に詰め込まない
+  （改行なしの壁テキスト化を防ぐ。issue #242）
+- `verification_evidence`（任意だが原則列挙する）: 検証した根拠（テスト実行・diff 照合・
+  edge case 確認等）を **1 項目 1 文**の配列で列挙する。PR コメント・終了レポートで
+  箇条書き表示される
 
 - `topic`（任意だが**反復時は必須**）: 同一問題を識別する安定 ID。同じ問題を再提起するときは
   前ラウンドと同じ文字列を再利用する（stuck 突合に使う）。新規問題には新しい topic を付ける。

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -131,9 +131,11 @@ function mdCell(v) {
  * @param {number} opts.iteration - 反復回数
  * @param {string} opts.decision - 'approve' | 'request-changes' | 'comment'
  * @param {Array} opts.blocking - blocking finding の配列
+ * @param {string} [opts.summary] - 結論 1-2 文（任意）
+ * @param {string[]} [opts.verificationEvidence] - 検証根拠リスト（任意）
  * @returns {string}
  */
-function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
+function buildReviewCommentBody({ pr, iteration, decision, blocking, summary, verificationEvidence }) {
   const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
   const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const label = DECISION_LABEL[decision] ?? decision;
@@ -166,6 +168,17 @@ function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
     }
   }
 
+  if (summary != null && summary !== '') {
+    lines.push('');
+    lines.push(`**summary**: ${summary}`);
+  }
+  const evList = verificationEvidence || [];
+  if (evList.length > 0) {
+    lines.push('');
+    lines.push('**検証根拠**:');
+    for (const e of evList) lines.push(`- ${mdCell(e)}`);
+  }
+
   return lines.join('\n');
 }
 
@@ -184,10 +197,11 @@ const STATUS_HEADLINE = {
  * @param {number} opts.iterations - 総反復回数
  * @param {string} opts.lastDecision - 最終判定
  * @param {string} opts.lastSummary - 最終サマリーテキスト
+ * @param {string[]} [opts.lastVerificationEvidence] - 最終検証根拠リスト（任意）
  * @param {Array} opts.history - ラウンド履歴 [{iteration, decision, summary, blocking}]
  * @returns {string}
  */
-function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, history }) {
+function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, lastVerificationEvidence, history }) {
   const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
   const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const lines = [];
@@ -205,6 +219,13 @@ function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSu
 
   lines.push('');
   lines.push(`**最終判定理由**: ${lastSummary}`);
+
+  const evList2 = lastVerificationEvidence || [];
+  if (evList2.length > 0) {
+    lines.push('');
+    lines.push('**検証根拠**:');
+    for (const e of evList2) lines.push(`- ${mdCell(e)}`);
+  }
 
   const histList = history || [];
   if (histList.length > 0) {
@@ -313,6 +334,8 @@ const REVIEW = {
       },
     },
     summary: { type: 'string' },
+    // 検証根拠の箇条書き（1 項目 1 文）。summary は結論 1-2 文に留める（issue #242）
+    verification_evidence: { type: 'array', items: { type: 'string' } },
   },
 }
 
@@ -415,7 +438,7 @@ for (i = 1; i <= MAX; i++) {
       history.push({ iteration: i, decision: review.decision, summary: review.summary, blocking: [] })
 
       // per-round 投稿: approve（self-PR 検出 → --approve 失敗時 gh pr comment へフォールバック）
-      const approveBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking: [] })
+      const approveBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking: [], summary: review.summary, verificationEvidence: review.verification_evidence })
       const approvePost = await agent(
         `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: approve）。\n\n`
         + bodySaveInstr(approveBody)
@@ -480,7 +503,7 @@ for (i = 1; i <= MAX; i++) {
 
       // per-round 投稿: CI failed。decision は approve だが CI red のため gh pr review --approve は使わず
       // plain な gh pr comment で情報提供のみ行う
-      const ciRoundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking: ciFindings })
+      const ciRoundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking: ciFindings, summary: review.summary, verificationEvidence: review.verification_evidence })
       const ciRoundPost = await agent(
         `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: ${review.decision}、CI failed）。\n\n`
         + bodySaveInstr(ciRoundBody)
@@ -540,7 +563,7 @@ for (i = 1; i <= MAX; i++) {
   history.push({ iteration: i, decision: review.decision, summary: review.summary, blocking })
 
   // per-round 投稿: request-changes または comment
-  const roundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking })
+  const roundBody = buildReviewCommentBody({ pr: PR, iteration: i, decision: review.decision, blocking, summary: review.summary, verificationEvidence: review.verification_evidence })
   const roundPost = await agent(
     `## Objective\nPR #${PR} に pr-iterate のレビュー結果コメントを投稿する（iteration ${i}、判定: ${review.decision}）。\n\n`
     + bodySaveInstr(roundBody)
@@ -605,6 +628,7 @@ const summaryBody = buildTerminalSummaryBody({
   iterations: Math.min(i, MAX),
   lastDecision: lastReview?.decision ?? null,
   lastSummary: lastReview?.summary ?? null,
+  lastVerificationEvidence: lastReview?.verification_evidence ?? null,
   history,
 })
 const summaryPost = await agent(

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -387,6 +387,7 @@ for (i = 1; i <= MAX; i++) {
   const prior = reviewSeen.prior()   // 前 iteration までの累積 findings
   const review = await agent(
     `PR #${PR} を批判的にレビューせよ。gh pr view / gh pr diff で実 diff を確認し、宣言意図に照合する。\n`
+    + `summary は結論 1-2 文に留めよ。検証した根拠（テスト実行・diff 照合・edge case 確認等）は verification_evidence に 1 項目 1 文の配列で列挙せよ。\n`
     + (prior.length
         ? `既出 findings（前ラウンドまでに指摘済み。author は対応済みのはず）:\n${JSON.stringify(prior)}\n`
           + `**新規の critical/major のみ報告**せよ。前ラウンドで対応済み・却下済みの論点の蒸し返し、`

--- a/_lib/pr-comment-format.mjs
+++ b/_lib/pr-comment-format.mjs
@@ -23,9 +23,11 @@ export function mdCell(v) {
  * @param {number} opts.iteration - 反復回数
  * @param {string} opts.decision - 'approve' | 'request-changes' | 'comment'
  * @param {Array} opts.blocking - blocking finding の配列
+ * @param {string} [opts.summary] - 結論 1-2 文（任意）
+ * @param {string[]} [opts.verificationEvidence] - 検証根拠リスト（任意）
  * @returns {string}
  */
-export function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
+export function buildReviewCommentBody({ pr, iteration, decision, blocking, summary, verificationEvidence }) {
   const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
   const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const label = DECISION_LABEL[decision] ?? decision;
@@ -58,6 +60,17 @@ export function buildReviewCommentBody({ pr, iteration, decision, blocking }) {
     }
   }
 
+  if (summary != null && summary !== '') {
+    lines.push('');
+    lines.push(`**summary**: ${summary}`);
+  }
+  const evList = verificationEvidence || [];
+  if (evList.length > 0) {
+    lines.push('');
+    lines.push('**検証根拠**:');
+    for (const e of evList) lines.push(`- ${mdCell(e)}`);
+  }
+
   return lines.join('\n');
 }
 
@@ -76,10 +89,11 @@ const STATUS_HEADLINE = {
  * @param {number} opts.iterations - 総反復回数
  * @param {string} opts.lastDecision - 最終判定
  * @param {string} opts.lastSummary - 最終サマリーテキスト
+ * @param {string[]} [opts.lastVerificationEvidence] - 最終検証根拠リスト（任意）
  * @param {Array} opts.history - ラウンド履歴 [{iteration, decision, summary, blocking}]
  * @returns {string}
  */
-export function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, history }) {
+export function buildTerminalSummaryBody({ pr, status, iterations, lastDecision, lastSummary, lastVerificationEvidence, history }) {
   const DECISION_EMOJI = { 'approve': '✅', 'request-changes': '🔴', 'comment': '💬' };
   const SEV_LABEL = { 'critical': '🔴 critical', 'major': '🟠 major', 'minor': '🟡 minor' };
   const lines = [];
@@ -97,6 +111,13 @@ export function buildTerminalSummaryBody({ pr, status, iterations, lastDecision,
 
   lines.push('');
   lines.push(`**最終判定理由**: ${lastSummary}`);
+
+  const evList2 = lastVerificationEvidence || [];
+  if (evList2.length > 0) {
+    lines.push('');
+    lines.push('**検証根拠**:');
+    for (const e of evList2) lines.push(`- ${mdCell(e)}`);
+  }
 
   const histList = history || [];
   if (histList.length > 0) {

--- a/_lib/pr-comment-format.test.mjs
+++ b/_lib/pr-comment-format.test.mjs
@@ -430,3 +430,175 @@ test('buildTerminalSummaryBody: 決定性（同入力 -> 同出力）', () => {
   const second = buildTerminalSummaryBody(input);
   assert.equal(first, second, '同入力 -> バイト完全一致');
 });
+
+// --- New tests: verification_evidence support ------------------------------------
+
+// (1) buildTerminalSummaryBody with lastVerificationEvidence — snapshot pin
+test('buildTerminalSummaryBody: lastVerificationEvidence を渡すと **検証根拠**: + 箇条書きが出る（スナップショット pin）', () => {
+  const body = buildTerminalSummaryBody({
+    pr: 10,
+    status: 'lgtm',
+    iterations: 2,
+    lastDecision: 'approve',
+    lastSummary: '問題なし',
+    lastVerificationEvidence: ['根拠A', '根拠B'],
+    history: [
+      { iteration: 1, decision: 'request-changes', summary: 'issues', blocking: [] },
+      { iteration: 2, decision: 'approve', summary: 'fixed', blocking: [] },
+    ],
+  });
+
+  const expectedBody = [
+    '## PR #10 — pr-iterate 終了レポート',
+    '',
+    '### 🎉 LGTM',
+    '',
+    '| 終了状態 | 総反復 | 最終判定 |',
+    '|---|---|---|',
+    '| lgtm | 2 | ✅ 承認 (LGTM) |',
+    '',
+    '**最終判定理由**: 問題なし',
+    '',
+    '**検証根拠**:',
+    '- 根拠A',
+    '- 根拠B',
+    '',
+    '### 反復履歴',
+    '',
+    '| iter | 判定 | blocking | summary |',
+    '|---|---|---|---|',
+    '| 1 | 🔴 変更要求 | 0 | issues |',
+    '| 2 | ✅ 承認 (LGTM) | 0 | fixed |',
+    '',
+    '---',
+    '*このコメントは pr-iterate により自動生成されました。*',
+    '<!-- pr-iterate:lgtm:2 -->',
+  ].join('\n');
+
+  assert.equal(body, expectedBody, 'スナップショット全文一致');
+});
+
+// (2) lastVerificationEvidence が undefined のとき現行出力と完全一致
+test('buildTerminalSummaryBody: lastVerificationEvidence が undefined のとき **検証根拠** を含まない', () => {
+  const withoutEvidence = buildTerminalSummaryBody({
+    pr: 5,
+    status: 'lgtm',
+    iterations: 1,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    history: [],
+  });
+  const withUndefined = buildTerminalSummaryBody({
+    pr: 5,
+    status: 'lgtm',
+    iterations: 1,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    lastVerificationEvidence: undefined,
+    history: [],
+  });
+  assert.ok(!withoutEvidence.includes('**検証根拠**'), 'undefined 時: **検証根拠** を含まない');
+  assert.equal(withoutEvidence, withUndefined, 'undefined 省略と undefined 明示で出力が完全一致');
+});
+
+// (3) lastVerificationEvidence が空配列 [] のとき (2) と同一
+test('buildTerminalSummaryBody: lastVerificationEvidence が [] のとき **検証根拠** を含まない', () => {
+  const withoutEvidence = buildTerminalSummaryBody({
+    pr: 5,
+    status: 'lgtm',
+    iterations: 1,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    history: [],
+  });
+  const withEmpty = buildTerminalSummaryBody({
+    pr: 5,
+    status: 'lgtm',
+    iterations: 1,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    lastVerificationEvidence: [],
+    history: [],
+  });
+  assert.ok(!withEmpty.includes('**検証根拠**'), '空配列時: **検証根拠** を含まない');
+  assert.equal(withoutEvidence, withEmpty, '省略と空配列で出力が完全一致');
+});
+
+// (4) history の round.summary が 120 文字超でテーブル truncation、evidence 非混入
+test('buildTerminalSummaryBody: 長文 summary truncation + evidence がテーブル行に混入しない', () => {
+  const longSummary = 'a'.repeat(130);
+  const body = buildTerminalSummaryBody({
+    pr: 7,
+    status: 'lgtm',
+    iterations: 1,
+    lastDecision: 'approve',
+    lastSummary: 'done',
+    lastVerificationEvidence: ['evidence item X'],
+    history: [
+      { iteration: 1, decision: 'approve', summary: longSummary, blocking: [] },
+    ],
+  });
+  const truncated = 'a'.repeat(120) + '\u2026';
+  assert.ok(body.includes(truncated), '120文字+… が反復履歴テーブルに出る');
+
+  // テーブル行（`| <数字> |` で始まる行）に evidence 文字列が混入しないことを検証
+  const tableRows = body.split('\n').filter(l => /^\| \d+ \|/.test(l));
+  assert.ok(tableRows.length > 0, 'テーブル行が存在する');
+  for (const row of tableRows) {
+    assert.ok(!row.includes('evidence item X'), 'テーブル行に evidence が混入しない');
+  }
+});
+
+// (5) buildReviewCommentBody に summary / verificationEvidence を渡すと表示される
+test('buildReviewCommentBody: summary と verificationEvidence を渡すと **summary** + **検証根拠** が出る', () => {
+  const body = buildReviewCommentBody({
+    pr: 3,
+    iteration: 1,
+    decision: 'approve',
+    blocking: [],
+    summary: '結論文',
+    verificationEvidence: ['根拠1'],
+  });
+  assert.ok(body.includes('**summary**: 結論文'), '**summary**: が出る');
+  assert.ok(body.includes('**検証根拠**:'), '**検証根拠**: が出る');
+  assert.ok(body.includes('- 根拠1'), '箇条書き項目が出る');
+
+  // 判定行の後に summary が来ることを確認（順序検証）
+  const summaryIdx = body.indexOf('**summary**:');
+  const decisionIdx = body.indexOf('**判定**:');
+  assert.ok(decisionIdx < summaryIdx, '判定行より後に **summary** が来る');
+});
+
+// (6) buildReviewCommentBody で summary / verificationEvidence を渡さない場合、現行出力と完全一致
+test('buildReviewCommentBody: summary / verificationEvidence 省略時は現行出力と完全一致', () => {
+  const withoutNew = buildReviewCommentBody({
+    pr: 5,
+    iteration: 2,
+    decision: 'request-changes',
+    blocking: [{ severity: 'critical', description: 'issue' }],
+  });
+  const withUndefined = buildReviewCommentBody({
+    pr: 5,
+    iteration: 2,
+    decision: 'request-changes',
+    blocking: [{ severity: 'critical', description: 'issue' }],
+    summary: undefined,
+    verificationEvidence: undefined,
+  });
+  assert.ok(!withoutNew.includes('**summary**'), '省略時: **summary** を含まない');
+  assert.ok(!withoutNew.includes('**検証根拠**'), '省略時: **検証根拠** を含まない');
+  assert.equal(withoutNew, withUndefined, '省略と undefined 明示で出力が完全一致');
+});
+
+// (7) evidence 項目に改行を含む文字列を渡すと mdCell で <br> になる
+test('buildReviewCommentBody: evidence 項目の改行が mdCell で <br> に変換される', () => {
+  const body = buildReviewCommentBody({
+    pr: 1,
+    iteration: 1,
+    decision: 'approve',
+    blocking: [],
+    summary: '要約',
+    verificationEvidence: ['a\nb'],
+  });
+  assert.ok(body.includes('- a<br>b'), 'evidence 改行が <br> に変換される');
+});


### PR DESCRIPTION
## 概要

Closes #242

- REVIEW schema に `verification_evidence: string[]` フィールドを追加し、pr-reviewer が判定根拠を構造化して返せるようにした
- `buildReviewCommentBody` / `buildTerminalSummaryBody` を拡張し、per-round コメントおよび終了レポートに **summary**（結論 1-2 文）+ **検証根拠**（箇条書き）を表示
- `_lib/pr-comment-format.mjs` の canonical も同様に更新し workflow inline と一致させた
- `_lib/pr-comment-format.test.mjs` に 7 ケースのユニットテストを追加してスナップショット pin

## 動機

pr-iterate 終了レポートの最終判定理由が改行なしの壁テキストで読みにくかった。根本原因は REVIEW schema が `summary: string` 1 本しか受け付けず、検証 evidence の列挙を構造で表現できないことにあった。`verification_evidence` フィールドを追加し「summary は 1-2 文の結論のみ、根拠は verification_evidence に 1 項目 1 文で列挙」という契約に変更することで表示を構造化した。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/pr-iterate.js` | REVIEW schema に `verification_evidence` 追加、`buildReviewCommentBody` / `buildTerminalSummaryBody` 呼び出しに `summary` / `verificationEvidence` 渡す |
| `_lib/pr-comment-format.mjs` | `buildReviewCommentBody` / `buildTerminalSummaryBody` に `summary` / `verificationEvidence` / `lastVerificationEvidence` パラメータを追加し **summary** + **検証根拠** セクションを出力 |
| `_lib/pr-comment-format.test.mjs` | 7 ケースのユニットテスト追加（スナップショット pin、省略時の後方互換、改行変換等） |

## テスト計画

- [x] `_lib/pr-comment-format.test.mjs` — 7 ケース追加・全テスト通過
- [x] `verification_evidence` 欠落時（undefined / 空配列）に現行出力と完全一致することを確認
- [x] pr-reviewer.md の出力契約追記（dee5a31 で本 PR に追加 — main session から編集可能だったため）
