### PR TITLE
♻️ refactor(pr-iterate): telemetry を pending handoff に統一（#251）

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -48,6 +48,55 @@ function resolvePositiveIntArg(args, name) {
 }
 // ==== END inline: _lib/resolve-arg.mjs ====
 
+// ==== BEGIN inline: _lib/journal-handoff.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====
+// Journal telemetry handoff helpers for workflow runtime.
+// Workflow loader cannot import ESM, so tools/sync-inlines.mjs injects this file
+// into .claude/workflows/*.js. Keep this file import-free and deterministic.
+//
+// INLINE COPY POLICY: 本ファイルは tools/sync-inlines.mjs --write で workflow へ全文 inline 生成される。
+// 直接 workflow 側を編集しない。全文一致は _lib/workflow-inlines.sync.test.mjs が CI 保証。
+
+const JOURNAL_PENDING_DIR = '~/.claude/journal/pending';
+const JOURNAL_HANDOFF_DELIMITER = 'TELEMETRY_EOF';
+
+function buildJournalHandoffPayload({
+  skill,
+  outcome,
+  args,
+  issue,
+  journal_sh,
+  telemetry,
+  error_category,
+  error_msg,
+}) {
+  if (!skill) throw new Error('journal-handoff: skill is required');
+  if (!outcome) throw new Error('journal-handoff: outcome is required');
+
+  const payload = { skill, outcome };
+  if (args) payload.args = args;
+  if (issue != null && issue !== '') payload.issue = Number(issue);
+  if (journal_sh) payload.journal_sh = journal_sh;
+  if (telemetry != null) payload.telemetry = telemetry;
+  if (error_category) payload.error_category = error_category;
+  if (error_msg) payload.error_msg = error_msg;
+  return JSON.stringify(payload);
+}
+
+function buildJournalHandoffCommand({ prefix, id, payload }) {
+  const safePrefix = String(prefix ?? '').trim();
+  const safeId = String(id ?? '').trim();
+  if (!/^[a-z][a-z0-9-]*$/.test(safePrefix)) {
+    throw new Error(`journal-handoff: invalid prefix: ${JSON.stringify(prefix)}`);
+  }
+  if (!/^[1-9][0-9]*$/.test(safeId)) {
+    throw new Error(`journal-handoff: invalid id: ${JSON.stringify(id)}`);
+  }
+  if (payload == null) throw new Error('journal-handoff: payload is required');
+
+  return `mkdir -p ${JOURNAL_PENDING_DIR} && cat > ${JOURNAL_PENDING_DIR}/${safePrefix}-${safeId}-$(date +%s).json <<'${JOURNAL_HANDOFF_DELIMITER}'\n${String(payload)}\n${JOURNAL_HANDOFF_DELIMITER}`;
+}
+// ==== END inline: _lib/journal-handoff.mjs ====
+
 // ==== BEGIN inline: _lib/goal-ledger.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====
 // Goal Ledger: dev-flow の収束エンジン。収束 = BLOCKING lane の全項目 checked。
 // item = { id, text, dimension, severity, source, checked, evidence, check, floor }
