### PR TITLE
🐛 fix(dev-flow): diff-risk-classify.sh パス解決修正と fail-closed/danger-検出の evidence 語彙分離

### DIFF
--- a/.claude/workflows/dev-flow.js
+++ b/.claude/workflows/dev-flow.js
@@ -236,10 +236,14 @@ function seedSecurityLedger() {
 //   danger が同じ hit クラスで残る かつ evaluator clearance 済み(floor=true, checked=true) → checked 維持(温存)。
 function reconcileDanger(ledger, risk) {
   if (!risk || risk.ok !== true) {
-    const error = risk?.error ? `danger-grep error: ${risk.error}` : 'danger-grep error';
+    // ツール欠落/スクリプト実行不能/JSON 不正などによる fail-closed。
+    // 実際の danger 検出（risk.ok:true + hits）とは語彙を分け、
+    // operator が log と HOLD reason から「danger を検出したのか」「ツールが走らなかったのか」を判別できるようにする。
+    const errDetail = risk?.error ? `: ${risk.error}` : '';
+    const evidence = `danger-grep unavailable (fail-closed)${errDetail}`;
     const items = ledger.items.map((it) => {
       if (it.source !== 'seed' || it.dimension !== 'security') return it;
-      return { ...it, checked: false, evidence: error };
+      return { ...it, checked: false, evidence };
     });
     return { ...ledger, items };
   }
@@ -1657,7 +1661,7 @@ pushGreenFixAudit(greenFixIterations)
 // Security floor 直前に置くことで、empty-diff gate の retry 後の tree に対して danger-grep /
 // realized-diff / refloorShape / declared-path-check が自然に実行される（issue #219 fix）。
 const _dhPrompt = `cd ${WT} で作業。次を実行し **stdout の JSON 1 行をそのまま** verbatim で返せ（判定や脚色をしない）:\n`
-  + `bash ${WT}/_shared/scripts/worktree-diff-hash.sh ${WT} origin/${BASE}`
+  + `bash ~/.claude/skills/_shared/scripts/worktree-diff-hash.sh ${WT} origin/${BASE}`
 
 // ============================================================
 // empty-diff gate（issue #215）: Security floor phase の直前。
@@ -1712,12 +1716,12 @@ const risk = need(await agent(
   `cd ${WT} で作業。次を実行し **stdout の JSON object をそのまま** 返せ`
   + `（判定や脚色をしない。exit 非0・stdout 空・JSON 不正なら ok:false/hits:[]/error で返せ。`
   + `失敗時に ok:true を生成してはならない）:\n`
-  + `bash ${WT}/_shared/scripts/diff-risk-classify.sh --working-tree origin/${BASE}`,
+  + `bash ~/.claude/skills/_shared/scripts/diff-risk-classify.sh --working-tree origin/${BASE}`,
   { agentType: 'dev-runner-haiku', schema: RISK, label: 'danger-grep', phase: 'Security floor' },
 ), 'Security floor(danger-grep)')
 const dangerHits = risk.ok === true ? [...new Set((risk.hits ?? []).map((h) => h.class))] : []
 ledger = reconcileDanger(ledger, risk)
-log(`danger-grep: ${risk.ok !== true ? 'ERROR ' + (risk.error ?? 'unknown') : dangerHits.length ? 'HIT ' + dangerHits.join(',') : 'clean'} — `
+log(`danger-grep: ${risk.ok !== true ? 'UNAVAILABLE (fail-closed) ' + (risk.error ?? 'unknown') : dangerHits.length ? 'HIT ' + dangerHits.join(',') : 'clean'} — `
   + `SEC blocking 未 checked ${policyBlockingItems(ledger, GATE_POLICY).filter((it) => !it.checked).length} 件`)
 // Step F2: realized diff のファイル数を取得して re-floor を算出する
 // realized が null（agent drop／skip）のときは NaN を refloorShape へ渡し complex 安全弁へ流す。
@@ -1898,7 +1902,7 @@ for (let i = 1; i <= EVAL_PASSES; i++) {
         && Array.isArray(r.impl_files) && r.impl_files.length) {
       const rg = await agent(
         `cd ${WT} で作業。次を実行して **stdout の JSON 1 行だけ** を verbatim で返せ(判定や脚色をしない):\n`
-        + `bash ${WT}/_shared/scripts/redgreen-verify.sh ${WT} `
+        + `bash ~/.claude/skills/_shared/scripts/redgreen-verify.sh ${WT} `
         + `'${r.test_files.join(',')}' '${r.impl_files.join(',')}'`,
         { agentType: 'dev-runner-haiku', schema: RG, label: `redgreen:AC-${r.ac_index + 1}`, phase: 'Evaluate' })
       if (rg && rg.red === true && rg.green === true) {
@@ -2031,7 +2035,7 @@ phase('Merge tier')
 const riskFinal = need(await agent(
   `cd ${WT} で作業。次を実行し **stdout の JSON object をそのまま** 返せ`
   + `（exit 非0・stdout 空・JSON 不正なら ok:false/hits:[]/error で返せ。失敗時に ok:true を生成してはならない）:\n`
-  + `bash ${WT}/_shared/scripts/diff-risk-classify.sh origin/${BASE}`,
+  + `bash ~/.claude/skills/_shared/scripts/diff-risk-classify.sh origin/${BASE}`,
   { agentType: 'dev-runner-haiku', schema: RISK, label: 'danger-grep-final', phase: 'Merge tier' },
 ), 'Merge tier(danger-grep-final)')
 const dangerHitsFinal = riskFinal.ok === true ? [...new Set((riskFinal.hits ?? []).map((h) => h.class))] : []

--- a/_lib/merge-tier.mjs
+++ b/_lib/merge-tier.mjs
@@ -48,10 +48,14 @@ export function seedSecurityLedger() {
 //   danger が同じ hit クラスで残る かつ evaluator clearance 済み(floor=true, checked=true) → checked 維持(温存)。
 export function reconcileDanger(ledger, risk) {
   if (!risk || risk.ok !== true) {
-    const error = risk?.error ? `danger-grep error: ${risk.error}` : 'danger-grep error';
+    // ツール欠落/スクリプト実行不能/JSON 不正などによる fail-closed。
+    // 実際の danger 検出（risk.ok:true + hits）とは語彙を分け、
+    // operator が log と HOLD reason から「danger を検出したのか」「ツールが走らなかったのか」を判別できるようにする。
+    const errDetail = risk?.error ? `: ${risk.error}` : '';
+    const evidence = `danger-grep unavailable (fail-closed)${errDetail}`;
     const items = ledger.items.map((it) => {
       if (it.source !== 'seed' || it.dimension !== 'security') return it;
-      return { ...it, checked: false, evidence: error };
+      return { ...it, checked: false, evidence };
     });
     return { ...ledger, items };
   }

--- a/_lib/merge-tier.test.mjs
+++ b/_lib/merge-tier.test.mjs
@@ -139,6 +139,58 @@ test('reconcileDanger: danger-grep error は全 SEC seed を unchecked のまま
   assert.equal(mergeTier.tier, 'HOLD');
 });
 
+// AC #3: ツール欠落(fail-closed) と danger 実検出の evidence 語彙が区別できること
+test('reconcileDanger: risk.ok:false (tool 欠落/fail-closed) のとき evidence が tool-unavailable を示す語彙を含む', () => {
+  // error あり: evidence に "unavailable" または "fail-closed" の語彙が含まれ、
+  // "danger" 実検出と誤認できない形になること
+  const outWithError = reconcileDanger(ledgerWithSeeds(), { ok: false, error: 'No such file or directory' });
+  for (const it of outWithError.items) {
+    assert.equal(it.checked, false, `${it.id} should be unchecked (fail-closed)`);
+    // tool 欠落/fail-closed の文言を含む（"danger" 検出ではなく "unavailable" / "fail-closed" 語彙）
+    assert.match(it.evidence, /unavailable|fail-closed/i,
+      `fail-closed evidence should indicate tool unavailability, got: ${it.evidence}`);
+    // danger 実検出の evidence 語彙 ("danger-grep clean", critical/floor raise) と
+    // 混同できないよう、evidence が "danger-grep clean" や "danger detected" ではないことを確認
+    assert.doesNotMatch(it.evidence, /^danger-grep clean$/,
+      'fail-closed evidence must not say "danger-grep clean"');
+  }
+});
+
+test('reconcileDanger: risk.ok:false かつ error なし (空/null) のとき evidence が tool-unavailable を示す', () => {
+  // error フィールドなし
+  const outNoError = reconcileDanger(ledgerWithSeeds(), { ok: false });
+  for (const it of outNoError.items) {
+    assert.equal(it.checked, false, `${it.id} should be unchecked (fail-closed)`);
+    assert.match(it.evidence, /unavailable|fail-closed/i,
+      `no-error fail-closed evidence should indicate tool unavailability, got: ${it.evidence}`);
+  }
+});
+
+test('reconcileDanger: risk.ok:false と risk.ok:true(hit) の evidence 語彙が区別可能', () => {
+  // fail-closed (tool 欠落)
+  const failClosed = reconcileDanger(ledgerWithSeeds(), { ok: false, error: 'diff-risk-classify.sh not found' });
+  const failEvidence = failClosed.items.find((it) => it.id === 'SEC-AUTH')?.evidence ?? '';
+  assert.match(failEvidence, /unavailable|fail-closed/i, `fail-closed evidence: ${failEvidence}`);
+
+  // danger 実検出 (risk.ok:true + hit)
+  const hitResult = reconcileDanger(ledgerWithSeeds(), { ok: true, hits: [{ class: 'auth' }] });
+  const authHit = hitResult.items.find((it) => it.id === 'SEC-AUTH');
+  assert.equal(authHit.severity, 'critical', 'danger hit raises to critical');
+  assert.equal(authHit.floor, true, 'danger hit sets floor=true');
+  assert.equal(authHit.checked, false, 'danger hit is unchecked');
+  // hit item の evidence はない（unchecked のまま）か、あっても "unavailable" ではない
+  if (authHit.evidence !== null && authHit.evidence !== undefined) {
+    assert.doesNotMatch(String(authHit.evidence), /unavailable|fail-closed/i,
+      `danger hit evidence must not say "unavailable": ${authHit.evidence}`);
+  }
+
+  // clean item は "danger-grep clean" のまま
+  const cleanItem = hitResult.items.find((it) => it.id === 'SEC-CONFIG');
+  assert.match(cleanItem.evidence, /clean/, `clean evidence: ${cleanItem.evidence}`);
+  assert.doesNotMatch(cleanItem.evidence, /unavailable|fail-closed/i,
+    `clean evidence must not say "unavailable": ${cleanItem.evidence}`);
+});
+
 // ---- Task 3: isDocsOrTestOnly + classifyMergeTier ----
 
 test('isDocsOrTestOnly: md/test/bats のみ → true', () => {


### PR DESCRIPTION
## 概要

Closes #262

- `_shared/scripts/` のパス参照を `${WT}/_shared/scripts/` から `~/.claude/skills/_shared/scripts/` に修正（skills repo 以外の対象リポジトリでスクリプトが見つからない問題を解消）
- `reconcileDanger` で `risk.ok:false` 時の evidence 語彙を `"danger-grep error"` から `"danger-grep unavailable (fail-closed)"` に変更し、ツール欠落と danger 実検出を判別可能に
- `merge-tier.test.mjs` に AC #3 のテスト3件を追加

## 動機

skills repo 以外のリポジトリで dev-flow を実行すると、`diff-risk-classify.sh` が `${WT}/_shared/scripts/` 配下に存在せず `Script not found` エラーになる。danger-grep の fail-closed 挙動により SEC-* ledger 7件が全て blocking のまま残り、安全な diff でも `merge_tier=HOLD` になる誤検知が発生していた。

また、ツール欠落（fail-closed）と実際の danger 検出を同じ `"danger-grep error"` 語彙で表していたため、operator が log から「danger を検出したのか」「ツールが走らなかったのか」を判別できなかった。

## 変更内容

| ファイル | 変更内容 |
|---------|----------|
| `.claude/workflows/dev-flow.js` | `worktree-diff-hash.sh` / `diff-risk-classify.sh` (×2) / `redgreen-verify.sh` のパスを `~/.claude/skills/_shared/scripts/` に修正。fail-closed ログ語彙を `UNAVAILABLE (fail-closed)` に変更 |
| `_lib/merge-tier.mjs` | `reconcileDanger` の evidence 語彙を `"danger-grep unavailable (fail-closed)"` に変更（canonical）|
| `_lib/merge-tier.test.mjs` | fail-closed と danger 実検出の evidence 語彙が区別可能なことを検証するテスト3件追加 |

## テスト計画

- [x] `merge-tier.test.mjs` の既存テスト通過
- [x] AC #3: fail-closed evidence に `unavailable/fail-closed` 語彙が含まれることを検証
- [x] AC #3: danger 実検出 evidence と fail-closed evidence が混同できないことを検証
- [x] AC #3: `risk.ok:false` かつ error なし（空/null）の場合も正しく語彙が付くことを検証