### PR TITLE
feat(tools): sync-inlines の生成後検証を追加

### DIFF
--- a/tools/sync-inlines.mjs
+++ b/tools/sync-inlines.mjs
@@ -24,6 +24,8 @@ const END_RE   = /^\/\/ ==== END inline: (\S+) ====$/;
 //   - Template literals: handled as string context up to the matching closing backtick.
 //     ${ } expressions inside template literals are NOT recursed into (not needed for current
 //     canonicals; a comment in the code makes this limitation explicit).
+//   - Regex literals are not parsed as regex context. This is acceptable for current canonicals;
+//     add a focused fixture before relying on regex literals containing comment-like tokens.
 //   - After comment removal, the positions of remaining code are preserved (comments -> spaces).
 //
 // NOTE: canonicals with ${ } containing a nested backtick are NOT supported. The current 8
@@ -117,6 +119,62 @@ export function transformCanonical(src, label) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// collectTopLevelDeclNames(src): collect declaration names that will share the
+// workflow file's top-level scope after inline generation. This intentionally
+// only considers column-0 declarations; nested declarations stay scoped.
+// ─────────────────────────────────────────────────────────────────────────────
+export function collectTopLevelDeclNames(src) {
+  const stripped = stripComments(src);
+  const names = [];
+  for (const line of stripped.split('\n')) {
+    let match = line.match(/^(?:async\s+function|function)\s+([A-Za-z_$][\w$]*)\b/);
+    if (match) {
+      names.push(match[1]);
+      continue;
+    }
+    match = line.match(/^class\s+([A-Za-z_$][\w$]*)\b/);
+    if (match) {
+      names.push(match[1]);
+      continue;
+    }
+    match = line.match(/^(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b/);
+    if (match) {
+      names.push(match[1]);
+    }
+  }
+  return names;
+}
+
+function validateInlineDeclCollisions(wfFile, inlineRegions) {
+  const seen = new Map();
+  for (const region of inlineRegions) {
+    for (const name of collectTopLevelDeclNames(region.transformed)) {
+      const firstSource = seen.get(name);
+      if (firstSource) {
+        throw new Error(
+          `${wfFile}: top-level declaration collision '${name}' in ${firstSource} and ${region.source}`,
+        );
+      }
+      seen.set(name, region.source);
+    }
+  }
+}
+
+function validateGeneratedWorkflowSyntax(wfFile, src) {
+  const parseableSrc = src
+    .replace(/^export\s+(?=(async\s+)?(function|const|let|var|class)\b)/gm, '')
+    .replace(/^export\s+default\s+/gm, '');
+  try {
+    // Workflow bodies may contain top-level await/return. Wrapping in an async
+    // function validates syntax without executing the generated workflow.
+    // eslint-disable-next-line no-new-func
+    new Function(`return (async () => {\n${parseableSrc}\n});`);
+  } catch (err) {
+    throw new Error(`${wfFile}: generated workflow syntax error: ${err.message}`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // scanMarkers(wfSrc, wfLabel): parse BEGIN/END marker pairs in a workflow file source.
 // Returns: [{source: string (canonical relative path), beginLine: number, endLine: number}]
 // Line numbers are 0-indexed (index into wfSrc.split('\n')).
@@ -194,12 +252,14 @@ export function syncRepo(root, { write }) {
     const markers = scanMarkers(wfSrc, wfFile);
 
     if (markers.length === 0) {
+      validateGeneratedWorkflowSyntax(wfFile, wfSrc);
       results.push({ file: wfFile, source: null, changed: false });
       continue;
     }
 
     // Build new file content by replacing each marker zone
     const lines = wfSrc.split('\n');
+    const inlineRegions = [];
     // We need to process in reverse order to preserve line indices
     const sortedMarkers = [...markers].sort((a, b) => b.beginLine - a.beginLine);
 
@@ -215,6 +275,7 @@ export function syncRepo(root, { write }) {
       checkForbiddenTokens(canonicalSrc, marker.source);
       // Transform: strip export prefix, normalize trailing newline
       const transformed = transformCanonical(canonicalSrc, marker.source);
+      inlineRegions.push({ source: marker.source, transformed });
       // Replace: keep BEGIN line, replace body, keep END line
       const beginLine = lines[marker.beginLine];
       const endLine = lines[marker.endLine];
@@ -225,6 +286,8 @@ export function syncRepo(root, { write }) {
     }
 
     const newSrc = lines.join('\n');
+    validateInlineDeclCollisions(wfFile, inlineRegions);
+    validateGeneratedWorkflowSyntax(wfFile, newSrc);
     const changed = newSrc !== wfSrc;
 
     for (const marker of markers) {

--- a/tools/sync-inlines.test.mjs
+++ b/tools/sync-inlines.test.mjs
@@ -19,12 +19,14 @@ import {
   transformCanonical,
   scanMarkers,
   syncRepo,
+  collectTopLevelDeclNames,
 } from './sync-inlines.mjs';
 
 const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), 'sync-inlines.mjs');
 
 // Helper: create a minimal fixture repo in a tmpdir
-function makeFixtureRepo(canonicalContent, workflowContent, { multiWf = false, secondWfContent = null } = {}) {
+// extraCanonicals: { 'fake2.mjs': content, ... } — written to _lib/ alongside fake.mjs
+function makeFixtureRepo(canonicalContent, workflowContent, { multiWf = false, secondWfContent = null, extraCanonicals = {} } = {}) {
   const tmp = mkdtempSync(join(os.tmpdir(), 'sync-inlines-'));
   mkdirSync(join(tmp, '_lib'), { recursive: true });
   mkdirSync(join(tmp, '.claude', 'workflows'), { recursive: true });
@@ -32,6 +34,9 @@ function makeFixtureRepo(canonicalContent, workflowContent, { multiWf = false, s
   writeFileSync(join(tmp, '.claude', 'workflows', 'wf.js'), workflowContent, 'utf8');
   if (multiWf && secondWfContent !== null) {
     writeFileSync(join(tmp, '.claude', 'workflows', 'wf2.js'), secondWfContent, 'utf8');
+  }
+  for (const [name, content] of Object.entries(extraCanonicals)) {
+    writeFileSync(join(tmp, '_lib', name), content, 'utf8');
   }
   return tmp;
 }
@@ -329,4 +334,131 @@ test('CLI exits 2 with both --write and --check', () => {
 test('CLI exits 2 with unknown flag', () => {
   const result = runCli(['--unknown-flag']);
   assert.equal(result.status, 2);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test (t1-t3): collectTopLevelDeclNames unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('collectTopLevelDeclNames extracts function, async function, const, let, var, class', () => {
+  const src = `function foo(){}\nasync function bar(){}\nconst A = 1;\nlet b = 2;\nvar c = 3;\nclass D {}\n`;
+  const names = collectTopLevelDeclNames(src);
+  assert.deepEqual(names.sort(), ['A', 'D', 'b', 'bar', 'c', 'foo'].sort());
+});
+
+test('collectTopLevelDeclNames excludes indented nested declarations', () => {
+  const src = `function outer() {\n  const inner = 1;\n}\n`;
+  const names = collectTopLevelDeclNames(src);
+  assert.ok(names.includes('outer'), 'should include outer');
+  assert.ok(!names.includes('inner'), 'should NOT include inner (indented)');
+});
+
+test('collectTopLevelDeclNames excludes declarations in comments', () => {
+  const src = `// const ghost = 1;\nconst real = 2;\n`;
+  const names = collectTopLevelDeclNames(src);
+  assert.ok(names.includes('real'), 'should include real');
+  assert.ok(!names.includes('ghost'), 'should NOT include ghost (in comment)');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test (t4): function declaration collision between two canonicals
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('syncRepo throws on function declaration collision between two canonicals', () => {
+  const canonical1 = `export function topicKey(x) { return x; }\n`;
+  const canonical2 = `export function topicKey(y) { return y; }\n`;
+  const markerBegin1 = `// ==== BEGIN inline: _lib/fake.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd1 = `// ==== END inline: _lib/fake.mjs ====`;
+  const markerBegin2 = `// ==== BEGIN inline: _lib/fake2.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd2 = `// ==== END inline: _lib/fake2.mjs ====`;
+  const wf = `${markerBegin1}\n${markerEnd1}\n${markerBegin2}\n${markerEnd2}\n`;
+  const tmp = makeFixtureRepo(canonical1, wf, { extraCanonicals: { 'fake2.mjs': canonical2 } });
+  try {
+    assert.throws(() => syncRepo(tmp, { write: false }), /collision/i);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test (t5): const collision between two canonicals — explicit message, not SyntaxError
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('syncRepo throws on const collision between two canonicals with explicit collision message', () => {
+  const canonical1 = `export const topicKey = 1;\n`;
+  const canonical2 = `export const topicKey = 2;\n`;
+  const markerBegin1 = `// ==== BEGIN inline: _lib/fake.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd1 = `// ==== END inline: _lib/fake.mjs ====`;
+  const markerBegin2 = `// ==== BEGIN inline: _lib/fake2.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd2 = `// ==== END inline: _lib/fake2.mjs ====`;
+  const wf = `${markerBegin1}\n${markerEnd1}\n${markerBegin2}\n${markerEnd2}\n`;
+  const tmp = makeFixtureRepo(canonical1, wf, { extraCanonicals: { 'fake2.mjs': canonical2 } });
+  try {
+    assert.throws(() => syncRepo(tmp, { write: false }), /collision/i);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test (t6): syntax error canonical throws with 'syntax' in message
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('syncRepo throws with /syntax/i on canonical with syntax error', () => {
+  const canonical = `export const X = ;\n`;
+  const markerBegin = `// ==== BEGIN inline: _lib/fake.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd = `// ==== END inline: _lib/fake.mjs ====`;
+  const wf = `${markerBegin}\n${markerEnd}\n`;
+  const tmp = makeFixtureRepo(canonical, wf);
+  try {
+    assert.throws(() => syncRepo(tmp, { write: false }), /syntax/i);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test (t7): non-colliding two canonicals in one workflow — normal case
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('syncRepo succeeds when two canonicals have no collision', () => {
+  const canonical1 = `export const A = 1;\n`;
+  const canonical2 = `export const B = 2;\n`;
+  const markerBegin1 = `// ==== BEGIN inline: _lib/fake.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd1 = `// ==== END inline: _lib/fake.mjs ====`;
+  const markerBegin2 = `// ==== BEGIN inline: _lib/fake2.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd2 = `// ==== END inline: _lib/fake2.mjs ====`;
+  const wf = `${markerBegin1}\n// old A\n${markerEnd1}\n${markerBegin2}\n// old B\n${markerEnd2}\n`;
+  const tmp = makeFixtureRepo(canonical1, wf, { extraCanonicals: { 'fake2.mjs': canonical2 } });
+  try {
+    assert.doesNotThrow(() => syncRepo(tmp, { write: true }));
+    const written = readFileSync(join(tmp, '.claude', 'workflows', 'wf.js'), 'utf8');
+    assert.ok(written.includes('const A = 1;'), 'should contain A');
+    assert.ok(written.includes('const B = 2;'), 'should contain B');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test (t8): same canonical in two different workflow files — per-file scope guard
+// (guard: collision detection is per workflow file, not global)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('syncRepo does NOT collision-error when same canonical is inlined in two different workflow files', () => {
+  const canonical = `export function topicKey(x) { return x; }\n`;
+  const markerBegin = `// ==== BEGIN inline: _lib/fake.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====`;
+  const markerEnd = `// ==== END inline: _lib/fake.mjs ====`;
+  const wf1 = `${markerBegin}\n// old 1\n${markerEnd}\n`;
+  const wf2 = `${markerBegin}\n// old 2\n${markerEnd}\n`;
+  const tmp = makeFixtureRepo(canonical, wf1, { multiWf: true, secondWfContent: wf2 });
+  try {
+    assert.doesNotThrow(() => syncRepo(tmp, { write: true }));
+    const wf1Written = readFileSync(join(tmp, '.claude', 'workflows', 'wf.js'), 'utf8');
+    const wf2Written = readFileSync(join(tmp, '.claude', 'workflows', 'wf2.js'), 'utf8');
+    assert.ok(wf1Written.includes('function topicKey'), 'wf.js should contain topicKey');
+    assert.ok(wf2Written.includes('function topicKey'), 'wf2.js should contain topicKey');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## 概要
Closes #254
- `sync-inlines` の生成後 workflow に対して構文検証を追加
- 同一 workflow に inline される canonical 間のトップレベル宣言名衝突を明示 error に変更
- `stripComments` の regex literal 制約をコメントとして明記

## 動機
inline 生成後の単一トップレベルスコープで識別子衝突や構文破損が起きても、従来は後段テストまで検出できませんでした。generator 段階で fail fast できるようにします。

## 変更内容
| ファイル | 変更内容 |
|---------|----------|
| `tools/sync-inlines.mjs` | 生成後構文検証、inline 宣言名収集、衝突検出を追加 |
| `tools/sync-inlines.test.mjs` | 衝突・構文エラー・正常系の fixture test を追加 |

## テスト計画
- [x] `node --test tools/sync-inlines.test.mjs`
- [x] `node tools/sync-inlines.mjs --check`
- [x] `node --test _lib/workflow-inlines.sync.test.mjs tools/sync-inlines.test.mjs`
- [x] `bash tests/run-all-bats.sh`（bats 未インストールのため non-strict skip）
- [x] `dev-validate/scripts/validate.sh --worktree .../df-254`