@@ -924,7 +973,7 @@ if (!ISSUE) throw new Error('dev-flow: issue 番号が必要です（args.issue�
 // 3 つの失敗経路（needs_clarification×2・empty-diff throw）で呼ばれる。
 // need() で包まず null 容認（telemetry 欠損 > workflow 中断。成功経路行 2040-2042 と同じ方針）。
 async function writeFailureTelemetry({ error_category, error_msg, telemetry, phase }) {
-  const payload = JSON.stringify({
+  const payload = buildJournalHandoffPayload({
     skill: 'dev-flow',
     outcome: 'failure',
     issue: Number(ISSUE),
@@ -933,7 +982,7 @@ async function writeFailureTelemetry({ error_category, error_msg, telemetry, pha
     error_msg,
     telemetry,
   })
-  const journalCmd = `mkdir -p ~/.claude/journal/pending && cat > ~/.claude/journal/pending/devflow-${ISSUE}-$(date +%s).json <<'TELEMETRY_EOF'\n${payload}\nTELEMETRY_EOF`
+  const journalCmd = buildJournalHandoffCommand({ prefix: 'devflow', id: ISSUE, payload })
   const res = await agent(
     `## Objective\ndev-flow 失敗の telemetry handoff を ~/.claude/journal/pending/ に書き出す（Stop hook が journal へ flush する）。\n\n`
     + `## Instructions\n`
@@ -2001,7 +2050,7 @@ if (!summaryPost?.posted) {
 // 失敗は log 警告のみで workflow は継続（telemetry 欠損 > ワークフロー中断）。
 // need() で包まない — null 容認が必須。
 // ============================================================
-const telemetryHandoff = JSON.stringify({
+const telemetryHandoff = buildJournalHandoffPayload({
   skill: 'dev-flow',
   outcome: 'success',
   issue: Number(ISSUE),
@@ -2018,7 +2067,7 @@ const telemetryHandoff = JSON.stringify({
     ...(iterate?.status ? { iterate_status: iterate.status } : {}),
   },
 })
-const journalCmd = `mkdir -p ~/.claude/journal/pending && cat > ~/.claude/journal/pending/devflow-${ISSUE}-$(date +%s).json <<'TELEMETRY_EOF'\n${telemetryHandoff}\nTELEMETRY_EOF`
+const journalCmd = buildJournalHandoffCommand({ prefix: 'devflow', id: ISSUE, payload: telemetryHandoff })
 const journalPost = await agent(
   `## Objective\ndev-flow 完走の telemetry handoff を ~/.claude/journal/pending/ に書き出す（Stop hook が journal へ flush する）。\n\n`
   + `## Instructions\n`

--- a/.claude/workflows/pr-iterate.js
+++ b/.claude/workflows/pr-iterate.js
@@ -38,6 +38,55 @@ function resolvePositiveIntArg(args, name) {
 }
 // ==== END inline: _lib/resolve-arg.mjs ====
 
+// ==== BEGIN inline: _lib/journal-handoff.mjs (生成区間 — 直接編集禁止。_lib を編集して tools/sync-inlines.mjs --write) ====
+// Journal telemetry handoff helpers for workflow runtime.
+// Workflow loader cannot import ESM, so tools/sync-inlines.mjs injects this file
+// into .claude/workflows/*.js. Keep this file import-free and deterministic.
+//
+// INLINE COPY POLICY: 本ファイルは tools/sync-inlines.mjs --write で workflow へ全文 inline 生成される。
+// 直接 workflow 側を編集しない。全文一致は _lib/workflow-inlines.sync.test.mjs が CI 保証。
+
+const JOURNAL_PENDING_DIR = '~/.claude/journal/pending';
+const JOURNAL_HANDOFF_DELIMITER = 'TELEMETRY_EOF';
+
+function buildJournalHandoffPayload({
+  skill,
+  outcome,
+  args,
+  issue,
+  journal_sh,
+  telemetry,
+  error_category,
+  error_msg,
+}) {
+  if (!skill) throw new Error('journal-handoff: skill is required');
+  if (!outcome) throw new Error('journal-handoff: outcome is required');
+
+  const payload = { skill, outcome };
+  if (args) payload.args = args;
+  if (issue != null && issue !== '') payload.issue = Number(issue);
+  if (journal_sh) payload.journal_sh = journal_sh;
+  if (telemetry != null) payload.telemetry = telemetry;
+  if (error_category) payload.error_category = error_category;
+  if (error_msg) payload.error_msg = error_msg;
+  return JSON.stringify(payload);
+}
+
+function buildJournalHandoffCommand({ prefix, id, payload }) {
+  const safePrefix = String(prefix ?? '').trim();
+  const safeId = String(id ?? '').trim();
+  if (!/^[a-z][a-z0-9-]*$/.test(safePrefix)) {
+    throw new Error(`journal-handoff: invalid prefix: ${JSON.stringify(prefix)}`);
+  }
+  if (!/^[1-9][0-9]*$/.test(safeId)) {
+    throw new Error(`journal-handoff: invalid id: ${JSON.stringify(id)}`);
+  }
+  if (payload == null) throw new Error('journal-handoff: payload is required');
+
+  return `mkdir -p ${JOURNAL_PENDING_DIR} && cat > ${JOURNAL_PENDING_DIR}/${safePrefix}-${safeId}-$(date +%s).json <<'${JOURNAL_HANDOFF_DELIMITER}'\n${String(payload)}\n${JOURNAL_HANDOFF_DELIMITER}`;
+}
+// ==== END inline: _lib/journal-handoff.mjs ====
+
 // args 正規化: 単体 /pr-iterate <pr> でも dev-flow からの workflow('pr-iterate', {pr}) でも受ける
 const PR = resolvePositiveIntArg(args, 'pr')
 const MAX = args?.max_iterations == null
@@ -654,15 +703,25 @@ if (!summaryPost?.posted) {
   log(`⚠️ post-summary の投稿に失敗しました（posted=${summaryPost?.posted ?? 'null'}）。ワークフローは継続します。`)
 }
 
-const journalCmd = `bash ~/.claude/skills/skill-retrospective/scripts/journal.sh log pr-iterate success --iterate-status ${status} --args "pr=${PR}"`
+const telemetryHandoff = buildJournalHandoffPayload({
+  skill: 'pr-iterate',
+  outcome: 'success',
+  args: `pr=${PR}`,
+  telemetry: {
+    merge_tier: 'PR_ITERATE',
+    iterate_status: status,
+  },
+})
+const journalCmd = buildJournalHandoffCommand({ prefix: 'priterate', id: PR, payload: telemetryHandoff })
 const journalPost = await agent(
-  `## Objective\npr-iterate 終端 status の telemetry を journal に記録する。\n\n`
-  + `## Instructions\n次のコマンドをそのまま実行せよ。exit 0 なら logged:true、失敗時も throw せず logged:false を返すこと。\n`
-  + `\`\`\`\n${journalCmd}\n\`\`\`\n\n`
-  + `## Output format\n{ "logged": boolean, "summary": string }\n\n`
-  + `## Tools\n- 使用可: Bash のみ\n- 禁止: Write, Edit, git 操作\n\n`
-  + `## Boundary\n~/.claude/journal 以外のファイル変更禁止。git 操作禁止。\n\n`
-  + `## Token cap\n100 語以内で完結すること。`,
+  `## Objective\npr-iterate 終端 status の telemetry handoff を ~/.claude/journal/pending/ に書き出す（Stop hook が journal へ flush する）。\n\n`
+  + `## Instructions\n`
+  + `次のコマンドをそのまま実行せよ: \`${journalCmd}\`\n`
+  + `exit 0 なら logged:true、失敗しても throw せず logged:false を返すこと。\n`
+  + `\n## Output format\n{ "logged": boolean, "summary": string }\n`
+  + `\n## Tools\n使用可: Bash のみ\n`
+  + `\n## Boundary\n~/.claude/journal 以外のファイルを変更しない。git 操作禁止。\n`
+  + `\n## Token cap\n100 語以内で完結すること。`,
   { agentType: 'dev-runner-haiku', schema: JOURNAL_RESULT, label: 'journal-log', phase: 'Iterate' },
 )
 if (!journalPost?.logged) {

--- a/_lib/journal-handoff.mjs
+++ b/_lib/journal-handoff.mjs
@@ -1,0 +1,46 @@
+// Journal telemetry handoff helpers for workflow runtime.
+// Workflow loader cannot import ESM, so tools/sync-inlines.mjs injects this file
+// into .claude/workflows/*.js. Keep this file import-free and deterministic.
+//
+// INLINE COPY POLICY: 本ファイルは tools/sync-inlines.mjs --write で workflow へ全文 inline 生成される。
+// 直接 workflow 側を編集しない。全文一致は _lib/workflow-inlines.sync.test.mjs が CI 保証。
+
+const JOURNAL_PENDING_DIR = '~/.claude/journal/pending';
+const JOURNAL_HANDOFF_DELIMITER = 'TELEMETRY_EOF';
+
+export function buildJournalHandoffPayload({
+  skill,
+  outcome,
+  args,
+  issue,
+  journal_sh,
+  telemetry,
+  error_category,
+  error_msg,
+}) {
+  if (!skill) throw new Error('journal-handoff: skill is required');
+  if (!outcome) throw new Error('journal-handoff: outcome is required');
+
+  const payload = { skill, outcome };
+  if (args) payload.args = args;
+  if (issue != null && issue !== '') payload.issue = Number(issue);
+  if (journal_sh) payload.journal_sh = journal_sh;
+  if (telemetry != null) payload.telemetry = telemetry;
+  if (error_category) payload.error_category = error_category;
+  if (error_msg) payload.error_msg = error_msg;
+  return JSON.stringify(payload);
+}
+
+export function buildJournalHandoffCommand({ prefix, id, payload }) {
+  const safePrefix = String(prefix ?? '').trim();
+  const safeId = String(id ?? '').trim();
+  if (!/^[a-z][a-z0-9-]*$/.test(safePrefix)) {
+    throw new Error(`journal-handoff: invalid prefix: ${JSON.stringify(prefix)}`);
+  }
+  if (!/^[1-9][0-9]*$/.test(safeId)) {
+    throw new Error(`journal-handoff: invalid id: ${JSON.stringify(id)}`);
+  }
+  if (payload == null) throw new Error('journal-handoff: payload is required');
+
+  return `mkdir -p ${JOURNAL_PENDING_DIR} && cat > ${JOURNAL_PENDING_DIR}/${safePrefix}-${safeId}-$(date +%s).json <<'${JOURNAL_HANDOFF_DELIMITER}'\n${String(payload)}\n${JOURNAL_HANDOFF_DELIMITER}`;
+}

--- a/_lib/journal-handoff.test.mjs
+++ b/_lib/journal-handoff.test.mjs
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildJournalHandoffCommand, buildJournalHandoffPayload } from './journal-handoff.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+
+test('buildJournalHandoffPayload creates compact handoff JSON', () => {
+  const payload = buildJournalHandoffPayload({
+    skill: 'pr-iterate',
+    outcome: 'success',
+    args: 'pr=251',
+    telemetry: { merge_tier: 'PR_ITERATE', iterate_status: 'lgtm' },
+  });
+
+  assert.equal(
+    payload,
+    '{"skill":"pr-iterate","outcome":"success","args":"pr=251","telemetry":{"merge_tier":"PR_ITERATE","iterate_status":"lgtm"}}',
+  );
+});
+
+test('buildJournalHandoffCommand writes payload to pending dir with safe filename', () => {
+  const cmd = buildJournalHandoffCommand({
+    prefix: 'priterate',
+    id: 251,
+    payload: '{"ok":true}',
+  });
+
+  assert.equal(
+    cmd,
+    "mkdir -p ~/.claude/journal/pending && cat > ~/.claude/journal/pending/priterate-251-$(date +%s).json <<'TELEMETRY_EOF'\n{\"ok\":true}\nTELEMETRY_EOF",
+  );
+});
+
+test('buildJournalHandoffCommand rejects unsafe filename parts', () => {
+  assert.throws(
+    () => buildJournalHandoffCommand({ prefix: 'bad/prefix', id: 251, payload: '{}' }),
+    /invalid prefix/,
+  );
+  assert.throws(
+    () => buildJournalHandoffCommand({ prefix: 'priterate', id: '251;rm', payload: '{}' }),
+    /invalid id/,
+  );
+});
+
+test('workflows construct journal commands through the canonical helper', () => {
+  const devFlow = readFileSync(join(repoRoot, '.claude/workflows/dev-flow.js'), 'utf8');
+  const prIterate = readFileSync(join(repoRoot, '.claude/workflows/pr-iterate.js'), 'utf8');
+
+  assert.equal(
+    (devFlow.match(/const journalCmd = buildJournalHandoffCommand\(\{ prefix: 'devflow'/g) ?? []).length,
+    2,
+  );
+  assert.equal(
+    (prIterate.match(/const journalCmd = buildJournalHandoffCommand\(\{ prefix: 'priterate'/g) ?? []).length,
+    1,
+  );
+  assert.ok(!devFlow.includes('const journalCmd = `mkdir -p ~/.claude/journal/pending'));
+  assert.ok(!prIterate.includes('journal.sh log pr-iterate'));
+});

--- a/_lib/priterate-journal-log.test.mjs
+++ b/_lib/priterate-journal-log.test.mjs
@@ -109,7 +109,7 @@ async function runPrIterateCapture(src, ctx) {
 
 const src = readFileSync(prIteratePath, 'utf8');
 
-test('[journal-log] journalResult={logged:true} で完走 → journal-log 呼び出し 1 回、prompt に正しいコマンドが含まれ、result.status === lgtm', async () => {
+test('[journal-log] journalResult={logged:true} で完走 → journal-log 呼び出し 1 回、pending handoff コマンドが含まれ、result.status === lgtm', async () => {
   const journalResult = { logged: true, summary: 'ok' };
   const { ctx, getJournalCallCount, getCapturedPrompt } = makeSandbox(journalResult);
 
@@ -126,14 +126,23 @@ test('[journal-log] journalResult={logged:true} で完走 → journal-log 呼び
   );
 
   const capturedPrompt = getCapturedPrompt();
+  const requiredKeys = [
+    '~/.claude/journal/pending/priterate-5-',
+    '"skill":"pr-iterate"',
+    '"outcome":"success"',
+    '"args":"pr=5"',
+    '"merge_tier":"PR_ITERATE"',
+    '"iterate_status":"lgtm"',
+  ];
+  for (const key of requiredKeys) {
+    assert.ok(
+      typeof capturedPrompt === 'string' && capturedPrompt.includes(key),
+      `journal-log prompt に '${key}' が含まれるべきだが含まれない。prompt=${capturedPrompt}`,
+    );
+  }
   assert.ok(
-    typeof capturedPrompt === 'string' && capturedPrompt.includes('--iterate-status'),
-    `journal-log prompt に '--iterate-status' が含まれるべきだが含まれない。prompt=${capturedPrompt}`,
-  );
-
-  assert.ok(
-    typeof capturedPrompt === 'string' && capturedPrompt.includes('journal.sh log pr-iterate'),
-    `journal-log prompt に 'journal.sh log pr-iterate' が含まれるべきだが含まれない。prompt=${capturedPrompt}`,
+    typeof capturedPrompt === 'string' && !capturedPrompt.includes('journal.sh log pr-iterate'),
+    `journal-log prompt は direct journal.sh 実行ではなく pending handoff であるべき。prompt=${capturedPrompt}`,
   );
 
   assert.equal(


### PR DESCRIPTION
## 概要
Closes #251
- `pr-iterate` の終端 telemetry を `journal.sh` 直接実行から `~/.claude/journal/pending/` への handoff JSON 書き出しへ変更
- dev-flow / pr-iterate 共通の handoff payload / command 構築を `_lib/journal-handoff.mjs` に canonical 化し、workflow へ inline 生成
- pending handoff と canonical helper の回帰テストを追加

## 動機
dev-flow は pending handoff + Stop hook flush で失敗時に pending file が残る一方、pr-iterate は `journal.sh` 直接実行で失敗時に telemetry が欠損しやすかった。W6b calibration 用の原資料の欠損特性を揃えるため、pr-iterate も同じ handoff 経路へ寄せる。

## 変更内容
| ファイル | 変更内容 |
|---|---|
| `.claude/workflows/pr-iterate.js` | `priterate-<PR>-<ts>.json` を pending dir に書き出す telemetry handoff へ変更 |
| `.claude/workflows/dev-flow.js` | 成功/失敗 telemetry の `journalCmd` 構築を canonical helper 呼び出しへ置換 |
| `_lib/journal-handoff.mjs` | handoff payload と pending 書き出しコマンドの canonical helper を追加 |
| `_lib/journal-handoff.test.mjs` | helper と workflow 側の canonical 利用を検証 |
| `_lib/priterate-journal-log.test.mjs` | pr-iterate が direct `journal.sh` ではなく pending handoff を使うことを検証 |

## Stop hook 確認
既存の `stop-devflow-telemetry.sh` は `skill` 固定ではなく pending `*.json` を処理するため、`merge_tier: "PR_ITERATE"` と `iterate_status` を含む pr-iterate handoff は flush 可能であることをローカル stub で確認済み。現行 hook は handoff JSON の `args` を `journal.sh --args` へ転送しないため、`pr=<n>` を最終 journal entry に残すには dotfiles 側 follow-up が必要。

## テスト計画
- [x] `node --test _lib/journal-handoff.test.mjs _lib/priterate-journal-log.test.mjs _lib/devflow-journal-log.test.mjs _lib/devflow-failure-telemetry-routing.test.mjs _lib/workflow-inlines.sync.test.mjs`
- [x] `node --test _lib/*.test.mjs`（452 tests pass）
- [x] `node tools/sync-inlines.mjs --check`
- [x] `git diff --check`
- [x] `bash tests/run-all-bats.sh`（bats 未インストールのため non-strict graceful skip）
- [x] Stop hook stub flush check（pending file removed, `log pr-iterate success ... --iterate-status lgtm` 実行を確認）