### PR TITLE
fix(dev-flow): danger-grep を fail-closed 化

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -145,7 +145,9 @@ function seedSecurityLedger() {
   }));
 }
 
-// danger-grep の hit クラス集合で SEC seed item を解決する。
+// danger-grep の結果で SEC seed item を解決する。
+// risk.ok !== true は danger-grep 実行失敗/転写失敗/空出力を表し、fail-closed として
+// 全 SEC seed を unchecked に戻す（clean と区別する）。
 // clean クラス → checked(evidence='danger-grep clean')。
 // hit クラス → critical へ raise(floor=true)。
 //   - floor=true かつ checked=true(evaluator が evidence で clearance 済み) → checked を維持する(HOLD に巻き戻さない)。
@@ -157,8 +159,17 @@ function seedSecurityLedger() {
 //   danger が増えた(新クラスが hit に転じた)場合 → floor=false なので unchecked 復活 = HOLD。
 //   danger が減った(以前 hit だったクラスが clean に転じた)場合 → checked=true に解放(自動解消)。
 //   danger が同じ hit クラスで残る かつ evaluator clearance 済み(floor=true, checked=true) → checked 維持(温存)。
-function reconcileDanger(ledger, hitClasses) {
-  const hits = new Set(hitClasses);
+function reconcileDanger(ledger, risk) {
+  if (!risk || risk.ok !== true) {
+    const error = risk?.error ? `danger-grep error: ${risk.error}` : 'danger-grep error';
+    const items = ledger.items.map((it) => {
+      if (it.source !== 'seed' || it.dimension !== 'security') return it;
+      return { ...it, checked: false, evidence: error };
+    });
+    return { ...ledger, items };
+  }
+
+  const hits = new Set((risk.hits ?? []).map((h) => h.class));
   const items = ledger.items.map((it) => {
     if (it.source !== 'seed' || it.dimension !== 'security') return it;
     if (hits.has(it.danger_class)) {
@@ -1134,8 +1145,9 @@ const PRURL = {
   },
 }
 const RISK = {
-  type: 'object', required: ['hits'],
+  type: 'object', required: ['ok', 'hits'],
   properties: {
+    ok: { type: 'boolean' },
     hits: {
       type: 'array',
       items: {
@@ -1148,6 +1160,8 @@ const RISK = {
         },
       },
     },
+    error: { type: 'string' },
+    exit_code: { type: ['number', 'string'] },
   },
 }
 const CHANGED = {
@@ -1607,14 +1621,15 @@ for (const seed of seedSecurityLedger()) {
   ledger = appendItem(ledger, seed).ledger
 }
 const risk = need(await agent(
-  `cd ${WT} で作業。次を実行し **stdout の JSON 配列をそのまま** \`{"hits": <配列>}\` に包んで返せ`
-  + `（判定や脚色をしない。空配列なら hits:[]）:\n`
+  `cd ${WT} で作業。次を実行し **stdout の JSON object をそのまま** 返せ`
+  + `（判定や脚色をしない。exit 非0・stdout 空・JSON 不正なら ok:false/hits:[]/error で返せ。`
+  + `失敗時に ok:true を生成してはならない）:\n`
   + `bash ${WT}/_shared/scripts/diff-risk-classify.sh --working-tree origin/${BASE}`,
   { agentType: 'dev-runner-haiku', schema: RISK, label: 'danger-grep', phase: 'Security floor' },
 ), 'Security floor(danger-grep)')
-const dangerHits = [...new Set((risk.hits ?? []).map((h) => h.class))]
-ledger = reconcileDanger(ledger, dangerHits)
-log(`danger-grep: ${dangerHits.length ? 'HIT ' + dangerHits.join(',') : 'clean'} — `
+const dangerHits = risk.ok === true ? [...new Set((risk.hits ?? []).map((h) => h.class))] : []
+ledger = reconcileDanger(ledger, risk)
+log(`danger-grep: ${risk.ok !== true ? 'ERROR ' + (risk.error ?? 'unknown') : dangerHits.length ? 'HIT ' + dangerHits.join(',') : 'clean'} — `
   + `SEC blocking 未 checked ${policyBlockingItems(ledger, GATE_POLICY).filter((it) => !it.checked).length} 件`)
 // Step F2: realized diff のファイル数を取得して re-floor を算出する
 // realized が null（agent drop／skip）のときは NaN を refloorShape へ渡し complex 安全弁へ流す。
@@ -1928,11 +1943,12 @@ if (runEval && iterateChangedTree && !evalTreeStale) {
 // ============================================================
 phase('Merge tier')
 const riskFinal = need(await agent(
-  `cd ${WT} で作業。次を実行し **stdout の JSON 配列をそのまま** \`{"hits": <配列>}\` に包んで返せ:\n`
+  `cd ${WT} で作業。次を実行し **stdout の JSON object をそのまま** 返せ`
+  + `（exit 非0・stdout 空・JSON 不正なら ok:false/hits:[]/error で返せ。失敗時に ok:true を生成してはならない）:\n`
   + `bash ${WT}/_shared/scripts/diff-risk-classify.sh origin/${BASE}`,
   { agentType: 'dev-runner-haiku', schema: RISK, label: 'danger-grep-final', phase: 'Merge tier' },
 ), 'Merge tier(danger-grep-final)')
-const dangerHitsFinal = [...new Set((riskFinal.hits ?? []).map((h) => h.class))]
+const dangerHitsFinal = riskFinal.ok === true ? [...new Set((riskFinal.hits ?? []).map((h) => h.class))] : []
 const changed = need(await agent(
   `cd ${WT} で作業。次を実行し **stdout の各行(ファイルパス)を** \`{"files": [...]}\` に包んで返せ:\n`
   + `git -C ${WT} diff --name-only origin/${BASE}...HEAD`,
@@ -1940,7 +1956,7 @@ const changed = need(await agent(
 ), 'Merge tier(changed-files)')
 
 // 最終 danger を ledger に再反映(PR 中の修正で hit が消えた/増えた場合に追従)。
-ledger = reconcileDanger(ledger, dangerHitsFinal)
+ledger = reconcileDanger(ledger, riskFinal)
 const unresolvedDanger = ledger.items.some(
   (it) => it.dimension === 'security' && it.source === 'seed' && it.floor && !it.checked)
 const breaking = isBreakingText(`${req.scope ?? ''} ${req.summary ?? ''}`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,15 @@ pr-iterate major 閾値の sunset path —
 - 表現: dev-runner(-haiku) verbatim 転写プロンプト群
 - 再評価トリガ: harness が workflow への直接 exec（または fs/exec API）を解禁した時点で、当該プロンプト群を直接実行に置換して exec-proxy ごと撤去する
 
+exec-proxy の失敗ポリシーは、決定論ゲートの性質ごとに明示する:
+
+| proxy | 失敗検出 | ポリシー | 理由 |
+|-------|----------|----------|------|
+| danger-grep / `diff-risk-classify.sh` | `ok:false` / schema 不一致 / 空出力 / command failure | fail-closed（全 SEC seed を unchecked） | W7 軸A invariant の security floor。clean と失敗を同一視しない |
+| realized-diff | `null` / schema 不一致 | fail-safe（complex floor） | diff 不明時は shape を安全側へ raise する |
+| redgreen | `null` / schema 不一致 | fail-safe（inspection 据え置き） | テスト状態不明時は検査済みにしない |
+| diff-hash | `null` / schema 不一致 | fail-open（stale 検出 skip、警告のみ） | stale 検出の補助信号。失敗しても既存の deterministic gate を緩めない |
+
 ### 設計原則 (要約)
 
 1. **機能特化** — 汎用ロール (QA engineer 等) ではなく機能特化スキルを作る

--- a/_lib/blocked-done-preservation.test.mjs
+++ b/_lib/blocked-done-preservation.test.mjs
@@ -99,7 +99,7 @@ function makeSandbox(analyzeReq) {
       return { status: 'DONE', task_id: 'T?', files: [], summary: '', concerns: [] };
     }
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     if (label.startsWith('test')) {
       return { tests: 'no_tests', green: true, summary: '' };

--- a/_lib/blocked-replan-history.test.mjs
+++ b/_lib/blocked-replan-history.test.mjs
@@ -47,7 +47,7 @@ function makeSandbox(analyzeReq, implementerStub) {
       return implementerStub(prompt, opts);
     }
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     if (label.startsWith('test')) {
       return { tests: 'no_tests', green: true, summary: '' };

--- a/_lib/design-replan-cap.test.mjs
+++ b/_lib/design-replan-cap.test.mjs
@@ -61,7 +61,7 @@ function makeSandbox(analyzeReq) {
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     // → danger clean にして HOLD 要因を絞る
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {

--- a/_lib/devflow-failure-telemetry-routing.test.mjs
+++ b/_lib/devflow-failure-telemetry-routing.test.mjs
@@ -35,7 +35,7 @@ function makeSandbox({ analyzeReq, implementerFn, diffGateConfig } = {}) {
       return { summary: 'p', serial: [{ id: 'T1', desc: 't', file_changes: ['src/foo.ts'], test_plan: '' }], parallel: [] };
     }
     if (agentType === 'plan-reviewer') return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
-    if (label.startsWith('danger-grep')) return { hits: [] };
+    if (label.startsWith('danger-grep')) return { ok: true, hits: [] };
     if (label === 'realized-diff') return { files: ['src/foo.ts'] };
     if (label === 'declared-path-check') return { files: [] };
     if (label === 'changed-files') return { files: ['src/foo.ts'] };

--- a/_lib/devflow-journal-log.test.mjs
+++ b/_lib/devflow-journal-log.test.mjs
@@ -59,7 +59,7 @@ function makeSandbox(analyzeReq, journalResult) {
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     // → danger clean にして HOLD 要因を発生させない
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {

--- a/_lib/devflow-summary-post.test.mjs
+++ b/_lib/devflow-summary-post.test.mjs
@@ -56,7 +56,7 @@ function makeSandbox(analyzeReq, postResult) {
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     // → danger clean にして HOLD 要因を発生させない
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {

--- a/_lib/empty-diff-evaluate-routing.test.mjs
+++ b/_lib/empty-diff-evaluate-routing.test.mjs
@@ -41,7 +41,7 @@ function makeCountingSandbox(analyzeReq, diffHashConfig) {
     if (label.startsWith('analyze')) return analyzeReq;
     if (agentType === 'dev-planner') return { summary: 'p', serial: [{ id: 'T1', desc: 't', file_changes: ['src/foo.ts'], test_plan: '' }], parallel: [] };
     if (agentType === 'plan-reviewer') return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
-    if (label.startsWith('danger-grep')) return { hits: [] };
+    if (label.startsWith('danger-grep')) return { ok: true, hits: [] };
     if (label === 'realized-diff') return { files: ['src/foo.ts'] };
     if (label === 'declared-path-check') return { files: [] };
     if (label.startsWith('test')) return { tests: 'no_tests', green: true, summary: '' };

--- a/_lib/ephemeral-paths-routing.test.mjs
+++ b/_lib/ephemeral-paths-routing.test.mjs
@@ -56,7 +56,7 @@ function makeCountingSandbox(analyzeReq, realizedFiles) {
       return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
     }
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     if (label === 'realized-diff') {
       return { files: realizedFiles };

--- a/_lib/escalate-producer.test.mjs
+++ b/_lib/escalate-producer.test.mjs
@@ -58,7 +58,7 @@ function makeSandbox(analyzeReq, evaluatorResponse) {
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     // → danger clean にして HOLD 要因を escalate のみに絞る
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {
@@ -359,7 +359,7 @@ test('[escalate-producer] テスト4: complex shape iteration 2 に初出 escala
         return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
       }
       if (label.startsWith('danger-grep')) {
-        return { hits: [] };
+        return { ok: true, hits: [] };
       }
       if (label.startsWith('test')) {
         return { tests: 'no_tests', green: true, summary: '' };

--- a/_lib/eval-convergence.test.mjs
+++ b/_lib/eval-convergence.test.mjs
@@ -53,7 +53,7 @@ function makeSandbox(analyzeReq, responses) {
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     // → danger clean にして HOLD 要因を絞る
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {

--- a/_lib/green-fix-concerns-routing.test.mjs
+++ b/_lib/green-fix-concerns-routing.test.mjs
@@ -60,7 +60,7 @@ function makeCountingSandbox() {
     }
     // Security floor / danger-grep 系
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     // 1 回目は failed (green:false)、2 回目以降は passed (green:true)

--- a/_lib/green-fix-micro-eval.test.mjs
+++ b/_lib/green-fix-micro-eval.test.mjs
@@ -65,7 +65,7 @@ function makeMicroGreenFixSandbox() {
     }
     // danger-grep: 空（danger path ではない）
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // realized-diff: 1 ファイル → refloor で micro 維持
     if (label === 'realized-diff') {

--- a/_lib/green-fix-no-audit.test.mjs
+++ b/_lib/green-fix-no-audit.test.mjs
@@ -59,7 +59,7 @@ function makeCountingSandbox() {
     }
     // Security floor / danger-grep 系
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     // 常に passed (green:true) を返す — green-fix 経路に入らない

--- a/_lib/green-fix-test-audit.test.mjs
+++ b/_lib/green-fix-test-audit.test.mjs
@@ -60,7 +60,7 @@ function makeCountingSandbox() {
     }
     // Security floor / danger-grep 系
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     // 1 回目は failed (green:false)、2 回目以降は passed (green:true)

--- a/_lib/implementer-requirements-injection.test.mjs
+++ b/_lib/implementer-requirements-injection.test.mjs
@@ -144,7 +144,7 @@ function makeCountingSandbox() {
       return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
     }
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     if (label === 'realized-diff') {
       return { files: ['src/a.ts', 'src/b.ts'] };

--- a/_lib/implementer-staging-convention.test.mjs
+++ b/_lib/implementer-staging-convention.test.mjs
@@ -109,7 +109,7 @@ function makeCountingSandbox() {
       return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
     }
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     if (label === 'realized-diff') {
       return { files: ['src/a.ts', 'src/b.ts'] };

--- a/_lib/merge-tier-unsatisfied-ac.test.mjs
+++ b/_lib/merge-tier-unsatisfied-ac.test.mjs
@@ -51,7 +51,7 @@ function makeSandbox(analyzeReq, evaluatorResponse) {
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     // → danger clean にして HOLD 要因を AC のみに絞る
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {

--- a/_lib/merge-tier.mjs
+++ b/_lib/merge-tier.mjs
@@ -32,7 +32,9 @@ export function seedSecurityLedger() {
   }));
 }
 
-// danger-grep の hit クラス集合で SEC seed item を解決する。
+// danger-grep の結果で SEC seed item を解決する。
+// risk.ok !== true は danger-grep 実行失敗/転写失敗/空出力を表し、fail-closed として
+// 全 SEC seed を unchecked に戻す（clean と区別する）。
 // clean クラス → checked(evidence='danger-grep clean')。
 // hit クラス → critical へ raise(floor=true)。
 //   - floor=true かつ checked=true(evaluator が evidence で clearance 済み) → checked を維持する(HOLD に巻き戻さない)。
@@ -44,8 +46,17 @@ export function seedSecurityLedger() {
 //   danger が増えた(新クラスが hit に転じた)場合 → floor=false なので unchecked 復活 = HOLD。
 //   danger が減った(以前 hit だったクラスが clean に転じた)場合 → checked=true に解放(自動解消)。
 //   danger が同じ hit クラスで残る かつ evaluator clearance 済み(floor=true, checked=true) → checked 維持(温存)。
-export function reconcileDanger(ledger, hitClasses) {
-  const hits = new Set(hitClasses);
+export function reconcileDanger(ledger, risk) {
+  if (!risk || risk.ok !== true) {
+    const error = risk?.error ? `danger-grep error: ${risk.error}` : 'danger-grep error';
+    const items = ledger.items.map((it) => {
+      if (it.source !== 'seed' || it.dimension !== 'security') return it;
+      return { ...it, checked: false, evidence: error };
+    });
+    return { ...ledger, items };
+  }
+
+  const hits = new Set((risk.hits ?? []).map((h) => h.class));
   const items = ledger.items.map((it) => {
     if (it.source !== 'seed' || it.dimension !== 'security') return it;
     if (hits.has(it.danger_class)) {

--- a/_lib/merge-tier.test.mjs
+++ b/_lib/merge-tier.test.mjs
@@ -41,7 +41,7 @@ function ledgerWithSeeds() {
 }
 
 test('reconcileDanger: clean クラスは checked=true(evidence=grep clean)', () => {
-  const out = reconcileDanger(ledgerWithSeeds(), []);
+  const out = reconcileDanger(ledgerWithSeeds(), { ok: true, hits: [] });
   for (const it of out.items) {
     assert.equal(it.checked, true);
     assert.match(it.evidence, /clean/);
@@ -50,7 +50,10 @@ test('reconcileDanger: clean クラスは checked=true(evidence=grep clean)', ()
 });
 
 test('reconcileDanger: hit クラスは critical へ raise + checked=false 据え置き', () => {
-  const out = reconcileDanger(ledgerWithSeeds(), ['auth', 'crypto']);
+  const out = reconcileDanger(ledgerWithSeeds(), {
+    ok: true,
+    hits: [{ class: 'auth' }, { class: 'crypto' }],
+  });
   const auth = out.items.find((it) => it.id === 'SEC-AUTH');
   assert.equal(auth.severity, 'critical');
   assert.equal(auth.floor, true);
@@ -61,13 +64,13 @@ test('reconcileDanger: hit クラスは critical へ raise + checked=false 据�
 });
 
 test('reconcileDanger: 未知 hit クラスは無視(対応 seed なし)', () => {
-  const out = reconcileDanger(ledgerWithSeeds(), ['bogus']);
+  const out = reconcileDanger(ledgerWithSeeds(), { ok: true, hits: [{ class: 'bogus' }] });
   assert.ok(out.items.every((it) => it.checked === true));
 });
 
 test('reconcileDanger: checked=true(evaluator clearance 済み)の hit item を 2 度目に reconcile しても checked が保持される(HOLD 巻き戻し防止)', () => {
   // Step 1: 初回 reconcile — auth hit → critical/unchecked
-  const step1 = reconcileDanger(ledgerWithSeeds(), ['auth']);
+  const step1 = reconcileDanger(ledgerWithSeeds(), { ok: true, hits: [{ class: 'auth' }] });
   const authAfterStep1 = step1.items.find((it) => it.id === 'SEC-AUTH');
   assert.equal(authAfterStep1.checked, false);
   assert.equal(authAfterStep1.severity, 'critical');
@@ -83,7 +86,7 @@ test('reconcileDanger: checked=true(evaluator clearance 済み)の hit item を 
   assert.equal(authCleared.checked, true);
 
   // Step 3: 2 度目 reconcile(Merge tier phase) — auth は依然 hit だが checked を維持すべき
-  const step3 = reconcileDanger(ledgerCleared, ['auth']);
+  const step3 = reconcileDanger(ledgerCleared, { ok: true, hits: [{ class: 'auth' }] });
   const authAfterStep3 = step3.items.find((it) => it.id === 'SEC-AUTH');
   assert.equal(authAfterStep3.checked, true, 'checked=true(clearance 済み)は 2 度目 reconcile で維持される');
   assert.equal(authAfterStep3.severity, 'critical', 'severity は引き続き critical のまま');
@@ -95,7 +98,7 @@ test('reconcileDanger: checked=true(evaluator clearance 済み)の hit item を 
 
 test('reconcileDanger: pr-iterate で新クラスが hit に増えた場合は unchecked(HOLD)', () => {
   // auth を先に clearance 済みにした ledger から出発
-  const step1 = reconcileDanger(ledgerWithSeeds(), ['auth']);
+  const step1 = reconcileDanger(ledgerWithSeeds(), { ok: true, hits: [{ class: 'auth' }] });
   const ledgerCleared = {
     ...step1,
     items: step1.items.map((it) =>
@@ -104,12 +107,36 @@ test('reconcileDanger: pr-iterate で新クラスが hit に増えた場合は u
   };
 
   // pr-iterate 後に crypto も新たに hit
-  const step2 = reconcileDanger(ledgerCleared, ['auth', 'crypto']);
+  const step2 = reconcileDanger(ledgerCleared, {
+    ok: true,
+    hits: [{ class: 'auth' }, { class: 'crypto' }],
+  });
   const authAfter = step2.items.find((it) => it.id === 'SEC-AUTH');
   const cryptoAfter = step2.items.find((it) => it.id === 'SEC-CRYPTO');
   assert.equal(authAfter.checked, true, 'auth: clearance 済みは維持');
   assert.equal(cryptoAfter.checked, false, 'crypto: 新 hit は unchecked(HOLD を保つ)');
   assert.equal(cryptoAfter.severity, 'critical');
+});
+
+test('reconcileDanger: danger-grep error は全 SEC seed を unchecked のまま返す(fail-closed)', () => {
+  const cleaned = reconcileDanger(ledgerWithSeeds(), { ok: true, hits: [] });
+  assert.ok(cleaned.items.every((it) => it.checked === true), 'precondition: clean risk checks all SEC seeds');
+
+  const out = reconcileDanger(cleaned, { ok: false, hits: [], error: 'script failed' });
+  for (const it of out.items) {
+    assert.equal(it.checked, false, `${it.id} should fail closed`);
+    assert.match(it.evidence, /script failed/);
+  }
+
+  const mergeTier = classifyMergeTier({
+    shape: 'micro',
+    converged: false,
+    unresolvedDanger: false,
+    breaking: false,
+    docsOrTestOnly: true,
+    escalateCount: 0,
+  });
+  assert.equal(mergeTier.tier, 'HOLD');
 });
 
 // ---- Task 3: isDocsOrTestOnly + classifyMergeTier ----

--- a/_lib/micro-auto-ac-disclosure-routing.test.mjs
+++ b/_lib/micro-auto-ac-disclosure-routing.test.mjs
@@ -59,7 +59,7 @@ function makeSandbox(analyzeReq, opts) {
     if (label.startsWith('analyze')) return analyzeReq;
     if (agentType === 'dev-planner') return { summary: 'p', serial: [{ id: 'T1', desc: 't', file_changes: [], test_plan: '' }], parallel: [] };
     if (agentType === 'plan-reviewer') return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
-    if (label.startsWith('danger-grep')) return { hits: [] };
+    if (label.startsWith('danger-grep')) return { ok: true, hits: [] };
     if (label === 'realized-diff') return { files: realizedFiles };
     if (label === 'declared-path-check') return { files: [] };
     if (label === 'changed-files') return { files: changedFiles };

--- a/_lib/needs-clarification-routing.test.mjs
+++ b/_lib/needs-clarification-routing.test.mjs
@@ -66,7 +66,7 @@ function makeCountingSandbox(analyzeReq, implementerFn) {
     }
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {

--- a/_lib/parallel-disjoint-routing.test.mjs
+++ b/_lib/parallel-disjoint-routing.test.mjs
@@ -58,7 +58,7 @@ function makeCountingSandbox(analyzeReq, plannerPlan) {
     }
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {
@@ -326,7 +326,7 @@ test('[parallel-disjoint-routing] Evaluate replan: design feedback 後の衝突 
       return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
     }
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     if (label.startsWith('test')) {
       return { tests: 'no_tests', green: true, summary: '' };

--- a/_lib/refloor-shape-routing.test.mjs
+++ b/_lib/refloor-shape-routing.test.mjs
@@ -65,7 +65,7 @@ function makeCountingSandbox(analyzeReq, realizedFiles, changedFiles = ['src/foo
     }
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // (a) realized-diff: label レベルで分離。可変ファイル数を返す
     if (label === 'realized-diff') {
@@ -256,7 +256,7 @@ test('[refloor] (B) standard 見積もり + realized 6 files → evaluator >= 2 
     if (label.startsWith('analyze')) return standardReq;
     if (agentType === 'dev-planner') return { summary: 'p', serial: [], parallel: [] };
     if (agentType === 'plan-reviewer') return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
-    if (label.startsWith('danger-grep')) return { hits: [] };
+    if (label.startsWith('danger-grep')) return { ok: true, hits: [] };
     // (a) realized-diff: 6 ファイル返す → standard+6件 → EFFECTIVE_SHAPE=complex → EVAL_PASSES=EVAL_MAX
     if (label === 'realized-diff') {
       return { files: ['a', 'b', 'c', 'd', 'e', 'f'] };
@@ -465,7 +465,7 @@ test('[refloor] (D) realized-diff が null を返す（agent drop）→ NaN 経�
       return { score: 100, verdict: 'pass', findings: [], summary: 'ok' };
     }
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // (D) realized-diff を null で返す → ?? [] を使うと 0 に潰れ runEval=false になるバグ再現
     if (label === 'realized-diff') {

--- a/_lib/shape-loop-routing.test.mjs
+++ b/_lib/shape-loop-routing.test.mjs
@@ -52,7 +52,7 @@ function makeCountingSandbox(analyzeReq) {
     }
     // Security floor / Merge tier: danger-grep 系（label が 'danger-grep' で始まる）
     if (label.startsWith('danger-grep')) {
-      return { hits: [] };
+      return { ok: true, hits: [] };
     }
     // Validate: test runner（label が 'test' で始まる）
     if (label.startsWith('test')) {

--- a/_lib/validate-loop-unification.test.mjs
+++ b/_lib/validate-loop-unification.test.mjs
@@ -85,7 +85,7 @@ function makeCountingSandbox(opts) {
     }
 
     // Security / danger-grep
-    if (label.startsWith('danger-grep')) return { hits: [] };
+    if (label.startsWith('danger-grep')) return { ok: true, hits: [] };
 
     // diff-gate / diff-gate-retry
     if (label === 'diff-gate') return { hash: gateEmpty ? 'EMPTY' : 'H', empty: gateEmpty };

--- a/_lib/workflow-load-smoke.test.mjs
+++ b/_lib/workflow-load-smoke.test.mjs
@@ -329,6 +329,7 @@ test('[triage] dev-flow.js: 最終 return に shape: SHAPE が含まれる', () 
 test('[W5] dev-flow.js: RISK schema と diff-risk-classify 呼び出しが存在', () => {
   const src = readFileSync(join(workflowDir, 'dev-flow.js'), 'utf8');
   assert.ok(src.includes('const RISK ='), 'RISK schema があること');
+  assert.ok(src.includes("required: ['ok', 'hits']"), 'RISK schema が ok error channel を必須にすること');
   assert.ok(src.includes('diff-risk-classify.sh'), 'diff-risk-classify.sh を呼ぶこと');
   assert.ok(
     src.includes('diff-risk-classify.sh --working-tree origin/${' + 'BASE}'),

--- a/_shared/scripts/diff-risk-classify.bats
+++ b/_shared/scripts/diff-risk-classify.bats
@@ -35,7 +35,7 @@ teardown() {
     [[ "$output" == *'"class":"auth"'* ]]
     [[ "$output" == *'auth.ts'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "auth")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "auth")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -47,7 +47,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"crypto"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "crypto")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "crypto")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -76,7 +76,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -90,7 +90,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"config"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "config")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "config")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -102,7 +102,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -118,7 +118,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"data-migration"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "data-migration")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "data-migration")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -130,7 +130,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -146,7 +146,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"public-api"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -160,7 +160,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -176,7 +176,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"exec-sink"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "exec-sink")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -189,7 +189,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"dependency"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "dependency")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "dependency")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -216,7 +216,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -228,7 +228,13 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
+}
+
+@test "ERROR: invalid base ref -> ok:false error channel" {
+    run bash -c "cd '$REPO' && '$SCRIPT' does-not-exist"
+    [ "$status" -ne 0 ]
+    printf '%s\n' "$output" | jq -e '.ok == false and .hits == [] and (.error | test("invalid base ref"))'
 }
 
 # ---------------------------------------------------------------------------
@@ -243,9 +249,9 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "auth")] | length > 0'
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
-    printf '%s\n' "$output" | jq -e 'length >= 2'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "auth")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "exec-sink")] | length > 0'
+    printf '%s\n' "$output" | jq -e '.hits | length >= 2'
 }
 
 # ---------------------------------------------------------------------------
@@ -264,9 +270,9 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"public-api"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
     # file 値が壊れた escape シーケンスでないことを確認
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")][0].file | test("認証api\\.ts$")'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")][0].file | test("認証api\\.ts$")'
 }
 
 # ---------------------------------------------------------------------------
@@ -285,7 +291,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"public-api"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -315,7 +321,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 @test "docs EXCLUSION: docs/ 配下の .txt に auth 語彙 -> 除外され []" {
@@ -325,7 +331,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 @test "docs EXCLUSION regression: 同じ auth 語彙でも .ts は HIT のまま (非 docs は不変)" {
@@ -351,7 +357,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"public-api"'* ]]
     [[ "$output" == *'"severity":"critical"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -366,7 +372,7 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"auth"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "auth")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "auth")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -381,7 +387,7 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"public-api"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -391,7 +397,7 @@ teardown() {
     # 何も変更しない
     run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -423,7 +429,7 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$MAIN_SHA'"
     [ "$status" -eq 0 ]
     # auth-helper が含まれないこと
-    printf '%s\n' "$output" | jq -e '[.[] | .file | test("auth-helper")] | any | not'
+    printf '%s\n' "$output" | jq -e '[.hits[] | .file | test("auth-helper")] | any | not'
 }
 
 # ---------------------------------------------------------------------------
@@ -437,7 +443,7 @@ teardown() {
     # git add も commit もしない
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -452,9 +458,9 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' --working-tree '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"public-api"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
     # file 値が壊れたエスケープシーケンスでないことを確認
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")][0].file | test("認証処理\\.ts$")'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")][0].file | test("認証処理\\.ts$")'
 }
 
 # ---------------------------------------------------------------------------
@@ -494,7 +500,7 @@ teardown() {
     run bash -c "cd '$C' && '$SCRIPT' --working-tree origin/main"
     [ "$status" -eq 0 ]
     # merged-auth が含まれないこと
-    printf '%s\n' "$output" | jq -e '[.[] | .file | test("merged-auth")] | any | not'
+    printf '%s\n' "$output" | jq -e '[.hits[] | .file | test("merged-auth")] | any | not'
 
     rm -rf "$R" "$C"
 }
@@ -514,7 +520,7 @@ teardown() {
 
     run bash -c "cd '$REPO' && '$SCRIPT' --working-tree origin/main"
     [ "$status" -eq 0 ]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -528,7 +534,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    printf '%s\n' "$output" | jq -e '.ok == true and .hits == []'
 }
 
 # ---------------------------------------------------------------------------
@@ -543,7 +549,7 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"crypto"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "crypto")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "crypto")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -557,7 +563,7 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"crypto"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "crypto")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "crypto")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -572,7 +578,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length == 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length == 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -588,7 +594,7 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"exec-sink"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "exec-sink")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -604,7 +610,7 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length == 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length == 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -620,7 +626,7 @@ teardown() {
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"class":"exec-sink"'* ]]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "exec-sink")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "exec-sink")] | length > 0'
 }
 
 # ---------------------------------------------------------------------------
@@ -635,5 +641,5 @@ teardown() {
     git -C "$REPO" commit -q -m change
     run bash -c "cd '$REPO' && '$SCRIPT' '$BASE'"
     [ "$status" -eq 0 ]
-    printf '%s\n' "$output" | jq -e '[.[] | select(.class == "public-api")] | length > 0'
+    printf '%s\n' "$output" | jq -e '[.hits[] | select(.class == "public-api")] | length > 0'
 }

--- a/_shared/scripts/diff-risk-classify.sh
+++ b/_shared/scripts/diff-risk-classify.sh
@@ -2,7 +2,7 @@
 # diff-risk-classify.sh - dev-flow W1 deterministic danger-grep on realized diff.
 #
 # Purpose: Grep the REALIZED git diff (actual written changes, not proposed/issue text)
-# between a base ref and HEAD for 7 danger classes and print hit files as a JSON array
+# between a base ref and HEAD for 7 danger classes and print hit files as a JSON object
 # to stdout. Called directly from workflow JS. Ungameable critical floor -- severity is
 # ALWAYS "critical" and cannot be lowered by any flag or input.
 #
@@ -10,7 +10,8 @@
 #   --working-tree  Classify worktree changes (staged + untracked) instead of committed
 #                   diff. Uses merge-base($BASE, HEAD) as anchor so BASE-ahead commits
 #                   from other branches do not bleed into the result.
-# Output: JSON array of {file, class, severity:"critical"} objects (stdout)
+# Output: {"ok":true,"hits":[{file, class, severity:"critical"}]} on success (stdout)
+#         {"ok":false,"hits":[],"error": "...", "exit_code": N} on error (stdout)
 # Exit: 0 on success (even with empty hits), non-zero via die_json on error.
 
 set -euo pipefail
@@ -19,6 +20,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=../../_lib/common.sh
 source "$SCRIPT_DIR/../../_lib/common.sh"
+
+die_json() {
+    local msg="$1"
+    local code="${2:-1}"
+    printf '{"ok":false,"hits":[],"error":%s,"exit_code":%s}\n' "$(json_str "$msg")" "$code"
+    exit "$code"
+}
 
 # ============================================================================
 # Args
@@ -134,7 +142,7 @@ else
 fi
 
 if [[ -z "$files" ]]; then
-    printf '%s\n' "[]"
+    printf '%s\n' '{"ok":true,"hits":[]}'
     exit 0
 fi
 
@@ -261,17 +269,17 @@ done <<< "$files"
 hits="${hits%$'\n'}"
 
 if [[ -z "$hits" ]]; then
-    printf '%s\n' "[]"
+    printf '%s\n' '{"ok":true,"hits":[]}'
     exit 0
 fi
 
 if has_jq; then
     # Use jq to build the array deterministically (compact output, no spaces)
     printf '%s\n' "$hits" | \
-        jq -c -R -n '[inputs | split("\t") | {file:.[0], class:.[1], severity:"critical"}]'
+        jq -c -R -n '{ok:true,hits:[inputs | split("\t") | {file:.[0], class:.[1], severity:"critical"}]}'
 else
     # Fallback: build JSON array with json_escape
-    result="["
+    result="{\"ok\":true,\"hits\":["
     first=true
     while IFS=$'\t' read -r f c; do
         [[ -z "$f" ]] && continue
@@ -283,7 +291,7 @@ else
         escaped_file="$(json_escape "$f")"
         result="${result}{\"file\":${escaped_file},\"class\":\"${c}\",\"severity\":\"critical\"}"
     done <<< "$hits"
-    result="${result}]"
+    result="${result}]}"
     printf '%s\n' "$result"
 fi
 


### PR DESCRIPTION
## 概要
Closes #249
- `diff-risk-classify.sh` の出力を `ok` / `hits` / `error` を持つ envelope に変更
- `RISK` schema に `ok` と error channel を追加し、danger-grep の失敗を clean と区別
- `reconcileDanger` を fail-closed にし、`ok:false` では全 SEC seed を unchecked に戻す
- exec-proxy 失敗ポリシー一覧を `AGENTS.md` に追加

## 動機
danger-grep は gate_policy に依らず blocking であるべき deterministic security floor です。従来は script failure / 転写ミス / 空出力が `hits:[]` と同じ扱いになり、security floor が fail-open になっていました。

## 変更内容
| ファイル | 変更内容 |
|---------|----------|
| `_shared/scripts/diff-risk-classify.sh` | 成功/失敗を `ok` envelope で返すよう変更 |
| `_lib/merge-tier.mjs` | `ok:false` 時に SEC seed を fail-closed |
| `.claude/workflows/dev-flow.js` | RISK schema/prompt/call site を新 envelope に対応 |
| `_lib/*.test.mjs` | danger-grep stub を `ok:true` 契約へ更新 |
| `_shared/scripts/diff-risk-classify.bats` | `.hits` envelope 対応と error channel test 追加 |
| `AGENTS.md` | exec-proxy 失敗ポリシー表を追加 |

## テスト計画
- [x] `node --test _lib/merge-tier.test.mjs _lib/workflow-load-smoke.test.mjs`
- [x] `node tools/sync-inlines.mjs --check`
- [x] `_shared/scripts/diff-risk-classify.sh origin/dev`
- [x] `_shared/scripts/diff-risk-classify.sh does-not-exist`（`ok:false` を確認）
- [x] `node --test _lib/*.test.mjs`
- [x] `bash tests/run-all-bats.sh`（bats 未インストールのため non-strict skip）
- [x] `dev-validate/scripts/validate.sh --worktree .../df-249`
